### PR TITLE
Cleaning up Docs Site SCSS comments (issue #72)

### DIFF
--- a/core/scss/foundation/_reset.scss
+++ b/core/scss/foundation/_reset.scss
@@ -92,7 +92,7 @@ video {
   vertical-align: baseline;
 }
 
-/* HTML5 display-role reset for older browsers */
+// HTML5 display-role reset for older browsers
 article,
 aside,
 details,

--- a/docs/src/scss/_example_pages.scss
+++ b/docs/src/scss/_example_pages.scss
@@ -1,15 +1,4 @@
-/**
-
-File:         _example_pages.scss
-Description:  Styling for stand-alone example pages
-
-    ◡◠ ✥ ◠◡
-
-    Table of Contents:
-
-    1. Example page styles
-
-*/
+// Styling for stand-alone example pages
 
 .ex-page {
   main {

--- a/docs/src/scss/_examples.scss
+++ b/docs/src/scss/_examples.scss
@@ -1,15 +1,4 @@
-/**
-
-File:         _examples.scss
-Description:  Styling for examples in-line with documentation
-
-    ◡◠ ✥ ◠◡
-
-    Table of Contents:
-
-    1. Example styles
-
-*/
+// Styling for examples within documentation pages.
 
 .example {
   .grid-row {

--- a/docs/src/scss/_global.scss
+++ b/docs/src/scss/_global.scss
@@ -1,15 +1,4 @@
-/**
-
-File:         _global.scss
-Description:  Documentation Site global styles
-
-    ◡◠ ✥ ◠◡
-
-    Table of Contents:
-
-    1. Site-wide styles
-
-*/
+// Documentation site-wide styles
 
 body {
   padding-top: 0;

--- a/docs/src/scss/_header.scss
+++ b/docs/src/scss/_header.scss
@@ -1,15 +1,4 @@
-/**
-
-File:         _header.scss
-Description:  Documentation Site global header
-
-    ◡◠ ✥ ◠◡
-
-    Table of Contents:
-
-    1. Site header
-
-*/
+// Documentation site global header styles
 
 .docs-header {
   height: 68px;

--- a/docs/src/scss/_layout.scss
+++ b/docs/src/scss/_layout.scss
@@ -1,15 +1,4 @@
-/**
-
-File:         _layout.scss
-Description:  Structural styles
-
-    ◡◠ ✥ ◠◡
-
-    Table of Contents:
-
-    1. Container sizing
-
-*/
+// Structural styles
 
 .container {
   height: 100%;

--- a/docs/src/scss/_navigation.scss
+++ b/docs/src/scss/_navigation.scss
@@ -1,15 +1,4 @@
-/**
-
-File:         _navigation.scss
-Description:  Left-hand navigation styles
-
-    ◡◠ ✥ ◠◡
-
-    Table of Contents:
-
-    1. Nav styles
-
-*/
+// Left-hand navigation menu styles
 
 .navigation {
   flex: 0 0 200px;

--- a/docs/src/scss/_page.scss
+++ b/docs/src/scss/_page.scss
@@ -1,15 +1,4 @@
-/**
-
-File:         _page.scss
-Description:  Styles for individual documentation pages
-
-    ◡◠ ✥ ◠◡
-
-    Table of Contents:
-
-    1. Doc page styles
-
-*/
+// Styles for individual documentation pages
 
 .page {
   flex: 1;

--- a/docs/src/scss/_typography.scss
+++ b/docs/src/scss/_typography.scss
@@ -1,15 +1,4 @@
-/**
-
-File:         _typography.scss
-Description:  Typography settings specific to the Documentation Site.
-
-    ◡◠ ✥ ◠◡
-
-    Table of Contents:
-
-    1. Markdown headings
-
-*/
+// Typography settings specific to the Documentation Site.
 
 .content {
   > h2 {

--- a/docs/src/scss/_variables.scss
+++ b/docs/src/scss/_variables.scss
@@ -1,14 +1,3 @@
-/**
-
-File:         _variables.scss
-Description:  Settings and other reusable values for the documentation site
-
-    ◡◠ ✥ ◠◡
-
-    Table of Contents:
-
-    1. Variables
-
-*/
+// Settings and other reusable values for the documentation site
 
 $docs-max-width: 1160px;


### PR DESCRIPTION
Converting Docs Site style comments to SCSS format so they're stripped
from output in developer mode, and are more concise.