### PR TITLE
chore(config): run lerna clean before linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint:js": "eslint packages shared config docs scripts/*.js --ext '.js,.jsx' --config config/eslint.config.js --max-warnings 0 --fix",
     "lint:scss": "stylelint '{packages,shared}/**/*.scss' --config config/stylelint.config.js",
     "lint:ec": "echint",
-    "lint": "npm-run-all --parallel lint:*",
+    "lint": "lerna clean --yes && npm-run-all --parallel lint:*",
     "precommit": "lint-staged && yarn test && yarn contributors:update",
     "prepare": "yarn gitbook:install",
     "prepr": "yarn test:e2e && node scripts/prePr.js --conventional-commits --yes",


### PR DESCRIPTION
<!--
  ### IMPORTANT SECURITY NOTE ###

  When opening pull requests, be sure NOT to include any private or personal
  information such as secrets, passwords, or any source code that involves
  data retrieval.

  Also, do not include links to sites on staging.
-->

## Related issues

None

## Description

Run lerna clean before linting, that way errors related to scanning `node_modules` go away. Yay or nay?

This is related to an issue where dependency version mismatching can cause `node_modules` folders to appear in package directories, causing eslint errors to appear. `lerna clean` deletes all unnecessary `node_modules` directories, allowing linters to run purely on our code. This appear more frequently in tds-community.

If approved, please replicate in tds-community.

## Checklist before submitting pull request

- [x] New code is unit tested
- Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [x] For code changes, run `yarn prepr` locally
  - make sure visual and accessibility tests pass
