### PR TITLE
Run a fresh build before each npm start

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,14 @@ Symlink the core & enriched modules so changes are immediately picked up by your
 Install the rest of the projects' dependencies and start up your local documentation site.
 
     npm install
-    npm run build
-    npm run start
+    npm start
 
-The documentation site will be available at `http://localhost:8081` with Webpack Hot Module Reloading enabled.
+The documentation site will be available at [http://localhost:8081](http://localhost:8081) with Webpack Hot Module Reloading enabled.
 
 Ready to commit changes? Validate your code by running the linters & tests:
 
     npm run lint
-    npm run test
+    npm test
 
 For more information about contributing, please see the [Governance - Contribution page](/docs/5-Governance/2-contributing.md).
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build:core": "cd core && npm run build",
     "build:docs": "cd docs && npm run build",
     "build:enriched": "cd enriched && npm run build",
+    "prestart": "npm run build",
     "start": "concurrently --kill-others \"cd docs && npm run start\" \"cd docs && npm run devServer\"",
     "install": "npm run install:core && npm run install:enriched && npm run install:docs",
     "install:core": "cd core && npm install",


### PR DESCRIPTION
Reduces the number of commands a developer has to execute in order to get their local site running.