### PR TITLE
fix(core-chevron-link): ie11 overlfow issue

### DIFF
--- a/packages/ChevronLink/ChevronLink.modules.scss
+++ b/packages/ChevronLink/ChevronLink.modules.scss
@@ -18,6 +18,7 @@
   composes: medium from '../Text/Text.modules.scss';
   display: inline-block;
   text-decoration: none;
+  max-width: 100%;
 
   @include helvetica-neue-roman-55;
 


### PR DESCRIPTION

[ChevronLink] Overflow on IE11 #642

## Related issues

#TDS Issue #642 

## Description

* Setting max-width:100% on ```.link``` on  ChevronLink.modules.scss

* [x] New code is unit tested
* [x] For code changes, run `yarn prepr` locally
