### PR TITLE
fix(core-input-feedback): add role alert to error message

### DIFF
--- a/packages/InputFeedback/InputFeedback.jsx
+++ b/packages/InputFeedback/InputFeedback.jsx
@@ -17,6 +17,7 @@ const InputFeedback = ({ feedback, children, ...rest }) => (
     {...safeRest(rest)}
     inset={3}
     dangerouslyAddClassName={feedback ? styles[feedback] : styles.default}
+    role={feedback === 'error' ? 'alert' : null}
   >
     {children}
   </Box>

--- a/packages/InputFeedback/__tests__/InputFeedback.spec.jsx
+++ b/packages/InputFeedback/__tests__/InputFeedback.spec.jsx
@@ -29,9 +29,14 @@ describe('InputFeedback', () => {
   })
 
   it('passes additional attributes to the element', () => {
-    const inputFeedback = doShallow({ id: 'the-inputFeedback', role: 'alert' })
+    const inputFeedback = doShallow({ id: 'the-inputFeedback' })
 
     expect(inputFeedback).toHaveProp('id', 'the-inputFeedback')
+  })
+
+  it('sets role to alert on error', () => {
+    const inputFeedback = doShallow({ feedback: 'error' })
+
     expect(inputFeedback).toHaveProp('role', 'alert')
   })
 


### PR DESCRIPTION
Adds `role="alert"` to all input errors by default. Addresses #654.

prepr:
```
Changes:
 - @tds/core-checkbox: 1.0.4 => 1.0.5
 - @tds/core-input: 1.0.6 => 1.0.7
 - @tds/core-input-feedback: 1.0.1 => 1.0.2
 - @tds/core-radio: 1.0.4 => 1.0.5
 - @tds/core-select: 1.0.7 => 1.0.8
 - @tds/core-text-area: 1.0.6 => 1.0.7
 - @tds/core-tooltip: 1.0.4 => 1.1.0
 - @tds/shared-choice: 1.0.4 => 1.0.5 (private)
 - @tds/shared-form-field: 1.0.5 => 1.0.6 (private)
```

This can be rebased.