### PR TITLE
fix(core-expand-collapse): enable adaptive panel size

### DIFF
--- a/packages/ExpandCollapse/Accordion/__tests__/__snapshots__/Accordion.spec.jsx.snap
+++ b/packages/ExpandCollapse/Accordion/__tests__/__snapshots__/Accordion.spec.jsx.snap
@@ -163,12 +163,14 @@ exports[`Accordion renders a closed accordion 1`] = `
             </button>
           </Clickable>
           <Reveal
+            duration={500}
             height={0}
             in={false}
-            timeout={500}
+            timeout={0}
           >
             <Transition
               appear={false}
+              duration={500}
               enter={true}
               exit={true}
               in={false}
@@ -179,7 +181,7 @@ exports[`Accordion renders a closed accordion 1`] = `
               onExit={[Function]}
               onExited={[Function]}
               onExiting={[Function]}
-              timeout={500}
+              timeout={0}
               unmountOnExit={false}
             >
               <div
@@ -418,12 +420,14 @@ exports[`Accordion renders an open accordion 1`] = `
             </button>
           </Clickable>
           <Reveal
+            duration={500}
             height={0}
             in={true}
             timeout={500}
           >
             <Transition
               appear={false}
+              duration={500}
               enter={true}
               exit={true}
               in={true}
@@ -442,7 +446,7 @@ exports[`Accordion renders an open accordion 1`] = `
                 data-testid="childrenContainer"
                 style={
                   Object {
-                    "height": "0px",
+                    "height": "auto",
                     "overflow": "hidden",
                     "transition": "height 500ms",
                   }

--- a/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
+++ b/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
@@ -138,7 +138,12 @@ class PanelWrapper extends React.Component {
           </Box>
         </Clickable>
 
-        <Reveal timeout={500} in={this.state.open} height={this.state.contentWrapperHeight}>
+        <Reveal
+          timeout={this.state.open ? 500 : 0}
+          duration={500}
+          in={this.state.open}
+          height={this.state.contentWrapperHeight}
+        >
           {() => (
             <div
               ref={contentWrapper => {

--- a/packages/ExpandCollapse/__tests__/__snapshots__/ExpandCollapse.spec.jsx.snap
+++ b/packages/ExpandCollapse/__tests__/__snapshots__/ExpandCollapse.spec.jsx.snap
@@ -166,12 +166,14 @@ exports[`ExpandCollapse renders a closed panel 1`] = `
             </button>
           </Clickable>
           <Reveal
+            duration={500}
             height={0}
             in={false}
-            timeout={500}
+            timeout={0}
           >
             <Transition
               appear={false}
+              duration={500}
               enter={true}
               exit={true}
               in={false}
@@ -182,7 +184,7 @@ exports[`ExpandCollapse renders a closed panel 1`] = `
               onExit={[Function]}
               onExited={[Function]}
               onExiting={[Function]}
-              timeout={500}
+              timeout={0}
               unmountOnExit={false}
             >
               <div
@@ -433,12 +435,14 @@ exports[`ExpandCollapse renders an open panel 1`] = `
             </button>
           </Clickable>
           <Reveal
+            duration={500}
             height={0}
             in={true}
             timeout={500}
           >
             <Transition
               appear={false}
+              duration={500}
               enter={true}
               exit={true}
               in={true}
@@ -457,7 +461,7 @@ exports[`ExpandCollapse renders an open panel 1`] = `
                 data-testid="childrenContainer"
                 style={
                   Object {
-                    "height": "0px",
+                    "height": "auto",
                     "overflow": "hidden",
                     "transition": "height 500ms",
                   }

--- a/shared/components/Animation/Reveal.jsx
+++ b/shared/components/Animation/Reveal.jsx
@@ -2,8 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Transition } from 'react-transition-group'
 
-const defaultStyle = timeout => ({
-  transition: `height ${timeout}ms`,
+const defaultStyle = (duration, timeout) => ({
+  transition: `height ${duration || timeout}ms`,
   height: 0,
   overflow: 'hidden',
 })
@@ -19,7 +19,8 @@ const transitionStyles = height => {
 
   return {
     entering: styles,
-    entered: styles,
+    entered: { height: 'auto' },
+    exiting: styles,
     exited: hiddenContent,
   }
 }
@@ -29,7 +30,7 @@ const Reveal = ({ height, children, ...rest }) => (
     {status => (
       <div
         style={{
-          ...defaultStyle(rest.timeout),
+          ...defaultStyle(rest.duration, rest.timeout),
           ...transitionStyles(height)[status],
         }}
         aria-hidden={status === 'exited'}
@@ -42,8 +43,13 @@ const Reveal = ({ height, children, ...rest }) => (
 )
 Reveal.propTypes = {
   timeout: PropTypes.number.isRequired,
+  duration: PropTypes.number,
   height: PropTypes.number.isRequired,
   children: PropTypes.func.isRequired,
+}
+
+Reveal.defaultProps = {
+  duration: undefined,
 }
 
 export default Reveal

--- a/shared/components/Animation/__tests__/__snapshots__/Reveal.spec.jsx.snap
+++ b/shared/components/Animation/__tests__/__snapshots__/Reveal.spec.jsx.snap
@@ -16,7 +16,7 @@ exports[`Reveal renders when the transition is triggered 1`] = `
 <div
   aria-hidden="false"
   data-testid="childrenContainer"
-  style="transition:height 500ms;height:300px;overflow:hidden"
+  style="transition:height 500ms;height:auto;overflow:hidden"
 >
   <div>
     Content to reveal


### PR DESCRIPTION
Allows ExpandCollapse to adapt to the size of its children. Addresses #671.

prepr:
```
Changes:
 - @tds/core-expand-collapse: 1.0.3 => 1.0.4
 - @tds/core-input: 1.0.6 => 1.0.7
 - @tds/core-select: 1.0.7 => 1.0.8
 - @tds/core-text-area: 1.0.6 => 1.0.7
 - @tds/core-tooltip: 1.0.4 => 1.1.0
 - @tds/shared-animation: 1.0.1 => 1.0.2 (private)
```

This can be rebased.