### PR TITLE
fix(core-tooltip): prevent multiple tooltips from being open on one page

### DIFF
--- a/packages/Checkbox/package.json
+++ b/packages/Checkbox/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "@tds/core-colours": "^1.0.0",
-    "@tds/shared-choice": "^1.1.0",
-    "core-js": "^2.5.3"
+    "@tds/shared-choice": "^1.1.0"
   }
 }

--- a/packages/ExpandCollapse/package.json
+++ b/packages/ExpandCollapse/package.json
@@ -37,7 +37,6 @@
     "@tds/core-responsive": "^1.1.0",
     "@tds/shared-animation": "^1.0.2",
     "airbnb-prop-types": "^2.8.1",
-    "core-js": "^2.5.3",
     "react-transition-group": "^2.2.1"
   }
 }

--- a/packages/Input/package.json
+++ b/packages/Input/package.json
@@ -36,7 +36,6 @@
     "@tds/shared-animation": "^1.0.2",
     "@tds/shared-form-field": "^1.0.8",
     "airbnb-prop-types": "^2.8.1",
-    "core-js": "^2.5.3",
     "react-transition-group": "^2.2.1"
   }
 }

--- a/packages/Tooltip/Tooltip.jsx
+++ b/packages/Tooltip/Tooltip.jsx
@@ -13,23 +13,6 @@ import Bubble from './Bubble'
 import iconWrapperStyles from '../../shared/styles/IconWrapper.modules.scss'
 import styles from './Tooltip.modules.scss'
 
