### PR TITLE
feat(core-expand-collapse): change React propType

### DIFF
--- a/packages/ExpandCollapse/Panel/Panel.jsx
+++ b/packages/ExpandCollapse/Panel/Panel.jsx
@@ -18,15 +18,15 @@ Panel.propTypes = {
   /**
    * The title.
    */
-  header: PropTypes.string.isRequired,
+  header: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   /**
    * Optional subtext.
    */
-  subtext: PropTypes.string,
+  subtext: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   /**
    * Optional tertiary text. Will be displayed on the right side of the panel header.
    */
-  tertiaryText: PropTypes.string,
+  tertiaryText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   /**
    * Whether or not to disable the panel from being opened or closed.
    */

--- a/packages/ExpandCollapse/Panel/Panel.jsx
+++ b/packages/ExpandCollapse/Panel/Panel.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
+import { componentWithName, or } from 'airbnb-prop-types'
 
 /**
  * Expandable content areas for use with the `ExpandCollapse` or `Accordion`
@@ -18,15 +19,15 @@ Panel.propTypes = {
   /**
    * The title.
    */
-  header: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  header: or([PropTypes.string, componentWithName('Text')]).isRequired,
   /**
    * Optional subtext.
    */
-  subtext: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  subtext: or([PropTypes.string, componentWithName('Text')]),
   /**
    * Optional tertiary text. Will be displayed on the right side of the panel header.
    */
-  tertiaryText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  tertiaryText: or([PropTypes.string, componentWithName('Text')]),
   /**
    * Whether or not to disable the panel from being opened or closed.
    */

--- a/packages/ExpandCollapse/Panel/Panel.jsx
+++ b/packages/ExpandCollapse/Panel/Panel.jsx
@@ -2,7 +2,7 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-import { componentWithName, or } from 'airbnb-prop-types'
+import { componentWithName } from '@tds/util-prop-types'
 
 /**
  * Expandable content areas for use with the `ExpandCollapse` or `Accordion`
@@ -19,15 +19,15 @@ Panel.propTypes = {
   /**
    * The title.
    */
-  header: or([PropTypes.string, componentWithName('Text')]).isRequired,
+  header: PropTypes.oneOfType([PropTypes.string, componentWithName('Text')]).isRequired,
   /**
    * Optional subtext.
    */
-  subtext: or([PropTypes.string, componentWithName('Text')]),
+  subtext: PropTypes.oneOfType([PropTypes.string, componentWithName('Text')]),
   /**
    * Optional tertiary text. Will be displayed on the right side of the panel header.
    */
-  tertiaryText: or([PropTypes.string, componentWithName('Text')]),
+  tertiaryText: PropTypes.oneOfType([PropTypes.string, componentWithName('Text')]),
   /**
    * Whether or not to disable the panel from being opened or closed.
    */

--- a/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
+++ b/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { childrenOfType, componentWithName, or } from 'airbnb-prop-types'
+import { childrenOfType } from 'airbnb-prop-types'
+import { componentWithName } from '@tds/util-prop-types'
 
 import Box from '@tds/core-box'
 import DecorativeIcon from '@tds/core-decorative-icon'
@@ -184,9 +185,9 @@ class PanelWrapper extends React.Component {
 
 PanelWrapper.propTypes = {
   panelId: PropTypes.string.isRequired,
-  panelHeader: or([PropTypes.string, componentWithName('Text')]).isRequired,
-  panelSubtext: or([PropTypes.string, componentWithName('Text')]),
-  panelTertiaryText: or([PropTypes.string, componentWithName('Text')]),
+  panelHeader: PropTypes.oneOfType([PropTypes.string, componentWithName('Text')]).isRequired,
+  panelSubtext: PropTypes.oneOfType([PropTypes.string, componentWithName('Text')]),
+  panelTertiaryText: PropTypes.oneOfType([PropTypes.string, componentWithName('Text')]),
   panelOnToggle: PropTypes.func,
   panelDisabled: PropTypes.bool,
   open: PropTypes.bool,

--- a/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
+++ b/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { childrenOfType } from 'airbnb-prop-types'
+import { childrenOfType, componentWithName, or } from 'airbnb-prop-types'
 
 import Box from '@tds/core-box'
 import DecorativeIcon from '@tds/core-decorative-icon'
@@ -184,9 +184,9 @@ class PanelWrapper extends React.Component {
 
 PanelWrapper.propTypes = {
   panelId: PropTypes.string.isRequired,
-  panelHeader: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
-  panelSubtext: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  panelTertiaryText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  panelHeader: or([PropTypes.string, componentWithName('Text')]).isRequired,
+  panelSubtext: or([PropTypes.string, componentWithName('Text')]),
+  panelTertiaryText: or([PropTypes.string, componentWithName('Text')]),
   panelOnToggle: PropTypes.func,
   panelDisabled: PropTypes.bool,
   open: PropTypes.bool,

--- a/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
+++ b/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
@@ -184,9 +184,9 @@ class PanelWrapper extends React.Component {
 
 PanelWrapper.propTypes = {
   panelId: PropTypes.string.isRequired,
-  panelHeader: PropTypes.string.isRequired,
-  panelSubtext: PropTypes.string,
-  panelTertiaryText: PropTypes.string,
+  panelHeader: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  panelSubtext: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  panelTertiaryText: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   panelOnToggle: PropTypes.func,
   panelDisabled: PropTypes.bool,
   open: PropTypes.bool,

--- a/packages/ExpandCollapse/package.json
+++ b/packages/ExpandCollapse/package.json
@@ -30,6 +30,7 @@
     "@tds/core-dimple-divider": "^1.0.0",
     "@tds/core-hairline-divider": "^1.0.0",
     "@tds/core-text": "^1.0.2",
+    "@tds/util-prop-types": "^1.0.0",
     "prop-types": "^15.5.10"
   },
   "devDependencies": {


### PR DESCRIPTION
## Related issues

https://github.com/telus/tds-core/issues/762

## Description

change the React PropType to accept a node instead of a string to allow other uses of TDS components

Changes:
 - @tds/core-expand-collapse: 1.1.2 => 1.2.0
 - @tds/core-notification: 1.2.0 => 1.3.0
 - @tds/util-prop-types: 1.0.0 => 1.1.0


## Checklist before submitting pull request

* [x] New code is unit tested
* Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
* [x] For code changes, run `yarn prepr` locally
  * make sure visual and accessibility tests pass
