### PR TITLE
[DSR-176] Fixing off-by-1 breakpoints bug

### DIFF
--- a/core/scss/utility/_mixins.scss
+++ b/core/scss/utility/_mixins.scss
@@ -36,7 +36,7 @@ Description:  Helpful SASS mixins
       $bp: nth($list, 1);
     }
 
-    @media screen and (min-width: #{$bp + 1}) {
+    @media screen and (min-width: #{$bp}) {
       @content;
     }
   }
@@ -49,7 +49,7 @@ Description:  Helpful SASS mixins
   $max: nth($list, length($list));
 
   @if ($min == null) {
-    @media screen and (max-width: #{$max}) {
+    @media screen and (max-width: #{$max - 1}) {
       @content;
     }
   }
@@ -61,7 +61,7 @@ Description:  Helpful SASS mixins
   }
 
   @else {
-    @media screen and (min-width: #{$min + 1}) and (max-width: #{$max}) {
+    @media screen and (min-width: #{$min}) and (max-width: #{$max - 1}) {
       @content;
     }
   }


### PR DESCRIPTION
Adding 1 to the lower limit of each breakpoint causes mis-alignment with
the Bootstrap grid spec:

http://v4-alpha.getbootstrap.com/layout/grid/#grid-options

For example, this bug causes the Medium layout to
begin at 769px instead of 768px. This change fixes that by subtracting 1
from the upper bound, instead of adding 1 to the lower bound.