### PR TITLE
fix(core-paragraph): prevent overflow on ie11

### DIFF
--- a/packages/Notification/__tests__/__snapshots__/Notification.spec.jsx.snap
+++ b/packages/Notification/__tests__/__snapshots__/Notification.spec.jsx.snap
@@ -17,7 +17,7 @@ exports[`<Notification /> renders 1`] = `
           class="TDS_Box-modules__betweenRightMargin-3___1dOvx TDS_Box-modules__inline___jTHcz"
         >
           <p
-            class="TDS_Typography-modules__wordBreak___3dmWU TDS_Spacing-modules__noSpacing___XPYDG TDS_Typography-modules__color___1Jt_W TDS_Typography-modules__medium___1DC1g TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__mediumFont___2ULml TDS_Paragraph-modules__leftAlign___KgwhE"
+            class="TDS_Paragraph-modules__base___3d3x0 TDS_Typography-modules__wordBreak___3dmWU TDS_Spacing-modules__noSpacing___XPYDG TDS_Typography-modules__color___1Jt_W TDS_Typography-modules__medium___1DC1g TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__mediumFont___2ULml TDS_Paragraph-modules__leftAlign___KgwhE"
           >
             Some content
           </p>

--- a/packages/Paragraph/Paragraph.jsx
+++ b/packages/Paragraph/Paragraph.jsx
@@ -17,6 +17,7 @@ const Paragraph = ({ bold, size, align, invert, children, ...rest }, context) =>
   const paragraphColor = invert ? typographyStyles.invertedColor : typographyStyles.color
 
   const classes = joinClassNames(
+    styles.base,
     typographyStyles.wordBreak,
     spacingStyles.noSpacing,
     context.inheritColor ? typographyStyles.inheritColor : paragraphColor,

--- a/packages/Paragraph/Paragraph.modules.scss
+++ b/packages/Paragraph/Paragraph.modules.scss
@@ -1,3 +1,7 @@
+.base {
+  width: 100%;
+}
+
 .leftAlign {
   text-align: left;
 }

--- a/packages/Paragraph/__tests__/__snapshots__/Paragraph.spec.jsx.snap
+++ b/packages/Paragraph/__tests__/__snapshots__/Paragraph.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Paragraph renders 1`] = `
 <p
-  className="wordBreak noSpacing color medium mediumFont leftAlign"
+  className="base wordBreak noSpacing color medium mediumFont leftAlign"
 >
   Some content
 </p>


### PR DESCRIPTION
## Related issues

See #643 

## Description

Prevent text from overflowing its parents in IE11.

## Package changes

```
Changes:
 - @tds/core-checkbox: 1.1.0 => 1.1.1 (PATCH)
 - @tds/core-input: 1.0.10 => 1.0.11 (PATCH)
 - @tds/core-notification: 1.1.7 => 1.1.8 (PATCH)
 - @tds/core-paragraph: 1.0.2 => 1.0.3 (PATCH)
 - @tds/core-radio: 1.1.0 => 1.1.1 (PATCH)
 - @tds/core-select: 1.0.11 => 1.0.12 (PATCH)
 - @tds/core-text-area: 1.0.9 => 1.0.10 (PATCH)
 - @tds/shared-choice: 1.0.6 => 1.0.7 (private) (PATCH)
 - @tds/shared-form-field: 1.0.7 => 1.0.8 (private) (PATCH)
```

## Checklist before submitting pull request

* [x] New code is unit tested
* Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
* [x] For code changes, run `yarn prepr` locally
  * make sure visual and accessibility tests pass
  * paste the lerna version output
