### PR TITLE
[DSR-131] Easy download of thorium.sketch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ docs/assets/css/styleguide.css
 docs/assets/css/thorium.css
 docs/assets/fonts/*
 !docs/assets/fonts/.gitkeep
+docs/assets/downloads
+!docs/assets/downloads/.gitkeep

--- a/docs/1-Introduction/2-use.md
+++ b/docs/1-Introduction/2-use.md
@@ -19,7 +19,7 @@ Review the Components section, to familiarize yourself with the existing compone
 
 **Step 3.** 
 
-Download [thorium.sketch](https://github.com/telusdigital/telus-thorium-core/blob/master/designs/thorium.sketch) and throium.fonts.zip—install the fonts.
+Download [thorium.sketch](/assets/downloads/thorium.sketch) and throium.fonts.zip—install the fonts.
 
 **Step 4.** 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,3 +4,11 @@ template: doc.jade
 ---
 
 The TELUS design system makes it easier to build & maintain digital experiences. The system is derived from the TELUS brand philosophy and contains reusable design, code and content patterns. Enabling autonomous teams to easily build, share, maintain and evolve consistent TELUS experiences.
+
+## Get Started with Thorium
+
+<ul class="list list--bulleted">
+    <li class="list__item">The latest release is v0.4.0</li>
+    <li class="list__item">[Add Thorium's code to your project](/5-Governance/1-consumption.html)</li>
+    <li class="list__item">[Download the master Sketch file](/assets/downloads/thorium.sketch)</li>
+</ul>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "npm run start:docs",
     "start:dev": "export NODE_ENV=dev && npm run start",
     "build:css": "npm run lint:css && npm run build:thorium:css && npm run build:docs:css",
-    "build:docs": "cp fonts/* docs/assets/fonts/ && npm run build:docs:css && npm run build:docs:html",
+    "build:docs": "cp fonts/* docs/assets/fonts/ && cp designs/thorium.sketch docs/assets/downloads/thorium.sketch && npm run build:docs:css && npm run build:docs:html",
     "build:docs:css": "node-sass --include-path docs/assets/scss docs/assets/scss/main.scss | postcss --use autoprefixer | cleancss > docs/assets/css/styleguide.css",
     "build:docs:html": "mkdir -p dist && wintersmith build --config=docs/config.json",
     "build:icons": "node scripts/icons.js",


### PR DESCRIPTION
- Moving thorium.sketch into the docs site at build time
- Changing download links from Github to the docs site
- Adding some helpful links to the homepage
