### PR TITLE
chore(config): update husky hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "cz:retry": "git-cz --retry",
     "deploy:docs": "node ./scripts/deploy-docs.js",
     "deploy:package": "scripts/publish.sh",
-    "commitmsg": "commitlint -e $GIT_PARAMS",
     "contributors:update": "node scripts/update-contributors.js",
     "dev": "styleguidist server --config config/styleguide.config.js",
     "dev:e2e": "STYLEGUIDIST_ENV=e2e styleguidist server --config config/styleguide.config.js",
@@ -35,10 +34,8 @@
     "lint:scss": "stylelint '{packages,shared}/**/*.scss' --config config/stylelint.config.js",
     "lint:ec": "echint",
     "lint": "lerna clean --yes && npm-run-all --parallel lint:*",
-    "precommit": "lint-staged && yarn test && yarn contributors:update",
     "prepare": "yarn gitbook:install",
     "prepr": "yarn test:e2e && node scripts/prePr.js --conventional-commits --yes",
-    "prepush": "yarn ci:build && npm-run-all --parallel test lint build-docs:*",
     "scaffold": "node scripts/scaffold.js",
     "test:e2e": "node scripts/e2e.js",
     "test:u": "yarn test -u",
@@ -178,5 +175,12 @@
       "**/reports/*.xml",
       "**/**.png"
     ]
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint -e $HUSKY_GIT_PARAMS",
+      "pre-commit": "lint-staged && yarn test && yarn contributors:update",
+      "pre-push": "yarn ci:build && npm-run-all --parallel test lint build-docs:*"
+    }
   }
 }


### PR DESCRIPTION
This updates our git hooks in `package.json` to use the new format required by Husky.

prepr:

```
Changes:
 - @tds/core-notification: 1.1.9 => 1.2.0
```