### PR TITLE
Add WithLegal Component to OverviewBlock

### DIFF
--- a/enriched/package.json
+++ b/enriched/package.json
@@ -16,6 +16,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@telusdigital/redux-contentful": "github:telusdigital/redux-contentful",
     "classnames": "^2.1.3"
   },
   "peerDependencies": {

--- a/enriched/src/blocks/components/TextTitleBodyButton/index.jsx
+++ b/enriched/src/blocks/components/TextTitleBodyButton/index.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import cx from 'classnames';
 
+import { components } from '@telusdigital/redux-contentful';
+const { Legal: { WithLegal } } = components;
+
 const TextTitleBodyButton = (props) => {
   const {className, ctaLink, title, description} = props;
 
@@ -8,9 +11,9 @@ const TextTitleBodyButton = (props) => {
 
   return (
     <div className={cls}>
-      <h4>{title}</h4>
+      <h4><WithLegal content={title} /></h4>
       <p>
-        {description}
+        <WithLegal content={description} />
       </p>
       <a className="button button-green" target={ctaLink.target} href={ctaLink.href}>
         {ctaLink.text}


### PR DESCRIPTION
## Description
We need to add the WithLegal component from redux-contentful to enable showing legal content to all components that are likely to contain text.

## Implementation
Added redux-contentful to the enriched project.
Added WithLegal to OverviewBlock where it shows text.

## Considerations
There is one text failing related to the WithLegal running in the test environment. I am not sure if there is anything to do here or if we need to fix redux-contentful before accepting this pull request. 