### PR TITLE
feat(enriched): Contributes BlockImageFullCentredQuote and ComponentQ…

### DIFF
--- a/enriched/src/blocks/BlockImageFullCentredQuote/README.md
+++ b/enriched/src/blocks/BlockImageFullCentredQuote/README.md
@@ -1,0 +1,11 @@
+Example:
+
+    <BlockImageFullCentredQuote 
+        quote="Design is not just what it looks like and feels like. Design is how it works." 
+        author="Steve Jobs"
+        clientName="Apple"
+        bannerImage={{
+            title: 'Banner image alt text',
+            file: { url: 'http://via.placeholder.com/1440x720' }
+        }} 
+        clientLogo={{file: { url: 'http://via.placeholder.com/50x50' }, title: 'Client logo title'}} />

--- a/enriched/src/blocks/BlockImageFullCentredQuote/__tests__/BlockImageFullCentredQuote.spec.jsx
+++ b/enriched/src/blocks/BlockImageFullCentredQuote/__tests__/BlockImageFullCentredQuote.spec.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import BlockImageFullCentredQuote from '../';
+
+describe('Quote Banner Block Component', () => {
+  let wrapper;
+
+  describe('props are not present', () => {
+    beforeEach(() => {
+      const props = {};
+      wrapper = shallow(<BlockImageFullCentredQuote {...props} />);
+    });
+
+    it('should not render banner image', () => {
+      expect(wrapper.find('img')).toHaveLength(0);
+    });
+
+    it('should not render client logo image', () => {
+      const quoteCard = wrapper.find('ComponentQuoteCard');
+      expect(quoteCard.props()).toHaveProperty('clientLogo', { file: { url: '' }, title: '' });
+    });
+  });
+
+  describe('props are present', () => {
+    beforeEach(() => {
+      const props = {
+        quote: 'Some quote',
+        author: 'Author',
+        clientName: 'Client Name',
+        clientLogo: { file: { url: 'some/path' }, title: 'description' },
+        bannerImage: { file: { url: 'picture.png' }, title: 'description' }
+      };
+      wrapper = shallow(<BlockImageFullCentredQuote {...props} />);
+    });
+
+    it('should render child component with props passed down', () => {
+      const quoteCard = wrapper.find('ComponentQuoteCard');
+      expect(quoteCard.props()).toHaveProperty('quote', 'Some quote');
+      expect(quoteCard.props()).toHaveProperty('author', 'Author');
+      expect(quoteCard.props()).toHaveProperty('clientName', 'Client Name');
+      expect(quoteCard.props()).toHaveProperty('clientLogo', { file: {url: 'some/path'}, title: 'description' });
+    });
+
+    it('should set the banner image as background image', () => {
+      expect(wrapper.find('ComponentWithWidth').exists()).toBe(true);
+      expect(wrapper.find('ComponentWithWidth').props()).toHaveProperty('imageData', {"file": {"url": "picture.png"}, "title": "description"});
+    });
+  });
+});

--- a/enriched/src/blocks/BlockImageFullCentredQuote/b-image-full-centred-quote.scss
+++ b/enriched/src/blocks/BlockImageFullCentredQuote/b-image-full-centred-quote.scss
@@ -1,0 +1,30 @@
+@import '~telus-thorium-core/scss/settings/variables';
+@import '~telus-thorium-core/scss/utility/mixins';
+
+.b-image-full-centred-quote {
+  position: relative;
+  margin-bottom: 50px;
+
+  @include from-breakpoint(medium) {
+    margin-bottom: 170px;
+    &__img {
+      display: block;
+      width: 100vw;
+      max-height: 500px;
+      object-fit: cover;
+    }
+  }
+
+  &__card {
+    position: relative;
+    margin-top: -30px;
+    width: 100%;
+    padding: 0px 16px;
+
+    @include from-breakpoint(medium) {
+      position: absolute;
+      top: initial;
+      bottom: -75px;
+    }
+  }
+}

