### PR TITLE
fix(core-price-lockup): prevent improper line height

### DIFF
--- a/packages/PriceLockup/PriceLockup.modules.scss
+++ b/packages/PriceLockup/PriceLockup.modules.scss
@@ -62,7 +62,7 @@
   }
 }
 
-.text {
+span.text {
   line-height: 1.2;
   @include mq($from: md) {
     line-height: 1.6;


### PR DESCRIPTION
See #843 

Adds specificity to the `line-height` css classes in PriceLockup to prevent improper placement of the dollar sign.