### PR TITLE
[RFC] Added support for nested children React component rendering.

### DIFF
--- a/docs/src/js/index.js
+++ b/docs/src/js/index.js
@@ -6,27 +6,40 @@ import '../scss/main.scss';
 import * as thoriumComponents from 'telus-thorium-enriched';
 import * as exampleComponents from './components';
 
+const components = { ...thoriumComponents, ...exampleComponents };
+
+function renderReactComponent(reactComponent) {
+  const componentName = reactComponent.getAttribute('data-thorium-component');
+  const unparsedProps = reactComponent.getAttribute('data-props') || {};
+
+  reactComponent.removeAttribute('data-props');
+  reactComponent.removeAttribute('data-thorium-component');
+
+  let parsedProps = {};
+
+  try {
+    parsedProps = JSON.parse(unparsedProps);
+  } catch (e) {
+    parsedProps = {};
+  }
+
+  const component = components[componentName];
+
+  if (component) {
+    parsedProps.dangerouslySetInnerHTML = {
+      __html: reactComponent.innerHTML
+    };
+
+    render(React.createElement(component, parsedProps), reactComponent);
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
-  const components = { ...thoriumComponents, ...exampleComponents };
-  const mounts = window.document.querySelectorAll('[data-thorium-component]');
+  // Iterate through the list of thorium components
+  // Bypasses the original set of DOM nodes found with querySelectorAll(), allowing new DOM nodes to be found.
+  var reactComponent;
 
-  [].forEach.call(mounts, (mountPoint) => {
-    const rawProps = mountPoint.getAttribute('data-props') || {};
-    let parsedProps = {};
-
-    mountPoint.removeAttribute('data-props');
-
-    try {
-      parsedProps = JSON.parse(rawProps);
-    } catch (e) {
-      parsedProps = {};
-    }
-
-    const componentName = mountPoint.getAttribute('data-thorium-component');
-    const component = components[componentName];
-
-    if (component) {
-      render(React.createElement(component, parsedProps), mountPoint);
-    }
-  });
+  while((reactComponent = window.document.querySelector('[data-thorium-component]')) != null) {
+    renderReactComponent(reactComponent);
+  }
 });


### PR DESCRIPTION
This allows to render children inside of a React component that can either be other React component or basic HTML.

Example:

```html
<span
  data-thorium-component='Icon'
  data-props='{ "glyph":"plus" }'
  class='inline-component'>
  <span className='accessible-hide'>button to add more</span>
</span>
```

Conceptually, we would be using React to document React components. I've done some testing, but it looks like it fails to import our components somehow. Until we address this issue, supporting children is our best option.

**Note**

This is how I tried to support it:

`layout.jade`

```jade
script(src='https://cdnjs.cloudflare.com/ajax/libs/react/15.3.2/react.min.js')
script(src='https://cdnjs.cloudflare.com/ajax/libs/react/15.3.2/react-dom.min.js')
script(src='https://unpkg.com/babel-core@5.8.38/browser.min.js')
```

`3-icon.md`

```html
<div id="example-1"></div>
<script type="text/babel">
  import Icon from 'telus-thorium-enriched'

  var root = document.getElementById('example-1')
  
  // ReactDOM is available globally after adding script tag of react-dom.min.js
  ReactDOM.render(
    <Icon glyph='plus' title='Expand section' role='button' aria-pressed='false' />,
    root
  )
</script>
```

Leading to:

```
Uncaught ReferenceError: require is not defined
```

at the `import` line