### PR TITLE
feat(Card): Adds a no-border variant of the Card component

### DIFF
--- a/docs/src/html/4-Global Components/Card.md
+++ b/docs/src/html/4-Global Components/Card.md
@@ -32,7 +32,7 @@ const CardEx = () => {
       <div className="grid-row">
         <div className="small-12 medium-6 large-4">
           <Card>
-            </h2>Hello World</h2>
+            <h2>Hello World</h2>
             <p>This is the content...</p>
           </Card>
         </div>
@@ -41,6 +41,28 @@ const CardEx = () => {
 }
 
 export default CardEx;
+```
+
+## Card with no border
+---
+<div class="grid-row">
+  <div class="small-12 medium-6 large-6">
+    <div id="borderlessCardExample">
+    </div>
+  </div>
+</div>
+<script type="text/babel">
+  ReactDOM.render(
+    <Thorium.BorderlessCardExample />,
+    document.getElementById('borderlessCardExample')
+  );
+</script>
+
+```javascript
+<Card className="card--no-border">
+  <h2>Hello World</h2>
+  <p>This is the body of a card with no border.</p>
+</Card>
 ```
 
 

--- a/docs/src/js/components/CardExample/index.jsx
+++ b/docs/src/js/components/CardExample/index.jsx
@@ -1,13 +1,20 @@
 import React from 'react';
 import { Card } from 'telus-thorium-enriched';
 
-const CardExample = () => {
+export const CardExample = () => {
     return (
       <Card>
         <h2>Hello World</h2>
         <p>This is the body.</p>
       </Card>
     );
-}
+};
 
-export default CardExample;
+export const BorderlessCardExample = () => {
+  return (
+    <Card className="card--no-border">
+      <h2>Hello World</h2>
+      <p>This is the body of a card with no border.</p>
+    </Card>
+  );
+};

--- a/docs/src/js/components/index.jsx
+++ b/docs/src/js/components/index.jsx
@@ -2,12 +2,13 @@ import SelectorCounterExample from './SelectorCounterExample';
 import RegularCollapsibleExample from './CollapsibleExample/RegularCollapsible';
 import AccordionCollapsibleExample from './CollapsibleExample/AccordionCollapsible';
 import ControlledCollapsibleExample from './CollapsibleExample/ControlledCollapsible';
-import CardExample from './CardExample';
+import {CardExample, BorderlessCardExample} from './CardExample';
 
 export {
   SelectorCounterExample,
   RegularCollapsibleExample,
   AccordionCollapsibleExample,
   ControlledCollapsibleExample,
-  CardExample
+  CardExample,
+  BorderlessCardExample
 };

--- a/enriched/src/components/Card/card.scss
+++ b/enriched/src/components/Card/card.scss
@@ -5,4 +5,8 @@
   box-sizing: border-box;
   border-radius: 4px;
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.08);
+
+  &--no-border {
+    border: 0;
+  }
 }


### PR DESCRIPTION
Adds a no-border variant of the Card component. This commit also includes updates to the documentation with a borderless Card example.

Examples of places where the no-border variant of the Card is used: 
- [Images with cards](https://app.zeplin.io/project/58e7d8bf419ba3423fd43814/screen/58efb01a22dfdbad55082615)
- [Need a hand?/Next Best Step sections](https://app.zeplin.io/project/58e7d8bf419ba3423fd43814/screen/58efb00dd6a1a5b0a721a209)


