### PR TITLE
refactor(util-generate-id): move into private package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "workspaces": [
     "packages/*",
     "shared/components/*",
-    "shared/styles/*"
+    "shared/styles/*",
+    "shared/utils/*"
   ],
   "scripts": {
     "bootstrap": "yarn install && yarn gitbook:install && lerna bootstrap && yarn build --all",

--- a/packages/Checkbox/Checkbox.jsx
+++ b/packages/Checkbox/Checkbox.jsx
@@ -29,7 +29,7 @@ Checkbox.propTypes = {
   /**
    * The value. Must be unique within the group.
    */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired,
   /**
    * The checked state
    */

--- a/packages/Checkbox/__tests__/Checkbox.spec.jsx
+++ b/packages/Checkbox/__tests__/Checkbox.spec.jsx
@@ -39,6 +39,12 @@ describe('Checkbox', () => {
     expect(checkbox).toMatchSnapshot()
   })
 
+  it('allows numbers as value', () => {
+    const checkbox = render(<Checkbox label="A label" name="the-group-name" value={1} />)
+
+    expect(checkbox).toMatchSnapshot()
+  })
+
   it('must have a label', () => {
     const { label } = doMount({ label: 'Some label' })
 

--- a/packages/Checkbox/__tests__/__snapshots__/Checkbox.spec.jsx.snap
+++ b/packages/Checkbox/__tests__/__snapshots__/Checkbox.spec.jsx.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Checkbox allows numbers as value 1`] = `
+<div
+  class="TDS_Box-modules__betweenBottomMargin-2___31zX_ TDS_Box-modules__stack___33m4D"
+>
+  <label
+    for="the-group-name_1"
+  >
+    <span
+      class="TDS_Box-modules__betweenRightMargin-3___1dOvx TDS_Box-modules__inline___jTHcz alignFlexStart"
+    >
+      <span
+        class="fakeCheckbox unchecked"
+        data-testid="fake-input"
+      >
+        <input
+          aria-invalid="false"
+          class="hiddenInput"
+          id="the-group-name_1"
+          name="the-group-name"
+          type="checkbox"
+          value="1"
+        />
+      </span>
+      <span
+        class="TDS_Typography-modules__medium___1DC1g TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__mediumFont___2ULml TDS_Typography-modules__color___1Jt_W"
+      >
+        A label
+      </span>
+    </span>
+  </label>
+</div>
+`;
+
 exports[`Checkbox renders 1`] = `
 <div
   class="TDS_Box-modules__betweenBottomMargin-2___31zX_ TDS_Box-modules__stack___33m4D"

--- a/packages/Radio/Radio.jsx
+++ b/packages/Radio/Radio.jsx
@@ -35,7 +35,7 @@ Radio.propTypes = {
   /**
    * The value. Must be unique within the group.
    */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired,
   /**
    * The checked state
    */

--- a/packages/Radio/__tests__/Radio.spec.jsx
+++ b/packages/Radio/__tests__/Radio.spec.jsx
@@ -38,6 +38,12 @@ describe('Radio', () => {
     expect(radio).toMatchSnapshot()
   })
 
+  it('allows numbers as value', () => {
+    const radio = render(<Radio label="A label" name="the-group" value={1} />)
+
+    expect(radio).toMatchSnapshot()
+  })
+
   it('must have a label', () => {
     const { label } = doMount({ label: 'Some label' })
 

--- a/packages/Radio/__tests__/__snapshots__/Radio.spec.jsx.snap
+++ b/packages/Radio/__tests__/__snapshots__/Radio.spec.jsx.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Radio allows numbers as value 1`] = `
+<div
+  class="TDS_Box-modules__betweenBottomMargin-2___31zX_ TDS_Box-modules__stack___33m4D"
+>
+  <label
+    for="the-group_1"
+  >
+    <span
+      class="TDS_Box-modules__betweenRightMargin-3___1dOvx TDS_Box-modules__inline___jTHcz alignFlexStart"
+    >
+      <span
+        class="fakeRadio unchecked"
+        data-testid="fake-input"
+      >
+        <input
+          aria-invalid="false"
+          class="hiddenInput"
+          id="the-group_1"
+          name="the-group"
+          type="radio"
+          value="1"
+        />
+      </span>
+      <span
+        class="TDS_Typography-modules__medium___1DC1g TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__mediumFont___2ULml TDS_Typography-modules__color___1Jt_W"
+      >
+        A label
+      </span>
+    </span>
+  </label>
+</div>
+`;
+
 exports[`Radio renders 1`] = `
 <div
   class="TDS_Box-modules__betweenBottomMargin-2___31zX_ TDS_Box-modules__stack___33m4D"

--- a/packages/Tooltip/Tooltip.jsx
+++ b/packages/Tooltip/Tooltip.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import StandaloneIcon from '@tds/core-standalone-icon'
 
 import safeRest from '../../shared/utils/safeRest'
-import generateId from '../../shared/utils/generateId'
+import generateId from '../../shared/utils/generateId/generateId'
 import joinClassNames from '../../shared/utils/joinClassNames'
 import closest from './element-closest'
 

--- a/packages/Tooltip/package.json
+++ b/packages/Tooltip/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@tds/core-colours": "^1.0.0",
     "@tds/core-responsive": "^1.1.0",
+    "@tds/util-generate-id": "^1.0.0-dev",
     "core-js": "^2.5.3"
   }
 }

--- a/shared/components/Choice/Choice.jsx
+++ b/shared/components/Choice/Choice.jsx
@@ -11,7 +11,7 @@ import ColoredTextProvider from '../ColoredTextProvider/ColoredTextProvider'
 
 import safeRest from '../../utils/safeRest'
 import joinClassNames from '../../utils/joinClassNames'
-import generateId from '../../utils/generateId'
+import generateId from '../../utils/generateId/generateId'
 
 import styles from './Choice.modules.scss'
 import messagingStyles from '../../styles/Messaging.modules.scss'

--- a/shared/components/Choice/package.json
+++ b/shared/components/Choice/package.json
@@ -9,5 +9,8 @@
     "@tds/core-input-feedback": "^1.0.2",
     "@tds/core-paragraph": "^1.0.2",
     "@tds/core-text": "^1.0.2"
+  },
+  "devDependencies": {
+    "@tds/util-generate-id": "^1.0.0-dev"
   }
 }

--- a/shared/components/FormField/FormField.jsx
+++ b/shared/components/FormField/FormField.jsx
@@ -8,7 +8,7 @@ import Paragraph from '@tds/core-paragraph'
 import InputFeedback from '@tds/core-input-feedback'
 
 import safeRest from '../../utils/safeRest'
-import generateId from '../../utils/generateId'
+import generateId from '../../utils/generateId/generateId'
 
 import Flexbox from '../Flexbox/Flexbox'
 

--- a/shared/components/FormField/package.json
+++ b/shared/components/FormField/package.json
@@ -9,5 +9,8 @@
     "@tds/core-input-feedback": "^1.0.2",
     "@tds/core-paragraph": "^1.0.2",
     "@tds/core-text": "^1.0.2"
+  },
+  "devDependencies": {
+    "@tds/util-generate-id": "^1.0.0-dev"
   }
 }

--- a/shared/utils/generateId/__tests__/generateId.spec.js
+++ b/shared/utils/generateId/__tests__/generateId.spec.js
@@ -14,6 +14,12 @@ describe('generateId', () => {
       expect(id.identity()).toEqual('allcaps')
     })
 
+    it('handles numbers', () => {
+      const id = generateId(1)
+
+      expect(id.identity()).toEqual('1')
+    })
+
     it('replaces spaces with dashes', () => {
       const id = generateId('an id with spaces')
 

--- a/shared/utils/generateId/generateId.js
+++ b/shared/utils/generateId/generateId.js
@@ -2,6 +2,7 @@ import find from 'core-js/fn/array/find'
 
 const sanitize = text =>
   text
+    .toString()
     .toLowerCase()
     .replace(/ /g, '-')
     .replace(/[^a-zA-Z0-9-]/g, '')

--- a/shared/utils/generateId/package.json
+++ b/shared/utils/generateId/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@tds/util-generate-id",
+  "version": "1.0.0-dev",
+  "private": true,
+  "main": "",
+  "module": ""
+}


### PR DESCRIPTION
<!--
  ### IMPORTANT SECURITY NOTE ###

  When opening pull requests, be sure NOT to include any private or personal
  information such as secrets, passwords, or any source code that involves
  data retrieval. 
-->

## Related issues

See #682 

## Description

Update Radio and Checkbox to allow numbers to be passed as value.

## Package changes

```
Changes:
 - @tds/core-checkbox: 1.0.5 => 1.0.6
 - @tds/core-expand-collapse: 1.1.1 => 1.1.2
 - @tds/core-input: 1.0.8 => 1.0.9
 - @tds/core-radio: 1.0.5 => 1.0.6
 - @tds/core-select: 1.0.9 => 1.0.10
 - @tds/core-text-area: 1.0.8 => 1.0.9
 - @tds/core-tooltip: 2.0.1 => 2.0.2
 - @tds/shared-choice: 1.0.5 => 1.0.6 (private)
 - @tds/shared-form-field: 1.0.6 => 1.0.7 (private)
 - @tds/util-generate-id: 1.0.0-dev => 1.0.0 (private)
```