### PR TITLE
Form hint display & accessibility bug fixes

### DIFF
--- a/docs/2-Foundations/5-forms.md
+++ b/docs/2-Foundations/5-forms.md
@@ -348,7 +348,7 @@ The `--success` modifier can be used on the helper to provide positive feedback 
     <input type="password" id="input_e" placeholder="Enter password">
 </div>
 ```
-<!-- The form hints feature is switched off until testing is complete. Targeted for v0.3.1.
+
 ## Hints
 
 ---
@@ -357,38 +357,37 @@ Hints provide information a user may need to complete a form field. While a labe
 
 * A hinted input should have an `aria-describedby` attribute whose value is the `id` of the hint text.
 * The hint should not be nested inside the `<label>` tag.
-* Modify the `.hint__text` element with `.hint__text--active` to reveal the speech bubble.
+* Modify the `.field` block with `.field--hinted` to position the icon correctly relative to the label.
+* Modify the `.hint` block with `.hint--active` to reveal the speech bubble.
+* Toggle the text's `aria-hidden` attribute when the button hides or shows the tooltip.
 
 <div id="example-hint" class="field field--hinted">
     <label for="hinted-field">Interactive hint</label>
-    <div class="hint">
-        <button class="button button-plain hint__trigger">
-            <i class="icon icon-core-help hint__icon"></i>
-            <span class="accessible-hide">Toggle helper text</span>
+    <input type="text" id="hinted-field" aria-describedby="some-hint">
+    <div class="hint hint--active">
+        <button class="button button-plain hint__trigger" aria-controls="some-hint">
+            <span class="accessible-hide">Toggle helper text visibility</span>
         </button>
-        <span id="some-hint" class="hint__text hint__text--active">
-            Helper text description goes here.
+        <span id="some-hint" class="hint__text" aria-role="tooltip" aria-hidden="false">
+            This text describes the field.
         </span>
     </div>
-    <input type="text" id="hinted-field" aria-describedby="some-hint">
 </div>
 
 ```html
 <div id="example-hint" class="field field--hinted">
     <label for="hinted-field">Interactive hint</label>
-    <div class="hint">
-        <button class="button button-plain hint__trigger">
-            <i class="icon icon-core-help hint__icon"></i>
-            <span class="accessible-hide">Toggle helper text</span>
+    <input type="text" id="hinted-field" aria-describedby="some-hint">
+    <div class="hint hint--active">
+        <button class="button button-plain hint__trigger" aria-controls="some-hint">
+            <span class="accessible-hide">Toggle helper text visibility</span>
         </button>
-        <span id="some-hint" class="hint__text hint__text--active">
-            Helper text description goes here.
+        <span id="some-hint" class="hint__text" aria-role="tooltip" aria-hidden="false">
+            This text describes the field.
         </span>
     </div>
