### PR TITLE
Updating breakpoint documentation

### DIFF
--- a/core/scss/settings/_variables.scss
+++ b/core/scss/settings/_variables.scss
@@ -79,8 +79,8 @@ $icon-font-prefix: 'https://cdn.telus.digital/thorium/core/v0.4.0';
 
 // Breakpoints for a mobile-first grid. The pixel values of adjacent breakpoints
 // can be the same value (i.e. it's unnecessary to write values like
-// small: (544px, 768px), medium: (769px, 992px)). Media Query-generating mixins
-// will automatically add 1 where necessary.
+// small: (544px, 767px), medium: (768px, 992px)). Media Query-generating mixins
+// will automatically adjust by 1px where necessary.
 $breakpoints: (
   xs: (null,   544px),
   small: (544px,  768px),

--- a/docs/src/html/3-Foundational-Elements/4-grid.md
+++ b/docs/src/html/3-Foundational-Elements/4-grid.md
@@ -25,11 +25,13 @@ Breakpoints are the points at which your site's layout and content will respond 
 
 Thorium will have five viewports over four breakpoints:
 
-* X-Small: (0-544)
-* Small: (544 - 768)
-* Medium: (768 - 992)
-* Large: (992 - 1200)
-* X-Large: (1200+)
+| Viewport name | Minimum width | Maximum width |
+|:---|:---|:---|
+| xs | 0 | 543 |
+| small | 544 | 767 |
+| medium | 768 | 991 |
+| large | 992 | 1199 |
+| xl | 1200 | *none* |
 
 ## Responsiveness
 


### PR DESCRIPTION
This addresses #136  and #137 by changing the grid docs to reflect that the upper bound of each breakpoint is automatically adjusted by -1px in order to prevent overlap.