### PR TITLE
docs(github): add warning for posting links to staging

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,7 +3,9 @@
 
   When opening issues, be sure NOT to include any private or personal
   information such as secrets, passwords, or any source code that involves
-  data retrieval. 
+  data retrieval.
+
+  Also, do not include links to sites on staging.
 -->
 
 <!--
@@ -15,28 +17,28 @@
 
 ## Description
 
-* Description of the defect
+- Description of the defect
 
 ## Reproduction Steps
 
-* Click this thing
-* Now click this
-* Observe this happens
+- Click this thing
+- Now click this
+- Observe this happens
 
 ## Reproduction Percentage (if applicable)
 
-* 0/10 times
+- 0/10 times
 
 ## Meta
 
-* TDS version: vX.Y.Z
-* Willing to develop solution: Yes/No
-* Has workaround: Yes/No
-* High impact: Yes/No
+- TDS version: vX.Y.Z
+- Willing to develop solution: Yes/No
+- Has workaround: Yes/No
+- High impact: Yes/No
 
 ## Screenshots
 
-* Include any relevant screenshots
+- Include any relevant screenshots
 
 <!--
   Template for logging FEATURE REQUESTS
@@ -47,20 +49,20 @@
 
 ## Description
 
-* Description of the problem
+- Description of the problem
 
 ## Recommendation
 
-* Description of the proposed solution
+- Description of the proposed solution
 
 ## Designs
 
-* Screenshots
-* Sketch file
+- Screenshots
+- Sketch file
 
 ## Meta
 
-* TDS version: vX.Y.Z
-* Willing to develop solution: Yes/No
-* Has workaround: Yes/No
-* High impact: Yes/No
+- TDS version: vX.Y.Z
+- Willing to develop solution: Yes/No
+- Has workaround: Yes/No
+- High impact: Yes/No

--- a/.github/ISSUE_TEMPLATE/defect_template.md
+++ b/.github/ISSUE_TEMPLATE/defect_template.md
@@ -8,30 +8,32 @@ about: Create a report to help us improve
 
   When opening issues, be sure NOT to include any private or personal
   information such as secrets, passwords, or any source code that involves
-  data retrieval. 
+  data retrieval.
+
+  Also, do not include links to sites on staging.
 -->
 
 ## Description
 
-* Description of the defect
+- Description of the defect
 
 ## Reproduction Steps
 
-* Click this thing
-* Now click this
-* Observe this happens
+- Click this thing
+- Now click this
+- Observe this happens
 
 ## Reproduction Percentage (if applicable)
 
-* 0/10 times
+- 0/10 times
 
 ## Meta
 
-* TDS version: vX.Y.Z
-* Willing to develop solution: Yes/No
-* Has workaround: Yes/No
-* High impact: Yes/No
+- TDS version: vX.Y.Z
+- Willing to develop solution: Yes/No
+- Has workaround: Yes/No
+- High impact: Yes/No
 
 ## Screenshots
 
-* Include any relevant screenshots
+- Include any relevant screenshots

--- a/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_template.md
@@ -8,26 +8,28 @@ about: Suggest an idea for tds-core
 
   When opening issues, be sure NOT to include any private or personal
   information such as secrets, passwords, or any source code that involves
-  data retrieval. 
+  data retrieval.
+
+  Also, do not include links to sites on staging.
 -->
 
 ## Description
 
-* Description of the problem
+- Description of the problem
 
 ## Recommendation
 
-* Description of the proposed solution
+- Description of the proposed solution
 
 ## Designs
 
-* Screenshots
-* Sketch file
+- Screenshots
+- Sketch file
 
 ## Meta
 
-* TDS version: vX.Y.Z
-* Willing to develop solution: Yes/No
-* Has workaround: Yes/No
-* High impact: Yes/No
-* Designer/Developer Pair: Your name, your design/dev pair's name 
+- TDS version: vX.Y.Z
+- Willing to develop solution: Yes/No
+- Has workaround: Yes/No
+- High impact: Yes/No
+- Designer/Developer Pair: Your name, your design/dev pair's name

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,8 @@
   When opening pull requests, be sure NOT to include any private or personal
   information such as secrets, passwords, or any source code that involves
   data retrieval.
+
+  Also, do not include links to sites on staging.
 -->
 
 ## Related issues
@@ -14,15 +16,14 @@ See <!-- put issue number here, or delete this section -->
 
 <!-- 'Description' section is optional -->
 
-* Feature 1
-* Feature 2
-* Patch 1
-* Patch 2
-
+- Feature 1
+- Feature 2
+- Patch 1
+- Patch 2
 
 ## Checklist before submitting pull request
 
-* [ ] New code is unit tested
-* Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
-* [ ] For code changes, run `yarn prepr` locally
-  * make sure visual and accessibility tests pass
+- [ ] New code is unit tested
+- Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
+- [ ] For code changes, run `yarn prepr` locally
+  - make sure visual and accessibility tests pass


### PR DESCRIPTION
<!--
  ### IMPORTANT SECURITY NOTE ###

  When opening pull requests, be sure NOT to include any private or personal
  information such as secrets, passwords, or any source code that involves
  data retrieval.
-->

## Related issues

None

## Description

Add warnings regarding posting links to staging.

After merging, replicate these changes in tds-community.

## Checklist before submitting pull request

* [x] New code is unit tested
* Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
* [x] For code changes, run `yarn prepr` locally
  * make sure visual and accessibility tests pass
