### PR TITLE
style(core-css-reset): mixin to keep the global footer at the bottom of the viewport

### DIFF
--- a/packages/css-reset/CssReset.md
+++ b/packages/css-reset/CssReset.md
@@ -30,3 +30,22 @@ import { fonts } from '@tds/core-css-reset'
 
 // convert fonts array to <link rel="preload"> tags in the page <head>
 ```
+
+### Flex Main for Viewport
+
+This package corrects a TELUS page that has content too short to fill the browser's height, the footer appears directly below the content, leaving white space between the footer and the bottom of the viewport.
+
+```css static
+@import '~@tds/core-css-reset/mixins';
+
+@include flex-main;
+```
+
+### Before
+
+![image](https://user-images.githubusercontent.com/12798751/49828374-b11a2f00-fd59-11e8-9744-f0208fbb6019.png)
+
+### After
+
+![image](https://user-images.githubusercontent.com/12798751/49891033-8ab8ca00-fe13-11e8-80bc-277e78b8ea49.png)
+

--- a/packages/css-reset/_mixins.scss
+++ b/packages/css-reset/_mixins.scss
@@ -1,0 +1,12 @@
+@mixin flex-main {
+  html, body {
+    height: 100%;
+  }
+  body {
+    display: flex;
+    flex-direction: column;
+  }
+  body > main {
+    flex: 1 0 auto;
+  }
+}


### PR DESCRIPTION
## Related issues

See #860

## Description

- Added `flex-main` mixin to align `footer` to bottom of viewport

## Checklist before submitting pull request

- [x] New code is unit tested
- Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [x] For code changes, run `yarn prepr` locally
  - make sure visual and accessibility tests pass