--- a/enriched/src/blocks/BlockImageFullCentredQuote/index.jsx
+++ b/enriched/src/blocks/BlockImageFullCentredQuote/index.jsx
@@ -1,0 +1,67 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { components } from '@telusdigital/redux-contentful';
+import ComponentQuoteCard from '../ComponentQuoteCard';
+
+if (process.env.BROWSER) {
+  require('./b-image-full-centred-quote.scss');
+}
+
+const { ResponsiveImage } = components;
+
+/**
+ * BlockImageFullCentredQuote is composed of a full bleed banner image (usually related to the quote)
+ * and a [ComponentQuoteCard](#componentquotecard).
+ *
+ * Contentful model (BUS > Marketing): Quote Banner Block
+ *
+ * https://telusdigital.atlassian.net/browse/BMK-58
+ */
+const BlockImageFullCentredQuote = ({ bannerImage, ...rest }) => (
+  <section className="b-image-full-centred-quote">
+    { bannerImage && bannerImage.file &&
+    <ResponsiveImage className="b-image-full-centred-quote__img" imageData={bannerImage} xs={576} sm={768} md={992} lg={1200} xl={1440} />
+      }
+    <div className="container b-image-full-centred-quote__card">
+      <div className="grid-row">
+        <div className="large-6 offset-large-3 medium-6 offset-medium-3 small-12">
+          <ComponentQuoteCard {...rest} />
+        </div>
+      </div>
+    </div>
+  </section>
+);
+
+BlockImageFullCentredQuote.propTypes = {
+  /** Contentful media field, recommended specification: 1440 x 720 */
+  bannerImage: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    file: PropTypes.shape({
+      url: PropTypes.string.isRequired
+    })
+  }),
+  /** prop consumed by ComponentQuoteCard */
+  quote: PropTypes.string,
+  /** prop consumed by ComponentQuoteCard */
+  author: PropTypes.string,
+  /** prop consumed by ComponentQuoteCard */
+  clientName: PropTypes.string,
+  /** Contentful media field, prop consumed by ComponentQuoteCard */
+  clientLogo: PropTypes.shape({
+    title: PropTypes.string,
+    file: PropTypes.shape({
+      url: PropTypes.string
+    })
+  })
+};
+
+BlockImageFullCentredQuote.defaultProps = {
+  clientLogo: {
+    file: {
+      url: ''
+    },
+    title: ''
+  }
+};
+
+export default BlockImageFullCentredQuote;

--- a/enriched/src/blocks/ComponentQuoteCard/README.md
+++ b/enriched/src/blocks/ComponentQuoteCard/README.md
@@ -1,0 +1,8 @@
+ComponentQuoteCard example:
+
+    <ComponentQuoteCard
+      quote="Being the richest man in the cemetery doesn't matter to me. Going to bed at night saying we've done something wonderful, that's what matters to me."
+      author="Steve Jobs"
+      clientName="Apple, Inc"
+      clientLogo={{file: { url: 'http://via.placeholder.com/50x50' }, title: 'Client logo title'}}
+    />

--- a/enriched/src/blocks/ComponentQuoteCard/__tests__/ComponentQuoteCard.spec.jsx
+++ b/enriched/src/blocks/ComponentQuoteCard/__tests__/ComponentQuoteCard.spec.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import ComponentQuoteCard from '../';
+
+describe('QuoteCard Component', () => {
+  let quoteCard;
+
+  describe('props are not present', () => {
+    beforeEach(() => {
+      const props = {};
+      quoteCard = shallow(<ComponentQuoteCard {...props} />);
+    });
+
+    it('should set default quote to empty string', () => {
+      expect(quoteCard.find('.c-quote-card__quote-text').text()).toEqual('“”');
+    });
+
+    it('should set default author to empty string', () => {
+      expect(quoteCard.find('.c-quote-card__author').text()).toContain('');
+    });
+
+    it('should not render client logo image', () => {
+      expect(quoteCard.find('img')).toHaveLength(0);
+    });
+  });
+
+  describe('props are present', () => {
+    beforeEach(() => {
+      const props = {
+        author: 'Author name',
+        quote: 'My quote',
+        clientName: 'Some company',
+        clientLogo: {file: {url: 'some/url'}, title: 'Client logo title'}
+      };
+      quoteCard = shallow(<ComponentQuoteCard {...props} />);
+    });
+
+    it('renders a quote', () => {
+      expect(quoteCard.find('.c-quote-card__quote-text').text()).toEqual('“My quote”');
+    });
+
+    it('renders an author title', () => {
+      expect(quoteCard.find('.c-quote-card__author').text()).toContain('Author name');
+    });
+
+    it('renders an author client name', () => {
+      expect(quoteCard.find('.c-quote-card__author').text()).toContain('Some company');
+    });
+
+    it('renders an author client name', () => {
+      const imgProps = quoteCard.find('ComponentWithWidth').props();
+      expect(imgProps).toHaveProperty('imageData', {file: {url: 'some/url'}, title: 'Client logo title'});
+    });
+  });
+});

