### PR TITLE
Update Link.md

### DIFF
--- a/packages/Link/Link.md
+++ b/packages/Link/Link.md
@@ -34,6 +34,9 @@ import { Link as ReactRouterLink } from 'react-router'
 
 import { Link as TdsLink } from '@telusdigital/tds'
 
+// If you're importing from @tds instead of telusdigital
+// import TdsLink from '@tds/core-link';
+
 const LinkWrapper = ({ children, ...rest }) => (
   <TdsLink
     {...rest}


### PR DESCRIPTION
I added in a comment the way you should import the TdsLink component considering that when you are using '@tds/core-link' instead of '@telusdigital/tds' there is an error that is not very understandable for most of the new team members that are not familiar with the differences between [default](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#Importing_defaults) and [named](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#Import_a_single_export_from_a_module) imports.

> Uncaught Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.

