### PR TITLE
#93 - adds a mixin to quickly set :hover and :focus styles together

### DIFF
--- a/core/scss/utility/_mixins.scss
+++ b/core/scss/utility/_mixins.scss
@@ -1,5 +1,22 @@
 // Helpful mixins
 
+// Mixin for mapping a set of :hover styles onto the :focus state
+// for a slightly nicer keyboard-user experience. Use where you'd use &:hover.
+// For example:
+// .something-interactive {
+//    background: $normal-background-color;
+//    @include alt-state {
+//       background: $hover-background-color;
+//    }
+// }
+
+@mixin alt-state() {
+  &:hover,
+  &:focus {
+    @content;
+  }
+}
+
 //
 // Breakpoints
 //


### PR DESCRIPTION
This is purely an aesthetics thing, brought up in #93 - making the focus styles match the hover styles is a nice detail that I (as someone who navigates by keyboard a lot) always notice on a site. Won't hurt accessibility - if anything, this might give it a slight boost, by making focused elements stand out a little more.

[Here's a demo](http://codepen.io/jackmakesthings/full/GNXwaa/) - it's not as noticeable on links, but you can see the difference on buttons.

Ideal next step: replace uses of `&:hover` in our existing Thorium styles with this mixin. (I'd be happy to take that on myself, if folks are cool with the concept.)