-    <input type="text" id="hinted-field" aria-describedby="some-hint">
 </div>
 ```
--->
 
 ## Example forms
 

--- a/docs/assets/js/styleguide.js
+++ b/docs/assets/js/styleguide.js
@@ -5,7 +5,7 @@
 
 (function () {
   var TRIGGERS_SELECTOR = '.ex-page .hint__trigger';
-  var ACTIVE_HINT_CLASS = 'hint__text--active';
+  var ACTIVE_HINT_CLASS = 'hint--active';
   var ENTER_KEYCODE = 13;
   var ESC_KEYCODE = 27;
 
@@ -18,15 +18,17 @@
   }
 
   function closeHints() {
-    eachElement(document.querySelectorAll('.hint__text'), function (el, i) {
+    eachElement(document.querySelectorAll('.hint'), function (el, i) {
       el.classList.remove(ACTIVE_HINT_CLASS);
     });
   }
 
-  function activateHintText(hint) {
-    eachElement(hint.parentNode.childNodes, function(el, i) {
+  function toggleHint(hint) {
+    var active = hint.classList.toggle(ACTIVE_HINT_CLASS);
+
+    eachElement(hint.childNodes, function(el, i) {
       if (hasClass(el, 'hint__text')) {
-        el.classList.toggle(ACTIVE_HINT_CLASS);
+        el.setAttribute('aria-hidden', !active);
       }
     });
   }
@@ -35,8 +37,7 @@
     eachElement(document.querySelectorAll(TRIGGERS_SELECTOR), function (el, i) {
       el.addEventListener('click', function (e) {
         e.preventDefault();
-
-        activateHintText(el)
+        toggleHint(el.parentNode)
       });
     });
   }
@@ -46,7 +47,7 @@
       el.addEventListener('keydown', function (e) {
         if (e.keyCode === ENTER_KEYCODE) {
           e.preventDefault();
-          activateHintText(el);
+          toggleHint(el.parentNode);
         }
       });
     });
@@ -54,7 +55,7 @@
 
   function closeHintsOnClickAway() {
     var handleClick = function (e) {
-      if (!hasClass(e.srcElement, 'icon-core-help')) {
+      if (!hasClass(e.srcElement, 'hint__trigger')) {
         closeHints();
       }
     };

--- a/docs/assets/templates/example-forms.jade
+++ b/docs/assets/templates/example-forms.jade
@@ -28,15 +28,13 @@ block content
     div.grid-row
       div.field-col
         h2 A wide field
-        fieldset.field
+        fieldset.field.field--hinted
           label(for='query') What are you looking for?
-          //The form hints feature is switched off until testing is complete. Targeted for v0.3.1.
-          //div.hint
-            button.button.button-plain.hint__trigger
-              i.hint__icon.icon.icon-core-help
-              span.accessible-hide Toggle helper text
-            span#some-hint.hint__text Enter a few keywords related to your search.
-          input(type='text', id='query', placeholder='smart phones')
+          input(type='text', id='query', aria-describedby='some-hint')
+          div.hint
+            button(aria-controls='some-hint').button.button-plain.hint__trigger
+              span.accessible-hide Toggle search field description visibility
+            span(aria-role='tooltip', aria-hidden='true')#some-hint.hint__text Enter a few keywords related to your search.
         div.field
           label.choice
             input(type='checkbox')

--- a/scss/elements/_forms.scss
+++ b/scss/elements/_forms.scss
@@ -66,8 +66,10 @@ label {
   position: relative;
 
   &--hinted {
+    position: relative;
+
     label {
-      margin-right: 25px;
+      width: 91%;
     }
   }
 }
@@ -264,12 +266,33 @@ $radio-checked-stroke-size: 6px;
 ---------------------------------------- */
 
 .hint {
-  position: relative;
-  float: right;
+  position: absolute;
+  top: 0;
+  right: 0;
 
-  &__icon {
-    color: $color-grey;
-    line-height: 2;
+  // Extra padding is added to a .field that follows a level 2 headline to
+  // increase space between the headline text and label. Inheriting
+  // the .field's padding in the .hint keeps the hint icon in line with
+  // the field's label.
+  padding-top: inherit;
+
+  &:not(.hint--active) {
+    .hint__text {
+      @extend %accessible-hide;
+    }
+  }
+
+  &__trigger {
+    width: $body-text-size;
+
+    &::before {
+      font-family: $font-icons;
+      content: '\f102';
+      color: $color-grey;
+      line-height: 1.7;
+      display: inline-block;
+      width: $body-text-size;
+    }
   }
 
   &__text {
@@ -284,10 +307,6 @@ $radio-checked-stroke-size: 6px;
     box-shadow: 0 0 2px 0 #2a2c2e, 0 3px 2px 0 rgba(84, 89, 95, .25);
     border-radius: 4px;
     transform: translate(15px, -100%);
-
-    &:not(.hint__text--active) {
-      @extend %accessible-hide;
-    }
 
     &::before,
     &::after {


### PR DESCRIPTION
- [DSR-88] Set the correct width of the question mark icon
- [DSR-86] Aligned the icon & speech bubble in all browsers
- [DSR-87] Cause screen readers to announce hint text on focus
- Fixing the position of the hint icon alongside labels
