### PR TITLE
fix(collapsible): Fixes vertical alignment of items in Collapsible using flex

### DIFF
--- a/enriched/src/components/Collapsible/Panel.scss
+++ b/enriched/src/components/Collapsible/Panel.scss
@@ -7,7 +7,9 @@
   &__label {
     background: transparent;
     border-radius: 0;
-    display: block;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     font-weight: 400;
     font-size: 19px;
     margin: 0;
@@ -101,8 +103,6 @@
 
 
   &__header {
-    display: inline-block;
-    margin-bottom: 0;
     color: $color-shark;
     position: relative;
   }
@@ -110,11 +110,9 @@
 
 
   &__icon {
-    float: right;
+    margin: 0 5px;
     font-size: 1.125rem;
     transition: all .5s;
-    width: 18px;
-    margin-top: -2px;
   }
 
 


### PR DESCRIPTION
When the Collapsible.Group title is too long, the '+' falls to the bottom, out of alignment. This happens quite a bit on mobile screens. 

The fix uses display flex to vertically align the two items. 

Some considerations: 
The current build process seems automatically inject vendor prefixes for flex. However, this is untested in IE11. If we want to eventually use more of flexbox in the code, I was hoping we can start with something small (like this issue) to discuss how we can polyfill flex for IE11. 

Some links for reference: https://github.com/philipwalton/flexbugs