### PR TITLE
fix(core-colours): use module.exports instead of exports

### DIFF
--- a/packages/colours/index.cjs.js
+++ b/packages/colours/index.cjs.js
@@ -1,1 +1,1 @@
-exports = require('./dist/index.cjs')
+module.exports = require('./dist/index.cjs')


### PR DESCRIPTION
## Description

* `index.cjs.js` now actually exports the colours object.

## Checklist before submitting pull request

- [ ] New code is unit tested
- Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [ ] For code changes, run `npm run prepr` locally
  - make sure visual and accessibility tests pass