-const getTriggerA11yText = connectedFieldLabel => {
-  if (!connectedFieldLabel) {
-    return 'Reveal additional information.'
-  }
-
-  return `Reveal additional information about ${connectedFieldLabel}.`
-}
-
-const getIds = connectedFieldLabel => {
-  const id = generateId(connectedFieldLabel, 'unknown-field')
-
-  return {
-    bubbleId: id.postfix('tooltip'),
-    triggerId: id.postfix('trigger'),
-  }
-}
-
 /**
  * Provide an explanation or instructions for a form field that most users do not need.
  *
@@ -48,6 +31,7 @@ class Tooltip extends React.Component {
 
   componentDidMount() {
     this.updatePageWidth()
+    this.uniqueId = btoa(Math.random())
   }
 
   componentDidUpdate() {
@@ -68,6 +52,23 @@ class Tooltip extends React.Component {
     window.removeEventListener('resize', this.updatePageWidth)
   }
 
+  getTriggerA11yText = connectedFieldLabel => {
+    if (!connectedFieldLabel) {
+      return 'Reveal additional information.'
+    }
+
+    return `Reveal additional information about ${connectedFieldLabel}.`
+  }
+
+  getIds = connectedFieldLabel => {
+    const id = generateId(connectedFieldLabel, `standalone-tooltip ${this.uniqueId}`)
+
+    return {
+      bubbleId: id.postfix('tooltip'),
+      triggerId: id.postfix('trigger'),
+    }
+  }
+
   setTooltipRef = element => {
     this.refTooltip = element
   }
@@ -75,11 +76,10 @@ class Tooltip extends React.Component {
   toggleBubbleOnOutsideEvent = event => {
     const { connectedFieldLabel } = this.props
 
-    const { bubbleId, triggerId } = getIds(connectedFieldLabel)
+    const { bubbleId, triggerId } = this.getIds(connectedFieldLabel)
 
     const inBubble = closest(event.target, `#${bubbleId}`)
     const inTrigger = closest(event.target, `#${triggerId}`)
-
     if (!inBubble && !inTrigger) {
       this.toggleBubble()
     }
@@ -104,7 +104,7 @@ class Tooltip extends React.Component {
   render() {
     const { direction, connectedFieldLabel, children, ...rest } = this.props
 
-    const { bubbleId, triggerId } = getIds(connectedFieldLabel)
+    const { bubbleId, triggerId } = this.getIds(connectedFieldLabel)
 
     const classes = joinClassNames(iconWrapperStyles.fixLineHeight, styles.tooltip)
 
@@ -133,7 +133,7 @@ class Tooltip extends React.Component {
           </Bubble>
           <StandaloneIcon
             symbol="questionMarkCircle"
-            a11yText={getTriggerA11yText(connectedFieldLabel)}
+            a11yText={this.getTriggerA11yText(connectedFieldLabel)}
             onClick={this.toggleBubble}
             id={triggerId}
             aria-controls={bubbleId}

--- a/packages/Tooltip/__tests__/Tooltip.spec.jsx
+++ b/packages/Tooltip/__tests__/Tooltip.spec.jsx
@@ -1,10 +1,14 @@
 import React from 'react'
-import { render, mount } from 'enzyme'
+import { mount } from 'enzyme'
 
 import StandaloneIcon from '@tds/core-standalone-icon'
 import Text from '@tds/core-text'
 
 import Tooltip from '../Tooltip'
+
+const mockMath = Object.create(global.Math)
+mockMath.random = () => 0.5
+global.Math = mockMath
 
 describe('Tooltip', () => {
   const defaultChildren = 'Tooltip text'
@@ -23,7 +27,7 @@ describe('Tooltip', () => {
   }
 
   it('renders', () => {
-    const tooltip = render(<Tooltip>Tooltip text</Tooltip>)
+    const { tooltip } = doMount()
 
     expect(tooltip).toMatchSnapshot()
   })

--- a/packages/Tooltip/__tests__/__snapshots__/Tooltip.spec.jsx.snap
+++ b/packages/Tooltip/__tests__/__snapshots__/Tooltip.spec.jsx.snap
@@ -1,46 +1,123 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tooltip renders 1`] = `
-<div
-  class="fixLineHeight tooltip"
+<Tooltip
+  direction="auto"
 >
   <div
-    class="tooltipContainer"
-    data-testid="tooltipContainer"
+    className="fixLineHeight tooltip"
   >
     <div
-      aria-hidden="true"
-      aria-live="assertive"
-      class="TDS_Box-modules__horizontalPadding-3___2uoUp TDS_Box-modules__verticalPadding-2___1Uh2T right hide"
-      data-testid="bubble"
-      id="unknown-field_tooltip"
-      role="tooltip"
+      className="tooltipContainer"
+      data-testid="tooltipContainer"
     >
-      <div
-        class="innerBubble"
-        style="width:calc(-16px - 1rem - 0.5rem)"
+      <Bubble
+        direction="right"
+        id="standalone-tooltip-mc41_tooltip"
+        open={false}
+        width={
+          Object {
+            "width": "calc(1008px - 1rem - 0.5rem)",
+          }
+        }
       >
-        <span
-          class="TDS_Typography-modules__small___3H68Z TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__smallFont___XkTI5 TDS_Typography-modules__color___1Jt_W"
+        <Box
+          aria-hidden="true"
+          aria-live="assertive"
+          dangerouslyAddClassName="right hide"
+          data-testid="bubble"
+          horizontal={3}
+          id="standalone-tooltip-mc41_tooltip"
+          inline={false}
+          role="tooltip"
+          tag="div"
+          vertical={2}
         >
-          Tooltip text
-        </span>
-      </div>
+          <div
+            aria-hidden="true"
+            aria-live="assertive"
+            className="TDS_Box-modules__horizontalPadding-3___2uoUp TDS_Box-modules__verticalPadding-2___1Uh2T right hide"
+            data-testid="bubble"
+            id="standalone-tooltip-mc41_tooltip"
+            role="tooltip"
+          >
+            <div
+              className="innerBubble"
+              style={
+                Object {
+                  "width": "calc(1008px - 1rem - 0.5rem)",
+                }
+              }
+            >
+              <Text
+                block={false}
+                bold={false}
+                invert={false}
+                size="small"
+              >
+                <span
+                  className="TDS_Typography-modules__small___3H68Z TDS_Typography-modules__wordBreak___3dmWU TDS_Typography-modules__smallFont___XkTI5 TDS_Typography-modules__color___1Jt_W"
+                >
+                  Tooltip text
+                </span>
+              </Text>
+            </div>
+          </div>
+        </Box>
+      </Bubble>
+      <StandaloneIcon
+        a11yText="Reveal additional information."
+        aria-controls="standalone-tooltip-mc41_tooltip"
+        aria-expanded="false"
+        aria-haspopup="true"
+        id="standalone-tooltip-mc41_trigger"
+        onClick={[Function]}
+        size={24}
+        symbol="questionMarkCircle"
+      >
+        <Clickable
+          aria-controls="standalone-tooltip-mc41_tooltip"
+          aria-expanded="false"
+          aria-haspopup="true"
+          dangerouslyAddStyle={
+            Object {
+              "margin": "-4px",
+              "padding": "4px",
+            }
+          }
+          id="standalone-tooltip-mc41_trigger"
+          onClick={[Function]}
+          type="button"
+        >
+          <button
+            aria-controls="standalone-tooltip-mc41_tooltip"
+            aria-expanded="false"
+            aria-haspopup="true"
+            className="TDS_Clickable-modules__clickable___Wf5Qr TDS_Spacing-modules__noSpacing___XPYDG TDS_Borders-modules__none___1fCjZ TDS_Forms-modules__font___g7OGX TDS_Text-modules__color___2f6lE"
+            id="standalone-tooltip-mc41_trigger"
+            onClick={[Function]}
+            style={
+              Object {
+                "margin": "-4px",
+                "padding": "4px",
+              }
+            }
+            type="button"
+          >
+            <Icon
+              aria-label="Reveal additional information."
+              size={24}
+              symbol="questionMarkCircle"
+            >
+              <i
+                aria-label="Reveal additional information."
+                className="TDS_Icon-modules__iconQuestionMarkCircle___2km-5 TDS_Icon-modules__icon___13xYd TDS_Icon-modules__size24___37pQ7"
+              />
+            </Icon>
+          </button>
+        </Clickable>
+      </StandaloneIcon>
     </div>
-    <button
-      aria-controls="unknown-field_tooltip"
-      aria-expanded="false"
-      aria-haspopup="true"
-      class="TDS_Clickable-modules__clickable___Wf5Qr TDS_Spacing-modules__noSpacing___XPYDG TDS_Borders-modules__none___1fCjZ TDS_Forms-modules__font___g7OGX TDS_Text-modules__color___2f6lE"
-      id="unknown-field_trigger"
-      style="padding:4px;margin:-4px"
-      type="button"
-    >
-      <i
-        aria-label="Reveal additional information."
-        class="TDS_Icon-modules__iconQuestionMarkCircle___2km-5 TDS_Icon-modules__icon___13xYd TDS_Icon-modules__size24___37pQ7"
-      />
-    </button>
   </div>
-</div>
+</Tooltip>
 `;

--- a/packages/Tooltip/package.json
+++ b/packages/Tooltip/package.json
@@ -34,7 +34,6 @@
   "devDependencies": {
     "@tds/core-colours": "^1.0.0",
     "@tds/core-responsive": "^1.1.0",
-    "@tds/util-generate-id": "^1.0.0",
-    "core-js": "^2.5.3"
+    "@tds/util-generate-id": "^1.0.0"
   }
 }

--- a/shared/utils/generateId/generateId.js
+++ b/shared/utils/generateId/generateId.js
@@ -1,4 +1,4 @@
-import find from 'core-js/fn/array/find'
+import find from 'array-find-es6'
 
 const sanitize = text =>
   text

--- a/shared/utils/generateId/package.json
+++ b/shared/utils/generateId/package.json
@@ -3,5 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "main": "",
-  "module": ""
+  "module": "",
+  "dependencies": {
+    "array-find-es6": "^2.0.3"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -760,6 +760,11 @@ array-filter@~0.0.0:
   resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
   integrity sha1-fajPLiZijtcygDWB/SH2fKzS7uw=
 
+array-find-es6@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/array-find-es6/-/array-find-es6-2.0.3.tgz#c5b512cd1f0c969d080c65684fe9860d88eb8731"
+  integrity sha512-35QZe7bM24H1Q+tAhFRVp6mUsCD+M1zREs45fjeiVqF2OAgzly76tcCjBISvu4AlR6slKv1oDaYr4KlPmzBKZA==
+
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
@@ -3473,7 +3478,7 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.5.3:
+core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
   integrity sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=


### PR DESCRIPTION
This fixes an issue where multiple tooltips that are not attached to an input could be opened at the same time. Additionally, it removes the `core-js` dependency and replaces it with the simpler `array-find-es6` dependency, which reduces our build size by around 600 lines.