### PR TITLE
docs(guide): add usability heuristics doc

### DIFF
--- a/guide/SUMMARY.md
+++ b/guide/SUMMARY.md
@@ -30,6 +30,7 @@
 - [Dividers](design/dividers.md)
 - [Motion](design/motion.md)
 - [Depth](design/depth.md)
+- [Usability Heuristics](design/heuristics.md)
 
 ## Support & links
 

--- a/guide/design/heuristics.md
+++ b/guide/design/heuristics.md
@@ -1,0 +1,40 @@
+# TELUS Usability Heuristics
+
+Usability heuristics are a list of design principles against which the usability of an interface can be assessed.
+Heuristic evaluations are never intended to stand alone. They are an element in a larger UX design process, which provide a quick and standardized means to assess the usability of an interface.
+
+## 1. Aesthetic and minimalist design
+
+Every unnecessary element competes with the important ones and diminishes their relative visibility. The TELUS aesthetic is both clear and simple. Less is better.
+
+## 2. Consistency
+
+Customers shouldn’t have to wonder whether different words or design elements mean the same thing. Follow standard conventions – both our internal conventions, and broader web standards.
+
+## 3. Visibility of system status
+
+Provide clear feedback as to what the system is doing and what the customer should do next.
+
+## 4. Recognition rather than recall
+
+Ensure all elements of the design are easy to comprehend and familiar-looking. Never rely on a customer's ability to remember information in order to navigate.
+
+## 5. Match between system and the real world
+
+Speak our customers’ language – with familiar words, phrases and concepts. Avoid technical or insider jargon.
+
+## 6. Efficiency of use
+
+Find ways to do the work for customers. Remember their choices and pre-populate fields where possible.
+
+## 7. Error avoidance and handling
+
+Prevent errors from happening in the first place – through intelligently constraining choice, clear instructions, anticipating customer questions or actions.
+
+Where errors do occur, provide graceful recovery. In plain language, tell customers what went wrong and how to fix it.
+
+## 8. Guiding the user
+
+Ideally, flows should be so simple that instructions aren’t necessary.
+
+For complex interactions, clearly lay out the steps customers need to take. And make sure the instructions are easy to ignore or dismiss by those who don’t need them.

--- a/guide/design/principles.md
+++ b/guide/design/principles.md
@@ -8,7 +8,7 @@ must meet these principles. They are used to assess whether an experience is goo
 - Promote the brand aesthetic
 - Reduce complexity by constraining choices
 - Ensure customers can complete task on first attempt
-- Leverage usability heuristics
+- Leverage [usability heuristics](heuristics.md)
 
 ## Respect our customers
 


### PR DESCRIPTION
On the request of #888, this adds docs to our front-facing page about usability heuristics. It also links to it in the design principles page.