### PR TITLE
feat(expandcollapse): Add aria-disabled and disabled flag to button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ coverage
 .idea
 *.iws
 .vscode
+*.swp
 
 # TDS build artifacts
 dist

--- a/src/old-components/ExpandCollapse/Panel.jsx
+++ b/src/old-components/ExpandCollapse/Panel.jsx
@@ -65,8 +65,10 @@ class Panel extends Component {
         <button
           onClick={onPanelClick}
           aria-expanded={isActive ? 'true' : 'false'}
+          aria-disabled={isDisabled ? 'true' : 'false'}
           aria-controls={this.contentId}
           className={collapsePaneLabelClassName}
+          disabled={isDisabled}
         >
           <span className="collapsible-panel__icon">
             <i className={iconClassName} />

--- a/src/old-components/ExpandCollapse/__tests__/ExpandCollapse.spec.jsx
+++ b/src/old-components/ExpandCollapse/__tests__/ExpandCollapse.spec.jsx
@@ -17,6 +17,7 @@ describe('<ExpandCollapse/>', () => {
       </Group>
     )
     expect(wrapper.find('.collapsible-panel__label--disabled').length).toEqual(1)
+    expect(wrapper.find('.collapsible-panel__label--disabled').find('button').props().disabled).toBe(true)
     const panel1 = wrapper.find('.collapsible-panel__header').first()
     panel1.simulate('click')
     expect(wrapper.find('.collapsible-panel__content').first().hasClass('collapsible-panel__content--visible')).toEqual(false)


### PR DESCRIPTION
Throwing out a suggestion for quality of life improvement. By adding aria-disabled as well as a disabled flag to buttons, screen readers will easily recognize sections that are currently disabled.

BREAKING CHANGE: None, I hope

## Description
- Description of the problem the contribution solves or link to design issue
  - [ ] Explanation of how existing TDS code falls short
  - [ ] Implementation method (how do you intend to do it)
  - [ ] Explanation of backwards compatibility for users who are already on this feature

## Considerations
- [ ] Provide access to Finalised designs in sketch and zeplin
- [ ] Add documentation
- [ ] Include any notes/discussion points as covered in grooming by DEV/QA regarding approach/implementation.

## Dev Acceptance Criteria
- [ ] Alignment to approved Sketch file and creative mockups
- [ ] Documentation is finalized
- [ ] Code meets AA accessibility guidelines
- [ ] Code passes automated tests and style checks
- [x] New code is unit tested where appropriate (developer should use own judgement)
- [ ] Code passes Pull Request review with 1 approval
