### PR TITLE
fix(core-flex-grid): add specificity to styles

### DIFF
--- a/packages/FlexGrid/FlexGrid.modules.scss
+++ b/packages/FlexGrid/FlexGrid.modules.scss
@@ -15,61 +15,61 @@
   }
 }
 
-.xsReverse {
+div.xsReverse {
   @include mq($until: sm) {
     flex-direction: column-reverse;
   }
 }
 
-.smReverse {
+div.smReverse {
   @include mq($from: sm) {
     flex-direction: column-reverse;
   }
 }
 
-.mdReverse {
+div.mdReverse {
   @include mq($from: md) {
     flex-direction: column-reverse;
   }
 }
 
-.lgReverse {
+div.lgReverse {
   @include mq($from: lg) {
     flex-direction: column-reverse;
   }
 }
 
-.xlReverse {
+div.xlReverse {
   @include mq($from: xl) {
     flex-direction: column-reverse;
   }
 }
 
-.xsReverseCancel {
+div.xsReverseCancel {
   @include mq($until: sm) {
     flex-direction: column;
   }
 }
 
-.smReverseCancel {
+div.smReverseCancel {
   @include mq($from: sm, $until: md) {
     flex-direction: column;
   }
 }
 
-.mdReverseCancel {
+div.mdReverseCancel {
   @include mq($from: md, $until: lg) {
     flex-direction: column;
   }
 }
 
-.lgReverseCancel {
+div.lgReverseCancel {
   @include mq($from: lg, $until: xl) {
     flex-direction: column;
   }
 }
 
-.xlReverseCancel {
+div.xlReverseCancel {
   @include mq($from: xl) {
     flex-direction: column;
   }

--- a/packages/FlexGrid/Row/Row.modules.scss
+++ b/packages/FlexGrid/Row/Row.modules.scss
@@ -5,61 +5,61 @@ div.flexRow {
   width: 100%;
 }
 
-.xsReverse {
+div.xsReverse {
   @include mq($until: sm) {
     flex-direction: row-reverse;
   }
 }
 
-.smReverse {
+div.smReverse {
   @include mq($from: sm) {
     flex-direction: row-reverse;
   }
 }
 
-.mdReverse {
+div.mdReverse {
   @include mq($from: md) {
     flex-direction: row-reverse;
   }
 }
 
-.lgReverse {
+div.lgReverse {
   @include mq($from: lg) {
     flex-direction: row-reverse;
   }
 }
 
-.xlReverse {
+div.xlReverse {
   @include mq($from: xl) {
     flex-direction: row-reverse;
   }
 }
 
-.xsReverseCancel {
+div.xsReverseCancel {
   @include mq($until: sm) {
     flex-direction: row;
   }
 }
 
-.smReverseCancel {
+div.smReverseCancel {
   @include mq($from: sm, $until: md) {
     flex-direction: row;
   }
 }
 
-.mdReverseCancel {
+div.mdReverseCancel {
   @include mq($from: md, $until: lg) {
     flex-direction: row;
   }
 }
 
-.lgReverseCancel {
+div.lgReverseCancel {
   @include mq($from: lg, $until: xl) {
     flex-direction: row;
   }
 }
 
-.xlReverseCancel {
+div.xlReverseCancel {
   @include mq($from: xl) {
     flex-direction: row;
   }


### PR DESCRIPTION
<!--
  ### IMPORTANT SECURITY NOTE ###

  When opening pull requests, be sure NOT to include any private or personal
  information such as secrets, passwords, or any source code that involves
  data retrieval. 
-->

## Description

Load order of css can be incorrect in cases overwriting the reverse classes and preventing users from being able to reverse grid elements.

## Package changes

```
Changes:
 - @tds/core-checkbox: 1.1.0 => 1.1.1
 - @tds/core-flex-grid: 2.1.0 => 2.1.1
 - @tds/core-input: 1.0.10 => 1.0.11
 - @tds/core-notification: 1.1.7 => 1.1.8
 - @tds/core-paragraph: 1.0.2 => 1.0.3
 - @tds/core-radio: 1.1.0 => 1.1.1
 - @tds/core-select: 1.0.11 => 1.0.12
 - @tds/core-text-area: 1.0.9 => 1.0.10
 - @tds/shared-choice: 1.0.6 => 1.0.7 (private)
 - @tds/shared-form-field: 1.0.7 => 1.0.8 (private)
```

## Checklist before submitting pull request

* [ ] New code is unit tested
* Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
* [ ] For code changes, run `yarn prepr` locally
  * make sure visual and accessibility tests pass
  * paste the lerna version output
