### PR TITLE
fix(shared-choice): allow value to be a number on Radio and Checkbox

### DIFF
--- a/packages/Checkbox/__tests__/Checkbox.spec.jsx
+++ b/packages/Checkbox/__tests__/Checkbox.spec.jsx
@@ -39,6 +39,12 @@ describe('Checkbox', () => {
     expect(checkbox).toMatchSnapshot()
   })
 
+  it('allows numbers as value', () => {
+    const checkbox = render(<Checkbox label="A label" name="the-group-name" value={1} />)
+
+    expect(checkbox).toMatchSnapshot()
+  })
+
   it('must have a label', () => {
     const { label } = doMount({ label: 'Some label' })
 

--- a/packages/Checkbox/__tests__/__snapshots__/Checkbox.spec.jsx.snap
+++ b/packages/Checkbox/__tests__/__snapshots__/Checkbox.spec.jsx.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Checkbox allows numbers as value 1`] = `
+<div
+  class="TDS_Box-modules__betweenBottomMargin-2___31zX_ TDS_Box-modules__stack___33m4D"
+>
+  <label
+    for="the-group-name_1"
+  >
+    <span
+      class="TDS_Box-modules__betweenRightMargin-3___1dOvx TDS_Box-modules__inline___jTHcz alignFlexStart"
+    >
+      <span
+        class="fakeCheckbox unchecked"
+        data-testid="fake-input"
+      >
+        <input
+          aria-invalid="false"
+          class="hiddenInput"
+          id="the-group-name_1"
+          name="the-group-name"
+          type="checkbox"
+          value="1"
+        />
+      </span>
+      <span
+        class="TDS_Typography-modules__medium___1DC1g TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__mediumFont___2ULml TDS_Typography-modules__color___1Jt_W"
+      >
+        A label
+      </span>
+    </span>
+  </label>
+</div>
+`;
+
 exports[`Checkbox renders 1`] = `
 <div
   class="TDS_Box-modules__betweenBottomMargin-2___31zX_ TDS_Box-modules__stack___33m4D"

--- a/packages/Radio/__tests__/Radio.spec.jsx
+++ b/packages/Radio/__tests__/Radio.spec.jsx
@@ -38,6 +38,12 @@ describe('Radio', () => {
     expect(radio).toMatchSnapshot()
   })
 
+  it('allows numbers as value', () => {
+    const radio = render(<Radio label="A label" name="the-group" value={1} />)
+
+    expect(radio).toMatchSnapshot()
+  })
+
   it('must have a label', () => {
     const { label } = doMount({ label: 'Some label' })
 

--- a/packages/Radio/__tests__/__snapshots__/Radio.spec.jsx.snap
+++ b/packages/Radio/__tests__/__snapshots__/Radio.spec.jsx.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Radio allows numbers as value 1`] = `
+<div
+  class="TDS_Box-modules__betweenBottomMargin-2___31zX_ TDS_Box-modules__stack___33m4D"
+>
+  <label
+    for="the-group_1"
+  >
+    <span
+      class="TDS_Box-modules__betweenRightMargin-3___1dOvx TDS_Box-modules__inline___jTHcz alignFlexStart"
+    >
+      <span
+        class="fakeRadio unchecked"
+        data-testid="fake-input"
+      >
+        <input
+          aria-invalid="false"
+          class="hiddenInput"
+          id="the-group_1"
+          name="the-group"
+          type="radio"
+          value="1"
+        />
+      </span>
+      <span
+        class="TDS_Typography-modules__medium___1DC1g TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__mediumFont___2ULml TDS_Typography-modules__color___1Jt_W"
+      >
+        A label
+      </span>
+    </span>
+  </label>
+</div>
+`;
+
 exports[`Radio renders 1`] = `
 <div
   class="TDS_Box-modules__betweenBottomMargin-2___31zX_ TDS_Box-modules__stack___33m4D"

--- a/shared/utils/generateId.js
+++ b/shared/utils/generateId.js
@@ -2,6 +2,7 @@ import find from 'core-js/fn/array/find'
 
 const sanitize = text =>
   text
+    .toString()
     .toLowerCase()
     .replace(/ /g, '-')
     .replace(/[^a-zA-Z0-9-]/g, '')


### PR DESCRIPTION
<!--
  ### IMPORTANT SECURITY NOTE ###

  When opening pull requests, be sure NOT to include any private or personal
  information such as secrets, passwords, or any source code that involves
  data retrieval. 
-->

## Related issues

See #682 

## Description

Update Radio and Checkbox to allow numbers to be passed as value./

## Package changes

```
$ yarn test:e2e && node scripts/prePr.js --conventional-commits --yes
$ node scripts/e2e.js
No components have been changed, nothing to do. Exiting.
lerna info versioning independent
lerna info ignore [ '*.md', '*.spec.jsx', '*.snap', '@tds/core-selector-counter' ]
lerna info Checking for updated packages...
lerna info Comparing with @tds/core-expand-collapse@1.1.0.
lerna info Checking for prereleased packages...
lerna info No updated packages to publish.

🤔 If this is not what you expected, ensure that your commit messages follow the Conventional Commits specification (https://conventionalcommits.org) and try again.

🚀 Please paste the entire output of this task into the body of your Pull Request so that a maintainer can verify before merging/publishing.
```