### PR TITLE
fix(shared-choice): call onchange after async setstate

### DIFF
--- a/packages/Checkbox/Checkbox.md
+++ b/packages/Checkbox/Checkbox.md
@@ -35,9 +35,9 @@ initialState = {
 
 const handleCheck = event => {
   if (event.target.checked) {
-    setState({ checked: false, feedback: undefined, message: undefined })
+    setState({ checked: true, feedback: undefined, message: undefined })
   } else {
-    setState({ checked: true, feedback: 'error', message: message })
+    setState({ checked: false, feedback: 'error', message: message })
   }
 }
 

--- a/packages/Radio/Radio.md
+++ b/packages/Radio/Radio.md
@@ -15,8 +15,11 @@ initialState = {
   choice: 'e.bill',
 }
 
-const setChoice = event => setState({ choice: event.target.value })
-;<Box tag="fieldset" between={2}>
+const setChoice = event => {
+  setState({ choice: event.target.value })
+}
+
+<Box tag="fieldset" between={2}>
   <legend>
     <Text bold size="medium">
       How would you like to recieve your monthly bill?
@@ -25,7 +28,7 @@ const setChoice = event => setState({ choice: event.target.value })
   <Radio
     label="e.Bill"
     name="monthly-bill"
-    value="e.Bill"
+    value="e.bill"
     checked={state.choice === 'e.bill'}
     onChange={setChoice}
   />

--- a/shared/components/Choice/Choice.jsx
+++ b/shared/components/Choice/Choice.jsx
@@ -85,13 +85,19 @@ class Choice extends React.Component {
 
   onChange = event => {
     const { onChange } = this.props
-    this.setState(({ checked }) => ({
-      checked: !checked,
-    }))
 
-    if (onChange) {
-      onChange(event)
-    }
+    event.persist()
+
+    this.setState(
+      ({ checked }) => {
+        return { checked: !checked }
+      },
+      () => {
+        if (onChange) {
+          onChange(event)
+        }
+      }
+    )
   }
 
   onFocus = event => {


### PR DESCRIPTION
## Description

- Addresses the Checkbox and Radio state issue described in: https://github.com/telusdigital/tds-core/issues/641
  - _When using application state to set the checked prop of Checkbox, the state of the Checkbox gets out of sync with the state of the application, causing the Checkbox to display the wrong state._
  - This is first seen on _Input_, _Select_, _Textarea_ in issue: https://github.com/telusdigital/tds-core/issues/606
- Fixes the issue by:
  - duplicating the solution in this PR: https://github.com/telusdigital/tds-core/pull/590
  - correcting sample code in both Checkbox and Radio, which used to reflect the expected but incorrect state

----

### Prepr output
```
[Components Spec] Test Suite
================================

Running:  @tds/core-checkbox
 ✔ Element <#checkbox> was visible after 30 milliseconds.
 ✔ Passed [ok]: 12 aXe Tests Passed
 ✔ #rsg-root passes accessibility scan
 ✔ Screenshots Matched for chrome_headless.png with a tolerance of 0%, actual was 0%.

OK. 4 assertions passed. (2.914s)

Running:  @tds/core-radio
 ✔ Element <#radio> was visible after 31 milliseconds.
 ✔ Passed [ok]: 14 aXe Tests Passed
 ✔ #rsg-root passes accessibility scan
 ✔ Screenshots Matched for chrome_headless.png with a tolerance of 0%, actual was 0%.

OK. 4 assertions passed. (2.685s)

OK. 8  total assertions passed. (5.663s)

================================

Changes:
 - @tds/core-checkbox: 1.0.2 => 1.0.3
 - @tds/core-radio: 1.0.2 => 1.0.3
 - @tds/shared-choice: 1.0.2 => 1.0.3 (private)
```