### PR TITLE
[DSR-74] fixing content width on Android 5 & 4

### DIFF
--- a/docs/2-Foundations/5-forms.md
+++ b/docs/2-Foundations/5-forms.md
@@ -133,12 +133,12 @@ Checkboxes are similar to radio buttons in their appearance and markup. The key 
         <span class="choice__text">Choice B</span>
     </label>
     <label for="multiple-choice-c" class="choice">
-	<input type="checkbox" name="multiple-choice" id="multiple-choice-c" disabled>
+	    <input type="checkbox" name="multiple-choice" id="multiple-choice-c" disabled>
         <span class="choice__text">Choice C</span>
     </label>
     <label for="multiple-choice-d" class="choice">
-	<input type="checkbox" name="multiple-choice" id="multiple-choice-d" checked disabled>
-	<span class="choice__text">Choice D</span>
+	    <input type="checkbox" name="multiple-choice" id="multiple-choice-d" checked disabled>
+	    <span class="choice__text">Choice D</span>
     </label>
 </fieldset>
 

--- a/scss/utility/_helpers.scss
+++ b/scss/utility/_helpers.scss
@@ -17,16 +17,16 @@ Description:  Helper classes and extensions
 
 // Visually hide an element without compromising accessibility.
 %accessible-hide {
-  border: 0;
-  // clip has been deprecated but is still supported
+  display: block;
+  position: absolute !important;
   clip: rect(1px 1px 1px 1px);
   clip: rect(1px, 1px, 1px, 1px);
+  left: -10000px;
+  top: auto;
+  width: 1px;
   height: 1px;
   margin: -1px;
-  overflow: hidden;
   padding: 0;
-  position: absolute;
-  width: 1px;
-  // ensure there are spaces in sr text
-  word-wrap: normal;
+  border: 0;
+  overflow: hidden;
 }


### PR DESCRIPTION
"Accessibly hidden" elements were still affecting page flow on Android 4
and 5 devices, causing there to be a large white gutter on the right
side of the page.
