### PR TITLE
refactor(shared-base-button): remove flexbox

### DIFF
--- a/packages/Button/__tests__/__snapshots__/Button.spec.jsx.snap
+++ b/packages/Button/__tests__/__snapshots__/Button.spec.jsx.snap
@@ -5,13 +5,6 @@ exports[`Button renders 1`] = `
   class="sizing primary"
   type="button"
 >
-  <div
-    class="row centered"
-    data-testid="button"
-  >
-    <span>
-      Submit
-    </span>
-  </div>
+  Submit
 </button>
 `;

--- a/packages/ButtonLink/__tests__/__snapshots__/ButtonLink.spec.jsx.snap
+++ b/packages/ButtonLink/__tests__/__snapshots__/ButtonLink.spec.jsx.snap
@@ -4,13 +4,6 @@ exports[`ButtonLink renders 1`] = `
 <a
   class="sizing primary primary"
 >
-  <div
-    class="row centered"
-    data-testid="button"
-  >
-    <span>
-      Go home
-    </span>
-  </div>
+  Go home
 </a>
 `;

--- a/shared/components/BaseButton/BaseButton.jsx
+++ b/shared/components/BaseButton/BaseButton.jsx
@@ -5,8 +5,6 @@ import { componentWithName, or } from 'airbnb-prop-types'
 import safeRest from '../../utils/safeRest'
 import joinClassNames from '../../utils/joinClassNames'
 
-import FlexBox from '../Flexbox/Flexbox'
-
 import styles from './BaseButton.modules.scss'
 
 /**
@@ -19,9 +17,7 @@ const BaseButton = ({ element, variant, dangerouslyAddClassName, children, ...re
       ...safeRest(rest),
       className: joinClassNames(styles.sizing, styles[variant], dangerouslyAddClassName),
     },
-    <FlexBox direction="row" dangerouslyAddClassName={styles.centered} data-testid="button">
-      <span>{children}</span>
-    </FlexBox>
+    children
   )
 }
 

--- a/shared/components/BaseButton/BaseButton.modules.scss
+++ b/shared/components/BaseButton/BaseButton.modules.scss
@@ -28,11 +28,13 @@ $button-text-color: $color-white;
 .sizing {
   composes: base;
 
-  display: block;
+  display: flex;
   width: 100%;
+  align-items: center;
+  justify-content: center;
 
   @include mq($from: md) {
-    display: inline-block;
+    display: inline-flex;
 
     width: auto;
     min-width: 180px;


### PR DESCRIPTION
<!--
  ### IMPORTANT SECURITY NOTE ###

  When opening pull requests, be sure NOT to include any private or personal
  information such as secrets, passwords, or any source code that involves
  data retrieval. 
-->

## Related issues

See #662 

## Description

Remove the `<FlexBox>` component from `<BaseButton>`, `<BaseButton>` should just render `children`.

## Package changes

```
Changes:
 - @tds/core-button: 1.1.0 => 1.1.1
 - @tds/core-button-link: 1.1.0 => 1.1.1
 - @tds/shared-base-button: 1.2.0 => 1.2.1 (private)
```