### PR TITLE
fix(core-expand-collapse): fix header overflow on tertiary text for IE11

### DIFF
--- a/packages/ExpandCollapse/Accordion/__tests__/__snapshots__/Accordion.spec.jsx.snap
+++ b/packages/ExpandCollapse/Accordion/__tests__/__snapshots__/Accordion.spec.jsx.snap
@@ -141,18 +141,22 @@ exports[`Accordion renders a closed accordion 1`] = `
                               <div
                                 className="column headerAlign"
                               >
-                                <Text
-                                  block={false}
-                                  bold={false}
-                                  invert={false}
-                                  size="large"
+                                <div
+                                  className="fullWidth"
                                 >
-                                  <span
-                                    className="TDS_Typography-modules__large___3Z5sJ TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__largeFont___3fZLf TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__color___1Jt_W"
+                                  <Text
+                                    block={false}
+                                    bold={false}
+                                    invert={false}
+                                    size="large"
                                   >
-                                    Panel title
-                                  </span>
-                                </Text>
+                                    <span
+                                      className="TDS_Typography-modules__large___3Z5sJ TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__largeFont___3fZLf TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__color___1Jt_W"
+                                    >
+                                      Panel title
+                                    </span>
+                                  </Text>
+                                </div>
                               </div>
                             </Flexbox>
                           </div>
@@ -400,18 +404,22 @@ exports[`Accordion renders an open accordion 1`] = `
                               <div
                                 className="column headerAlign"
                               >
-                                <Text
-                                  block={false}
-                                  bold={false}
-                                  invert={false}
-                                  size="large"
+                                <div
+                                  className="fullWidth"
                                 >
-                                  <span
-                                    className="TDS_Typography-modules__large___3Z5sJ TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__largeFont___3fZLf TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__color___1Jt_W"
+                                  <Text
+                                    block={false}
+                                    bold={false}
+                                    invert={false}
+                                    size="large"
                                   >
-                                    Panel title
-                                  </span>
-                                </Text>
+                                    <span
+                                      className="TDS_Typography-modules__large___3Z5sJ TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__largeFont___3fZLf TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__color___1Jt_W"
+                                    >
+                                      Panel title
+                                    </span>
+                                  </Text>
+                                </div>
                               </div>
                             </Flexbox>
                           </div>

--- a/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
+++ b/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
@@ -87,8 +87,12 @@ class PanelWrapper extends React.Component {
         <Flexbox direction="column" dangerouslyAddClassName={styles.headerAlign}>
           <div className={styles.fullWidth}>
             <Text size="large">{header}</Text>
-            {subtext && <Text size="small">{subtext}</Text>}
           </div>
+          {subtext && (
+            <div className={styles.fullWidth}>
+              <Text size="small">{subtext}</Text>
+            </div>
+          )}
         </Flexbox>
 
         {tertiaryText && (

--- a/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
+++ b/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
@@ -85,9 +85,10 @@ class PanelWrapper extends React.Component {
     return (
       <Flexbox direction="row" dangerouslyAddClassName={styles.headerAlign}>
         <Flexbox direction="column" dangerouslyAddClassName={styles.headerAlign}>
-          <Text size="large">{header}</Text>
-
-          {subtext && <Text size="small">{subtext}</Text>}
+          <div className={styles.fullWidth}>
+            <Text size="large">{header}</Text>
+            {subtext && <Text size="small">{subtext}</Text>}
+          </div>
         </Flexbox>
 
         {tertiaryText && (

--- a/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
+++ b/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
@@ -89,7 +89,7 @@ class PanelWrapper extends React.Component {
             <Text size="large">{header}</Text>
           </div>
           {subtext && (
-            <div className={styles.fullWidth}>
+            <div className={styles.subtextContainer}>
               <Text size="small">{subtext}</Text>
             </div>
           )}

--- a/packages/ExpandCollapse/PanelWrapper/PanelWrapper.modules.scss
+++ b/packages/ExpandCollapse/PanelWrapper/PanelWrapper.modules.scss
@@ -1,7 +1,13 @@
 @import '~@tds/core-colours/colours';
 @import '~@tds/core-responsive/responsive';
 
-.fullWidth { width: 100%; }
+.fullWidth {
+  width: 100%;
+}
+
+.subtextContainer {
+  line-height: 1px;
+}
 
 .header {
   composes: fullWidth;

--- a/packages/ExpandCollapse/PanelWrapper/PanelWrapper.modules.scss
+++ b/packages/ExpandCollapse/PanelWrapper/PanelWrapper.modules.scss
@@ -1,13 +1,16 @@
 @import '~@tds/core-colours/colours';
 @import '~@tds/core-responsive/responsive';
 
+.fullWidth { width: 100%; }
+
 .header {
-  width: 100%;
+  composes: fullWidth;
   text-align: left;
 }
 
 .headerAlign {
-  flex: 1;
+  flex: 1 1 auto;
+  composes: fullWidth;
   align-items: flex-start;
 }
 

--- a/packages/ExpandCollapse/__tests__/__snapshots__/ExpandCollapse.spec.jsx.snap
+++ b/packages/ExpandCollapse/__tests__/__snapshots__/ExpandCollapse.spec.jsx.snap
@@ -144,18 +144,22 @@ exports[`ExpandCollapse renders a closed panel 1`] = `
                               <div
                                 className="column headerAlign"
                               >
-                                <Text
-                                  block={false}
-                                  bold={false}
-                                  invert={false}
-                                  size="large"
+                                <div
+                                  className="fullWidth"
                                 >
-                                  <span
-                                    className="TDS_Typography-modules__large___3Z5sJ TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__largeFont___3fZLf TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__color___1Jt_W"
+                                  <Text
+                                    block={false}
+                                    bold={false}
+                                    invert={false}
+                                    size="large"
                                   >
-                                    Panel title
-                                  </span>
-                                </Text>
+                                    <span
+                                      className="TDS_Typography-modules__large___3Z5sJ TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__largeFont___3fZLf TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__color___1Jt_W"
+                                    >
+                                      Panel title
+                                    </span>
+                                  </Text>
+                                </div>
                               </div>
                             </Flexbox>
                           </div>
@@ -415,18 +419,22 @@ exports[`ExpandCollapse renders an open panel 1`] = `
                               <div
                                 className="column headerAlign"
                               >
-                                <Text
-                                  block={false}
-                                  bold={false}
-                                  invert={false}
-                                  size="large"
+                                <div
+                                  className="fullWidth"
                                 >
-                                  <span
-                                    className="TDS_Typography-modules__large___3Z5sJ TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__largeFont___3fZLf TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__color___1Jt_W"
+                                  <Text
+                                    block={false}
+                                    bold={false}
+                                    invert={false}
+                                    size="large"
                                   >
-                                    Panel title
-                                  </span>
-                                </Text>
+                                    <span
+                                      className="TDS_Typography-modules__large___3Z5sJ TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__largeFont___3fZLf TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__color___1Jt_W"
+                                    >
+                                      Panel title
+                                    </span>
+                                  </Text>
+                                </div>
                               </div>
                             </Flexbox>
                           </div>


### PR DESCRIPTION
## Related issues

See #655 

## Package changes

```
Changes:
 - @tds/core-expand-collapse: 1.1.1 => 1.1.2
```

## Checklist before submitting pull request

~~* [ ] New code is unit tested~~
* Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
* [x] For code changes, run `yarn prepr` locally
  * make sure visual and accessibility tests pass
  * paste the lerna version output
