### PR TITLE
Change tests from toHaveTagName to toHaveDisplayName

### DIFF
--- a/packages/Box/__tests__/Box.spec.jsx
+++ b/packages/Box/__tests__/Box.spec.jsx
@@ -22,7 +22,7 @@ describe('Box', () => {
   it('can render as a specified HTML element', () => {
     const box = doShallow({ tag: 'ul' })
 
-    expect(box).toHaveTagName('ul')
+    expect(box).toHaveDisplayName('ul')
   })
 
   it('can apply bottom margin', () => {

--- a/packages/ButtonLink/__tests__/ButtonLink.spec.jsx
+++ b/packages/ButtonLink/__tests__/ButtonLink.spec.jsx
@@ -34,7 +34,7 @@ describe('ButtonLink', () => {
   it('is an anchor HTML element when using the href attribute', () => {
     const link = doMount({ href: 'http://telus.com' })
 
-    expect(link).toHaveTagName('a')
+    expect(link).toHaveDisplayName('a')
     expect(link).toHaveProp('href', 'http://telus.com')
   })
 

--- a/packages/ChevronLink/__tests__/ChevronLink.spec.jsx
+++ b/packages/ChevronLink/__tests__/ChevronLink.spec.jsx
@@ -26,7 +26,7 @@ describe('ChevronLink', () => {
   it('is an anchor HTML element when using the href attribute', () => {
     const link = doShallow({ href: 'http://telus.com' })
 
-    expect(link).toHaveTagName('a')
+    expect(link).toHaveDisplayName('a')
     expect(link).toHaveProp('href', 'http://telus.com')
   })
 

--- a/packages/DimpleDivider/__tests__/DimpleDivider.spec.jsx
+++ b/packages/DimpleDivider/__tests__/DimpleDivider.spec.jsx
@@ -15,7 +15,7 @@ describe('DimpleDivider', () => {
   it('is an HTML <hr> element', () => {
     const dimpleDivider = doShallow()
 
-    expect(dimpleDivider).toHaveTagName('hr')
+    expect(dimpleDivider).toHaveDisplayName('hr')
   })
 
   it('passes additional attributes to the element', () => {

--- a/packages/DisplayHeading/DisplayHeadingSup/__tests__/HeadingSup.spec.jsx
+++ b/packages/DisplayHeading/DisplayHeadingSup/__tests__/HeadingSup.spec.jsx
@@ -15,7 +15,7 @@ describe('DisplayHeadingSup', () => {
   it('renders an HTML sub tag', () => {
     const displayHeadingSup = doShallow()
 
-    expect(displayHeadingSup).toHaveTagName('sup')
+    expect(displayHeadingSup).toHaveDisplayName('sup')
   })
 
   it('passes additional attributes to the sup element', () => {

--- a/packages/DisplayHeading/__tests__/DisplayHeading.spec.jsx
+++ b/packages/DisplayHeading/__tests__/DisplayHeading.spec.jsx
@@ -19,7 +19,7 @@ describe('DisplayHeading', () => {
   it('renders an h1', () => {
     const displayHeading = doShallow()
 
-    expect(displayHeading).toHaveTagName('h1')
+    expect(displayHeading).toHaveDisplayName('h1')
   })
 
   it('can be inverted', () => {

--- a/packages/ExpandCollapse/__tests__/ExpandCollapse.spec.jsx
+++ b/packages/ExpandCollapse/__tests__/ExpandCollapse.spec.jsx
@@ -285,7 +285,7 @@ describe('ExpandCollapse', () => {
       const { expandCollapse } = doMount(
         <ExpandCollapse tag="h3">{aPanel({ id: 'panel-1' })}</ExpandCollapse>
       )
-      expect(expandCollapse.find(`[data-testid="headerWrapper"]`).children()).toHaveTagName(
+      expect(expandCollapse.find(`[data-testid="headerWrapper"]`).children()).toHaveDisplayName(
         'Clickable'
       )
     })

--- a/packages/HairlineDivider/__tests__/HairlineDivider.spec.jsx
+++ b/packages/HairlineDivider/__tests__/HairlineDivider.spec.jsx
@@ -15,7 +15,7 @@ describe('HairlineDivider', () => {
   it('is an HTMl hr element', () => {
     const hairlineDivider = doShallow()
 
-    expect(hairlineDivider).toHaveTagName('hr')
+    expect(hairlineDivider).toHaveDisplayName('hr')
   })
 
   it('can be horizontal or vertical', () => {

--- a/packages/Heading/HeadingSup/__tests__/HeadingSup.spec.jsx
+++ b/packages/Heading/HeadingSup/__tests__/HeadingSup.spec.jsx
@@ -15,7 +15,7 @@ describe('HeadingSup', () => {
   it('renders an HTML sub tag', () => {
     const headingSup = doShallow()
 
-    expect(headingSup).toHaveTagName('sup')
+    expect(headingSup).toHaveDisplayName('sup')
   })
 
   it('passes additional attributes to the sup element', () => {

--- a/packages/Heading/__tests__/Heading.spec.jsx
+++ b/packages/Heading/__tests__/Heading.spec.jsx
@@ -32,20 +32,20 @@ describe('Heading', () => {
   it('renders a heading in the specified level', () => {
     const heading = doMount({ level: 'h3' })
 
-    expect(heading).toHaveTagName('h3')
+    expect(heading).toHaveDisplayName('h3')
   })
 
   it('renders a heading in the specified level and specified tag, when level and tag are different', () => {
     const heading = doMount({ level: 'h4', tag: 'h3' })
 
     expect(heading).toHaveClassName('h4')
-    expect(heading).toHaveTagName('h3')
+    expect(heading).toHaveDisplayName('h3')
   })
 
   it('renders a heading in the same tag as level if tag is not specified', () => {
     const heading = doMount({ level: 'h4' })
 
-    expect(heading).toHaveTagName('h4')
+    expect(heading).toHaveDisplayName('h4')
   })
 
   describe('colour', () => {

--- a/packages/Link/__tests__/Link.spec.jsx
+++ b/packages/Link/__tests__/Link.spec.jsx
@@ -23,7 +23,7 @@ describe('Link', () => {
   it('is an anchor HTML element when using the href attribute', () => {
     const link = doShallow({ href: 'http://telus.com' })
 
-    expect(link).toHaveTagName('a')
+    expect(link).toHaveDisplayName('a')
     expect(link).toHaveProp('href', 'http://telus.com')
   })
 

--- a/packages/Paragraph/__tests__/Paragraph.spec.jsx
+++ b/packages/Paragraph/__tests__/Paragraph.spec.jsx
@@ -15,7 +15,7 @@ describe('Paragraph', () => {
   it('renders an HTML p tag', () => {
     const paragraph = doShallow()
 
-    expect(paragraph).toHaveTagName('p')
+    expect(paragraph).toHaveDisplayName('p')
   })
 
   it('can be bold', () => {

--- a/packages/Small/__tests__/Small.spec.jsx
+++ b/packages/Small/__tests__/Small.spec.jsx
@@ -15,7 +15,7 @@ describe('Small', () => {
   it('renders an HTML small tag', () => {
     const small = doShallow()
 
-    expect(small).toHaveTagName('small')
+    expect(small).toHaveDisplayName('small')
   })
 
   it('passes additional attributes to the small element', () => {

--- a/packages/StandaloneIcon/__tests__/StandaloneIcon.spec.jsx
+++ b/packages/StandaloneIcon/__tests__/StandaloneIcon.spec.jsx
@@ -72,7 +72,7 @@ describe('StandaloneIcon', () => {
     it('renders an HTML button tag', () => {
       const { interactiveIcon } = doShallow({ onClick: jest.fn() })
 
-      expect(interactiveIcon.dive()).toHaveTagName('button')
+      expect(interactiveIcon.dive()).toHaveDisplayName('button')
     })
 
     it('triggers the click handler', () => {

--- a/packages/Strong/__tests__/Strong.spec.jsx
+++ b/packages/Strong/__tests__/Strong.spec.jsx
@@ -15,7 +15,7 @@ describe('Strong', () => {
   it('renders an HTML strong tag', () => {
     const strong = doShallow()
 
-    expect(strong).toHaveTagName('strong')
+    expect(strong).toHaveDisplayName('strong')
   })
 
   it('passes additional attributes to the strong element', () => {

--- a/packages/Text/TextSup/__tests__/TextSup.spec.jsx
+++ b/packages/Text/TextSup/__tests__/TextSup.spec.jsx
@@ -15,7 +15,7 @@ describe('TextSup', () => {
   it('renders an HTML sub tag', () => {
     const textSup = doShallow()
 
-    expect(textSup).toHaveTagName('sup')
+    expect(textSup).toHaveDisplayName('sup')
   })
 
   it('passes additional attributes to the sub element', () => {

--- a/packages/Text/__tests__/Text.spec.jsx
+++ b/packages/Text/__tests__/Text.spec.jsx
@@ -14,10 +14,10 @@ describe('Text', () => {
 
   it('renders an HTML span or div tag', () => {
     let text = doShallow()
-    expect(text).toHaveTagName('span')
+    expect(text).toHaveDisplayName('span')
 
     text = doShallow({ block: true })
-    expect(text).toHaveTagName('div')
+    expect(text).toHaveDisplayName('div')
   })
 
   it('can be bold', () => {

--- a/packages/WaveDivider/__tests__/WaveDivider.spec.jsx
+++ b/packages/WaveDivider/__tests__/WaveDivider.spec.jsx
@@ -15,7 +15,7 @@ describe('WaveDivider', () => {
   it('is an svg', () => {
     const waveDivider = doShallow()
 
-    expect(waveDivider).toHaveTagName('svg')
+    expect(waveDivider).toHaveDisplayName('svg')
   })
 
   it('passes additional attributes to the element', () => {

--- a/shared/components/Icon/__tests__/Icon.spec.jsx
+++ b/shared/components/Icon/__tests__/Icon.spec.jsx
@@ -17,7 +17,7 @@ describe('Icon', () => {
   it('renders an HTML i tag', () => {
     const icon = doShallow()
 
-    expect(icon).toHaveTagName('i')
+    expect(icon).toHaveDisplayName('i')
   })
 
   it('needs a symbol', () => {


### PR DESCRIPTION
This changes all of our Jest tests over from toHaveTagName to toHaveDisplay name, as the former no longer works in newer versions of our testing suite.