### PR TITLE
fix(shared-form-field): conditionally render icons

### DIFF
--- a/shared/components/FormField/FeedbackIcon.jsx
+++ b/shared/components/FormField/FeedbackIcon.jsx
@@ -6,27 +6,32 @@ import Fade from '../Animation/Fade'
 
 import iconWrapperStyles from '../../styles/IconWrapper.modules.scss'
 
+const renderIcon = feedback => {
+  if (feedback === 'success') {
+    return (
+      <StandaloneIcon
+        symbol="checkmark"
+        variant="primary"
+        size={16}
+        a11yText="The value of this input field is valid."
+      />
+    )
+  } else if (feedback === 'error') {
+    return (
+      <StandaloneIcon
+        symbol="exclamationPointCircle"
+        variant="error"
+        size={16}
+        a11yText="The value of this input field is invalid."
+      />
+    )
+  }
+  return null
+}
+
 const FeedbackIcon = ({ showIcon, feedback }) => (
   <Fade timeout={100} in={showIcon} mountOnEnter={true} unmountOnExit={true}>
-    {() => (
-      <div className={iconWrapperStyles.fixLineHeight}>
-        {feedback === 'success' ? (
-          <StandaloneIcon
-            symbol="checkmark"
-            variant="primary"
-            size={16}
-            a11yText="The value of this input field is valid."
-          />
-        ) : (
-          <StandaloneIcon
-            symbol="exclamationPointCircle"
-            variant="error"
-            size={16}
-            a11yText="The value of this input field is invalid."
-          />
-        )}
-      </div>
-    )}
+    {() => <div className={iconWrapperStyles.fixLineHeight}>{renderIcon(feedback)}</div>}
   </Fade>
 )
 FeedbackIcon.propTypes = {


### PR DESCRIPTION
## Related issues

See #861 

## Description

Do not default to rendering an error icon if `feedback !== 'success'`

## Checklist before submitting pull request

- [ ] New code is unit tested
- Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [ ] For code changes, run `yarn prepr` locally
  - make sure visual and accessibility tests pass
