### PR TITLE
Fix/divider aria hidden

### DIFF
--- a/packages/DimpleDivider/DimpleDivider.jsx
+++ b/packages/DimpleDivider/DimpleDivider.jsx
@@ -9,6 +9,8 @@ import styles from './DimpleDivider.modules.scss'
  *
  * @version ./package.json
  */
-const DimpleDivider = ({ ...rest }) => <hr {...safeRest(rest)} className={styles.dimple} />
+const DimpleDivider = ({ ...rest }) => (
+  <hr {...safeRest(rest)} className={styles.dimple} aria-hidden="true" />
+)
 
 export default DimpleDivider

--- a/packages/DimpleDivider/__tests__/DimpleDivider.spec.jsx
+++ b/packages/DimpleDivider/__tests__/DimpleDivider.spec.jsx
@@ -31,4 +31,10 @@ describe('DimpleDivider', () => {
     expect(dimpleDivider).not.toHaveProp('className', 'my-custom-class')
     expect(dimpleDivider).not.toHaveProp('style')
   })
+
+  it('is hidden from screen readers', () => {
+    const dimpleDivider = doShallow()
+
+    expect(dimpleDivider).toHaveProp('aria-hidden', 'true')
+  })
 })

--- a/packages/DimpleDivider/__tests__/__snapshots__/DimpleDivider.spec.jsx.snap
+++ b/packages/DimpleDivider/__tests__/__snapshots__/DimpleDivider.spec.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`DimpleDivider renders 1`] = `
 <hr
+  aria-hidden="true"
   class="dimple"
 />
 `;

--- a/packages/ExpandCollapse/Accordion/__tests__/__snapshots__/Accordion.spec.jsx.snap
+++ b/packages/ExpandCollapse/Accordion/__tests__/__snapshots__/Accordion.spec.jsx.snap
@@ -17,6 +17,7 @@ exports[`Accordion renders a closed accordion 1`] = `
         vertical={false}
       >
         <hr
+          aria-hidden="true"
           className="TDS_HairlineDivider-modules__horizontalThin___jAiIF TDS_HairlineDivider-modules__horizontal___14xom TDS_HairlineDivider-modules__reset___e92-M TDS_Spacing-modules__noSpacing___XPYDG TDS_Borders-modules__none___1fCjZ"
         />
       </HairlineDivider>
@@ -202,6 +203,7 @@ exports[`Accordion renders a closed accordion 1`] = `
                   >
                     <DimpleDivider>
                       <hr
+                        aria-hidden="true"
                         className="TDS_DimpleDivider-modules__dimple___1OWjL TDS_Spacing-modules__noSpacing___XPYDG TDS_Borders-modules__none___1fCjZ"
                       />
                     </DimpleDivider>
@@ -245,6 +247,7 @@ exports[`Accordion renders a closed accordion 1`] = `
               vertical={false}
             >
               <hr
+                aria-hidden="true"
                 className="TDS_HairlineDivider-modules__horizontalThin___jAiIF TDS_HairlineDivider-modules__horizontal___14xom TDS_HairlineDivider-modules__reset___e92-M TDS_Spacing-modules__noSpacing___XPYDG TDS_Borders-modules__none___1fCjZ"
               />
             </HairlineDivider>
@@ -276,6 +279,7 @@ exports[`Accordion renders an open accordion 1`] = `
         vertical={false}
       >
         <hr
+          aria-hidden="true"
           className="TDS_HairlineDivider-modules__horizontalThin___jAiIF TDS_HairlineDivider-modules__horizontal___14xom TDS_HairlineDivider-modules__reset___e92-M TDS_Spacing-modules__noSpacing___XPYDG TDS_Borders-modules__none___1fCjZ"
         />
       </HairlineDivider>
@@ -460,6 +464,7 @@ exports[`Accordion renders an open accordion 1`] = `
                   >
                     <DimpleDivider>
                       <hr
+                        aria-hidden="true"
                         className="TDS_DimpleDivider-modules__dimple___1OWjL TDS_Spacing-modules__noSpacing___XPYDG TDS_Borders-modules__none___1fCjZ"
                       />
                     </DimpleDivider>
@@ -503,6 +508,7 @@ exports[`Accordion renders an open accordion 1`] = `
               vertical={false}
             >
               <hr
+                aria-hidden="true"
                 className="TDS_HairlineDivider-modules__horizontalThin___jAiIF TDS_HairlineDivider-modules__horizontal___14xom TDS_HairlineDivider-modules__reset___e92-M TDS_Spacing-modules__noSpacing___XPYDG TDS_Borders-modules__none___1fCjZ"
               />
             </HairlineDivider>

--- a/packages/ExpandCollapse/__tests__/__snapshots__/ExpandCollapse.spec.jsx.snap
+++ b/packages/ExpandCollapse/__tests__/__snapshots__/ExpandCollapse.spec.jsx.snap
@@ -20,6 +20,7 @@ exports[`ExpandCollapse renders a closed panel 1`] = `
         vertical={false}
       >
         <hr
+          aria-hidden="true"
           className="TDS_HairlineDivider-modules__horizontalThin___jAiIF TDS_HairlineDivider-modules__horizontal___14xom TDS_HairlineDivider-modules__reset___e92-M TDS_Spacing-modules__noSpacing___XPYDG TDS_Borders-modules__none___1fCjZ"
         />
       </HairlineDivider>
@@ -205,6 +206,7 @@ exports[`ExpandCollapse renders a closed panel 1`] = `
                   >
                     <DimpleDivider>
                       <hr