--- a/enriched/src/blocks/ComponentQuoteCard/c-quote-card.scss
+++ b/enriched/src/blocks/ComponentQuoteCard/c-quote-card.scss
@@ -1,0 +1,27 @@
+@import '~telus-thorium-core/scss/settings/variables';
+@import '~telus-thorium-core/scss/utility/mixins';
+
+.c-quote-card {
+  &__logo {
+    max-width: 50px;
+    max-height: 50px;
+    margin-bottom: 10px;
+  }
+
+  @include from-breakpoint(medium) {
+    &__author {
+      position:relative;
+      height: 50px;
+    }
+
+    &__logo {
+      position:absolute;
+      left: 0;
+    }
+
+    &__names {
+      position:absolute;
+      left: 80px;
+    }
+  }
+}

--- a/enriched/src/blocks/ComponentQuoteCard/index.jsx
+++ b/enriched/src/blocks/ComponentQuoteCard/index.jsx
@@ -1,0 +1,67 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { components } from '@telusdigital/redux-contentful';
+import Card from '../../components/Card';
+
+if (process.env.BROWSER) {
+  require('./c-quote-card.scss');
+}
+
+const { ResponsiveImage } = components;
+
+/**
+ * ComponentQuoteCard takes up the full width of its parent container.
+ * It can be used with [BlockImageFullCenteredQuote](#blockimagefullcentredquote).
+ *
+ * Contentful model (BUS > Marketing): Quote Banner Block
+ *
+ * https://telusdigital.atlassian.net/browse/BMK-58
+ */
+const ComponentQuoteCard = ({ quote, author, clientName, clientLogo }) => (
+  <Card>
+    <p className="c-quote-card__quote-text">&ldquo;{quote}&rdquo;</p>
+    <div className="c-quote-card__author">
+
+      <div className="c-quote-card__logo">
+        { clientLogo && clientLogo.file &&
+        <ResponsiveImage imageData={clientLogo} xs={50} sm={50} md={50} lg={50} xl={50} />
+          }
+      </div>
+
+      <div className="text--medium c-quote-card__names">
+        <strong>{author}</strong><br />
+        {clientName}
+      </div>
+
+    </div>
+  </Card>
+);
+
+ComponentQuoteCard.propTypes = {
+  quote: PropTypes.string.isRequired,
+  /** recommended: not more than one line */
+  author: PropTypes.string.isRequired,
+  /** recommended: not more than one line */
+  clientName: PropTypes.string.isRequired,
+  /** Contentful media field, recommended specification: square (e.g. 50 x 50). Layout will not handle client logo not being present. */
+  clientLogo: PropTypes.shape({
+    title: PropTypes.string,
+    file: PropTypes.shape({
+      url: PropTypes.string
+    })
+  })
+};
+
+ComponentQuoteCard.defaultProps = {
+  quote: '',
+  author: '',
+  clientName: '',
+  clientLogo: {
+    file: {
+      url: ''
+    },
+    title: ''
+  }
+};
+
+export default ComponentQuoteCard;


### PR DESCRIPTION
Contributes BlockImageFullCentredQuote and ComponentQuoteCard from business-marketing.

Note: In business-marketing, BlockAAA's and ComponentBBB are placed in the same folder.

We make the same assumption when contributing, so that we can do a relative import of the Component from a Block: 
`import ComponentXXX from '../ComponentXX'`