### PR TITLE
Improve husky hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,13 +33,14 @@
     "lint:js": "eslint packages shared config docs scripts/*.js --ext '.js,.jsx' --config config/eslint.config.js --max-warnings 0 --fix",
     "lint:scss": "stylelint '{packages,shared}/**/*.scss' --config config/stylelint.config.js",
     "lint:ec": "echint",
-    "lint": "lerna clean --yes && npm-run-all --parallel lint:*",
+    "lint": "npm-run-all --parallel lint:*",
     "prepare": "yarn gitbook:install",
     "prepr": "yarn test:e2e && scripts/prePr.sh",
     "scaffold": "node scripts/scaffold.js",
     "test:e2e": "node scripts/e2e.js",
     "test:u": "yarn test -u",
     "test:watch": "yarn test --watch",
+    "test:quick": "jest -o --config config/jest.config.js",
     "test": "jest --config config/jest.config.js"
   },
   "repository": {
@@ -185,7 +186,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -e $HUSKY_GIT_PARAMS",
-      "pre-commit": "lint-staged && yarn test && yarn contributors:update",
+      "pre-commit": "lint-staged && yarn test:quick && yarn contributors:update",
       "pre-push": "yarn ci:build && npm-run-all --parallel test lint build-docs:*"
     }
   }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "^7.7.0",
-    "file-loader": "^2.0.0",
+    "file-loader": "^3.0.0",
     "gitbook-cli": "^2.3.2",
     "husky": "^1.0.0",
     "identity-obj-proxy": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
   },
   "husky": {
     "hooks": {
-      "commit-msg": "commitlint -e $HUSKY_GIT_PARAMS",
+      "commit-msg": "commitlint -e $HUSKY_GIT_PARAMS && node ./scripts/commit-scope-lint.js -m $HUSKY_GIT_PARAMS",
       "pre-commit": "lint-staged && yarn test:quick && yarn contributors:update",
       "pre-push": "yarn ci:build && npm-run-all --parallel test lint build-docs:*"
     }

--- a/scripts/commit-scope-lint.js
+++ b/scripts/commit-scope-lint.js
@@ -21,7 +21,7 @@ const gitDiff = spawnSync('git', ['diff', '--name-only', '--staged', 'HEAD'], {
 
 console.log('\nValidating commit scope...')
 
-gitDiff.forEach(element => {
+gitDiff.map(element => element.replace('-', '')).forEach(element => {
   if (
     (rootScopes.indexOf(commitScope) === -1 &&
       element.search(new RegExp(`^(.*(/+)|(/?))${commitScope}/`, 'i')) === -1) ||

--- a/scripts/commit-scope-lint.js
+++ b/scripts/commit-scope-lint.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+const { spawnSync } = require('child_process')
+const fs = require('fs')
+
+const rootScopes = ['deps', 'other'] // Scopes where modified files are typically in the repo's root.
+
+const commitMessage = fs.readFileSync(process.argv[3], 'utf8')
+const commitScope = commitMessage
+  .substr(commitMessage.indexOf('('), commitMessage.indexOf(':') - commitMessage.indexOf('('))
+  .replace(/(core)|(community)|(-)|(\()|(\))/g, '')
+
+const gitDiff = spawnSync('git', ['diff', '--name-only', '--staged', 'HEAD'], {
+  stdio: 'pipe',
+  encoding: 'utf-8',
+})
+  .output[1].trim()
+  .split('\n')
+
+console.log('\nValidating commit scope...')
+
+gitDiff.forEach(element => {
+  if (
+    (rootScopes.indexOf(commitScope) === -1 &&
+      element.search(new RegExp(`^(.*(/+)|(/?))${commitScope}/`, 'i')) === -1) ||
+    (rootScopes.indexOf(commitScope) !== -1 && element.search(/(\\)|(\/)/g) !== -1)
+  ) {
+    console.error(
+      '\n',
+      '\x1b[41m\x1b[37m',
+      'COMMIT SCOPE ERROR:',
+      '\x1b[0m',
+      `Files outside the scope '${commitScope}' have been added to this commit. Please create seperate commits for files out of scope.`
+    )
+    process.exit(1)
+  }
+})
+
+console.log(
+  '\n',
+  '\x1b[42m\x1b[30m',
+  'PASS:',
+  '\x1b[0m',
+  `Files staged for commit scope '${commitScope}' are valid.`
+)
+process.exit()

--- a/scripts/commit-scope-lint.js
+++ b/scripts/commit-scope-lint.js
@@ -10,7 +10,7 @@ const rootScopes = ['deps', 'other'] // Scopes where modified files are typicall
 const commitMessage = fs.readFileSync(process.argv[3], 'utf8')
 const commitScope = commitMessage
   .substr(commitMessage.indexOf('('), commitMessage.indexOf(':') - commitMessage.indexOf('('))
-  .replace(/(core)|(community)|(-)|(\()|(\))/g, '')
+  .replace(/(core)|(community)|(shared)|(util)|(-)|(\()|(\))/g, '')
 
 const gitDiff = spawnSync('git', ['diff', '--name-only', '--staged', 'HEAD'], {
   stdio: 'pipe',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6627,10 +6627,10 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
-file-loader@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-2.0.0.tgz#39749c82f020b9e85901dcff98e8004e6401cfde"
-  integrity sha512-YCsBfd1ZGCyonOKLxPiKPdu+8ld9HAaMEvJewzz+b2eTF7uL5Zm/HdBF6FjCrpCMRq25Mi0U1gl4pwn2TlH7hQ==
+file-loader@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-3.0.1.tgz#f8e0ba0b599918b51adfe45d66d1e771ad560faa"
+  integrity sha512-4sNIOXgtH/9WZq4NvlfU3Opn5ynUsqBwSLyM+I7UOwdGigTBYfVVQEwe/msZNX/j4pCJTIM14Fsw66Svo1oVrw==
   dependencies:
     loader-utils "^1.0.2"
     schema-utils "^1.0.0"


### PR DESCRIPTION
This PR makes the process of committing faster by including a new `test:quick` option.  Additionally, it will now lint commits to make sure that the files included in it are using the correct scope.