### PR TITLE
chore(scripts): disable lerna selective publish

### DIFF
--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -53,4 +53,4 @@ getPackageNames(packageNames => {
       read.close()
     }
   )
-})
+}, true)

--- a/scripts/utils/getPackageNames.js
+++ b/scripts/utils/getPackageNames.js
@@ -3,8 +3,8 @@
 const { exec } = require('child_process')
 const { userPackageNames, tdsOptions, lernaOptions } = require('./parseArgs')
 
-const getPackageNames = callback => {
-  if (userPackageNames.length > 0) {
+const getPackageNames = (callback, forceUpdatedPackages) => {
+  if (!forceUpdatedPackages && userPackageNames.length > 0) {
     callback(userPackageNames)
     return
   }


### PR DESCRIPTION
This disables lerna's selective publishing arguments. This functionality is broken, and is no longer part of our process. The publish docs have been updated in accordance with this.