### PR TITLE
[DSR] Deploy static site to S3 via Jenkins

### DIFF
--- a/ci.groovy
+++ b/ci.groovy
@@ -88,6 +88,11 @@ createJenkinsJob('telus-thorium--test') {
   }
 
   publishers {
+    archiveArtifacts {
+      pattern('**/*')
+      onlyIfSuccessful()
+    }
+
     downstream 'telus-thorium--build'
   }
 }
@@ -98,7 +103,7 @@ createJenkinsJob('telus-thorium--test') {
  */
 createJenkinsJob('telus-thorium--build') {
   steps {
-    copyArtifacts('telus-thorium--configure') {
+    copyArtifacts('telus-thorium--test') {
       buildSelector {
         latestSuccessful(true)
       }


### PR DESCRIPTION
Updates the Jenkins Job DSL for deploying static Docs Site to S3 via the AWS CLI.