### PR TITLE
Optimizing NPM module size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+designs
+dist
+docs


### PR DESCRIPTION
Adding an .npmignore file to prevent design assets, build artifacts, and
the documentation site source code from being published on NPM.
