### PR TITLE
[DSR-24] use small body copy below level 3 heading

### DIFF
--- a/docs/examples/typography.md
+++ b/docs/examples/typography.md
@@ -31,4 +31,4 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed venenatis justo ut 
 
 <p class="subhead subhead--small">Small/subhead</p>
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed venenatis justo ut purus interdum, nec rhoncus magna convallis. Integer suscipit, orci ut porta feugiat, nulla elit pellentesque sapien, sit amet tristique lectus leo at enim. Nulla sodales, elit sed feugiat vestibulum, elit est pretium lacus, in molestie est quam vitae eros.
+<small>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed venenatis justo ut purus interdum, nec rhoncus magna convallis. Integer suscipit, orci ut porta feugiat, nulla elit pellentesque sapien, sit amet tristique lectus leo at enim. Nulla sodales, elit sed feugiat vestibulum, elit est pretium lacus, in molestie est quam vitae eros.</small>


### PR DESCRIPTION
Feedback from @EarvinF - updating the typography examples page to show small body copy below the level 3 heading.
