### PR TITLE
Docker e2e fixes

### DIFF
--- a/config/nightwatch.conf.js
+++ b/config/nightwatch.conf.js
@@ -30,6 +30,7 @@ module.exports = {
     start_process: true,
     server_path: chromedriver.path,
     port: 9515,
+    log_path: false,
   },
   test_settings: {
     default: {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,5 +42,6 @@ services:
       - './config/.:/tds-core/config/'
       - './packages/.:/tds-core/packages/'
       - './shared/.:/tds-core/shared/'
+      - './.git/.:/tds-core/.git/'
       - '${PWD}/lerna.json:/tds-core/lerna.json'
       - '${PWD}/babel.config.js:/tds-core/babel.config.js'

--- a/e2e/globals.js
+++ b/e2e/globals.js
@@ -7,7 +7,7 @@ let counter = 0
 const healthCheck = done => {
   request(healthCheckUrl, (err, response, body) => {
     if (!body && counter < 20) {
-      console.log(`${counter}/20 waiting for the styleguide to start.`)
+      console.log(`${counter}/20 waiting for the styleguide to start. Please wait...`)
       counter += 1
 
       setTimeout(healthCheck, 3000, done)

--- a/scripts/docker-e2e.sh
+++ b/scripts/docker-e2e.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 
 ## Used by package.json to pass arguments into the docker-compose up command.
-
-mode=$1 docker-compose up --abort-on-container-exit e2e
+mode="$@" docker-compose up --abort-on-container-exit e2e

--- a/scripts/utils/parseArgs.js
+++ b/scripts/utils/parseArgs.js
@@ -2,7 +2,7 @@ const parseArgs = require('minimist')
 
 const TDS_OPTIONS = ['-a', '--all', '-u', '--update-screenshots']
 
-const originalArgs = process.argv.slice(2)
+const originalArgs = process.argv.slice(2).filter(arg => arg !== '')
 
 const parsedArgs = parseArgs(originalArgs, { alias: { a: 'all', u: 'update-screenshots' } })
 const lernaOptions = originalArgs

--- a/scripts/utils/parseArgs.js
+++ b/scripts/utils/parseArgs.js
@@ -2,9 +2,16 @@ const parseArgs = require('minimist')
 
 const TDS_OPTIONS = ['-a', '--all', '-u', '--update-screenshots']
 
-const originalArgs = process.argv.slice(2).filter(arg => arg !== '')
+let originalArgs = process.argv.slice(2).filter(arg => arg !== '')
 
-const parsedArgs = parseArgs(originalArgs, { alias: { a: 'all', u: 'update-screenshots' } })
+if (originalArgs[0]) {
+  originalArgs = originalArgs[0].split(' ')
+}
+
+const parsedArgs = parseArgs(originalArgs, {
+  alias: { a: 'all', u: 'update-screenshots' },
+})
+
 const lernaOptions = originalArgs
   .filter(arg => !parsedArgs._.includes(arg))
   .filter(arg => !TDS_OPTIONS.includes(arg))


### PR DESCRIPTION
This fixes some issues with the new e2e implementation.

- The test will now once again test only packages that were updated by default.
- The "cannot write to chromelog" error will no longer appear at the end of tests.
- The e2e startup message has been modified to indicate that no action is required from the user for it to start.