### PR TITLE
Add sublabel for smaller text next to input label

### DIFF
--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -158,8 +158,8 @@ class Input extends React.Component {
               </Text>
 
               {sublabel &&
-                <Box inline spacing="margin" left={2}>
-                  <Text size="small" data-test="sublabel">
+                <Box inline spacing="margin" left={2} data-testid="sublabel">
+                  <Text size="small">
                     {sublabel}
                   </Text>
                 </Box>
@@ -225,7 +225,7 @@ Input.propTypes = {
    */
   label: PropTypes.string.isRequired,
   /**
-   * Smaller text to display next to the label.
+   * Clarify attributes of the expected input.
    */
   sublabel: PropTypes.string,
   /**

--- a/src/components/Input/Input.md
+++ b/src/components/Input/Input.md
@@ -78,14 +78,13 @@ const validate = (event) => {
 
 ### Supplying extra information
 
-Use `sublabel` to display some smaller text next to the label.
+Use `sublabel` to clarify attributes of the expected input.
+We recommend using this over the html `placeholder` attribute because it's more usable and accessible.
 
 ```
-<div>
-  <Input
-    label="Transit number" sublabel="5 digits" type="number"
-  />
-</div>
+<Input
+  label="Transit number" sublabel="5 digits" type="number"
+/>
 ```
 
 Use a `helper` to offer the user a detailed explanation of the input expected by a form field. Use the `Input.Helper`

--- a/src/components/Input/__tests__/Input.spec.jsx
+++ b/src/components/Input/__tests__/Input.spec.jsx
@@ -54,16 +54,19 @@ describe('Input', () => {
       const input = doShallow({ sublabel: 'The sublabel' })
 
       const sublabel = input
-        .find('[data-test="sublabel"]')
-        .dive()
+        .find('[data-testid="sublabel"]')
 
-      expect(sublabel).toHaveText('The sublabel')
+      expect(sublabel).toContainReact(
+        <Text size="small">
+          The sublabel
+        </Text>
+      )
     })
 
     it('should not contain sublabel when not provided', () => {
       const input = doShallow({ sublabel: undefined })
 
-      const sublabel = input.find('[data-test="sublabel"]')
+      const sublabel = input.find('[data-testid="sublabel"]')
 
       expect(sublabel).not.toBePresent()
     })


### PR DESCRIPTION
## Description
Corresponding issue: https://github.com/telusdigital/tds/issues/420

Added a `sublabel` property to the `Input` component which is displayed in smaller text next to the label. We also added an example to the `Input` documentation.

![screen shot 2017-10-05 at 3 06 54 pm](https://user-images.githubusercontent.com/5311720/31251056-bdee26e6-a9ea-11e7-9bff-60a2957e6a6b.png)

@petermarshall878 