### PR TITLE
fix(core-video): improve mobile detection for server-side rendering

### DIFF
--- a/packages/Video/ControlBar/ControlBar.jsx
+++ b/packages/Video/ControlBar/ControlBar.jsx
@@ -192,7 +192,7 @@ ControlBar.propTypes = {
   videoPlayer: PropTypes.object.isRequired,
   videoPlayerContainer: PropTypes.object.isRequired,
   sources: PropTypes.array.isRequired,
-  tracks: PropTypes.array.isRequired,
+  tracks: PropTypes.array,
   videoPlaying: PropTypes.bool.isRequired,
   videoBufferEnd: PropTypes.number.isRequired,
   isHidden: PropTypes.bool,
@@ -223,6 +223,7 @@ ControlBar.propTypes = {
 }
 
 ControlBar.defaultProps = {
+  tracks: undefined,
   isHidden: false,
 }
 

--- a/packages/Video/__tests__/__snapshots__/Video.spec.jsx.snap
+++ b/packages/Video/__tests__/__snapshots__/Video.spec.jsx.snap
@@ -420,6 +420,7 @@ input[type=range].c21::-ms-tooltip {
   outline: none;
   width: 100%;
   height: 100%;
+  font-size: 0;
 }
 
 .c11 {
@@ -1004,6 +1005,7 @@ input[type=range].c21::-ms-tooltip {
   outline: none;
   width: 100%;
   height: 100%;
+  font-size: 0;
 }
 
 .c11 {
@@ -1837,7 +1839,7 @@ input[type=range].c21::-ms-tooltip {
                   "isStatic": true,
                   "lastClassName": "c10",
                   "rules": Array [
-                    "outline: none; width: 100%; height: 100%;",
+                    "outline: none; width: 100%; height: 100%; font-size: 0;",
                   ],
                 },
                 "displayName": "Video__VideoElementContainer",

--- a/packages/WebVideo/WebVideo.md
+++ b/packages/WebVideo/WebVideo.md
@@ -1,6 +1,11 @@
 ### Using a YouTube video
 
-When using a video from YouTube is necessary, you may do so by providing the ID of the video to the `videoId` prop. This will leverage the standard YouTube player, but is compatible with `FlexGrid`. It is required that the time be passed in (in seconds) to the `videoLength` prop. Additionally, you may define the video's default volume and if it is muted from the start. If you happen to be using a YouTube video that is not in 16:9 aspect ratio, you may also set a 4:3 or 1:1 aspect ratio via the `aspectRatio` prop. If a thumbnail that is different from the one provided by YouTube is required, a custom one may be passed in to the `posterSrc` prop.
+When using a video from YouTube is necessary, you may do so by providing the ID of the video to the `videoId` prop.
+This will leverage the standard YouTube player. Like `Video`, `WebVideo` can be positioned and sized with `FlexGrid`.
+It is required that the time be passed in (in seconds) to the `videoLength` prop. Additionally, you may define the
+video's default volume and whether it should be muted from the start. If you happen to be using a YouTube video that
+is not in 16:9 aspect ratio, you may also set a 4:3 or 1:1 aspect ratio via the `aspectRatio` prop. If a thumbnail
+that is different from the one provided by YouTube is required, a custom one may be passed in to the `posterSrc` prop.
 
 ```jsx
 <FlexGrid>


### PR DESCRIPTION
This PR fixes mobile detection on `Video` when it is rendered using server-side rendering. Additionally, it corrects the `posterSrc` prop verification.