### PR TITLE
Fixing sidebar nav layout in iOS 8

### DIFF
--- a/docs/browserslist
+++ b/docs/browserslist
@@ -1,0 +1,2 @@
+defaults
+iOS >= 8


### PR DESCRIPTION
Configuring the Docs Site build to include vendor prefixes for iOS 8 so
that the flexbox sidebar nav appears and disappears correctly.