+                        aria-hidden="true"
                         className="TDS_DimpleDivider-modules__dimple___1OWjL TDS_Spacing-modules__noSpacing___XPYDG TDS_Borders-modules__none___1fCjZ"
                       />
                     </DimpleDivider>
@@ -248,6 +250,7 @@ exports[`ExpandCollapse renders a closed panel 1`] = `
               vertical={false}
             >
               <hr
+                aria-hidden="true"
                 className="TDS_HairlineDivider-modules__horizontalThin___jAiIF TDS_HairlineDivider-modules__horizontal___14xom TDS_HairlineDivider-modules__reset___e92-M TDS_Spacing-modules__noSpacing___XPYDG TDS_Borders-modules__none___1fCjZ"
               />
             </HairlineDivider>
@@ -291,6 +294,7 @@ exports[`ExpandCollapse renders an open panel 1`] = `
         vertical={false}
       >
         <hr
+          aria-hidden="true"
           className="TDS_HairlineDivider-modules__horizontalThin___jAiIF TDS_HairlineDivider-modules__horizontal___14xom TDS_HairlineDivider-modules__reset___e92-M TDS_Spacing-modules__noSpacing___XPYDG TDS_Borders-modules__none___1fCjZ"
         />
       </HairlineDivider>
@@ -475,6 +479,7 @@ exports[`ExpandCollapse renders an open panel 1`] = `
                   >
                     <DimpleDivider>
                       <hr
+                        aria-hidden="true"
                         className="TDS_DimpleDivider-modules__dimple___1OWjL TDS_Spacing-modules__noSpacing___XPYDG TDS_Borders-modules__none___1fCjZ"
                       />
                     </DimpleDivider>
@@ -518,6 +523,7 @@ exports[`ExpandCollapse renders an open panel 1`] = `
               vertical={false}
             >
               <hr
+                aria-hidden="true"
                 className="TDS_HairlineDivider-modules__horizontalThin___jAiIF TDS_HairlineDivider-modules__horizontal___14xom TDS_HairlineDivider-modules__reset___e92-M TDS_Spacing-modules__noSpacing___XPYDG TDS_Borders-modules__none___1fCjZ"
               />
             </HairlineDivider>

--- a/packages/HairlineDivider/HairlineDivider.jsx
+++ b/packages/HairlineDivider/HairlineDivider.jsx
@@ -27,7 +27,7 @@ const getClassName = (vertical, gradient) => {
  * @version ./package.json
  */
 const HairlineDivider = ({ vertical, gradient, ...rest }) => (
-  <hr {...safeRest(rest)} className={styles[getClassName(vertical, gradient)]} />
+  <hr {...safeRest(rest)} className={styles[getClassName(vertical, gradient)]} aria-hidden="true" />
 )
 
 HairlineDivider.propTypes = {

--- a/packages/HairlineDivider/__tests__/HairlineDivider.spec.jsx
+++ b/packages/HairlineDivider/__tests__/HairlineDivider.spec.jsx
@@ -47,4 +47,10 @@ describe('HairlineDivider', () => {
     expect(hairlineDivider).not.toHaveProp('className', 'my-custom-class')
     expect(hairlineDivider).not.toHaveProp('style')
   })
+
+  it('is hidden from screen readers', () => {
+    const hairlineDivider = doShallow()
+
+    expect(hairlineDivider).toHaveProp('aria-hidden', 'true')
+  })
 })

--- a/packages/HairlineDivider/__tests__/__snapshots__/HairlineDivider.spec.jsx.snap
+++ b/packages/HairlineDivider/__tests__/__snapshots__/HairlineDivider.spec.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`HairlineDivider renders 1`] = `
 <hr
+  aria-hidden="true"
   class="horizontalThin"
 />
 `;

--- a/packages/WaveDivider/WaveDivider.jsx
+++ b/packages/WaveDivider/WaveDivider.jsx
@@ -17,6 +17,7 @@ const WaveDivider = ({ ...rest }) => (
     width="1202"
     height="226"
     viewBox="0 0 1202 226"
+    aria-hidden="true"
   >
     <defs>
       <linearGradient

--- a/packages/WaveDivider/__tests__/WaveDivider.spec.jsx
+++ b/packages/WaveDivider/__tests__/WaveDivider.spec.jsx
@@ -31,4 +31,10 @@ describe('WaveDivider', () => {
     expect(waveDivider).not.toHaveProp('className', 'my-custom-class')
     expect(waveDivider).not.toHaveProp('style')
   })
+
+  it('is hidden from screen readers', () => {
+    const waveDivider = doShallow()
+
+    expect(waveDivider).toHaveProp('aria-hidden', 'true')
+  })
 })

--- a/packages/WaveDivider/__tests__/__snapshots__/WaveDivider.spec.jsx.snap
+++ b/packages/WaveDivider/__tests__/__snapshots__/WaveDivider.spec.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`WaveDivider renders 1`] = `
 <svg
+  aria-hidden="true"
   class="wave"
   height="226"
   viewBox="0 0 1202 226"


### PR DESCRIPTION
<!--
  ### IMPORTANT SECURITY NOTE ###

  When opening pull requests, be sure NOT to include any private or personal
  information such as secrets, passwords, or any source code that involves
  data retrieval. 
-->

## Related issues

See #689 

## Description

Add `aria-hidden` to divider components

## Package changes

```
Changes:
 - @tds/core-dimple-divider: 1.0.0 => 1.0.1 (PATCH)
 - @tds/core-expand-collapse: 1.1.1 => 1.1.2 (PATCH)
 - @tds/core-hairline-divider: 1.0.0 => 1.0.1 (PATCH)
 - @tds/core-wave-divider: 1.0.0 => 1.0.1 (PATCH)
```

This should be rebased