### PR TITLE
Fix @tds/core-input, @tds/core-select

### DIFF
--- a/packages/Input/package.json
+++ b/packages/Input/package.json
@@ -35,7 +35,6 @@
   "devDependencies": {
     "@tds/core-colours": "^1.1.1",
     "@tds/shared-animation": "^1.1.1",
-    "@tds/shared-form-field": "^2.1.8",
-    "react-transition-group": "^2.2.1"
+    "@tds/shared-form-field": "^2.1.8"
   }
 }

--- a/packages/Select/package.json
+++ b/packages/Select/package.json
@@ -36,7 +36,6 @@
   "devDependencies": {
     "@tds/core-colours": "^1.1.1",
     "@tds/shared-animation": "^1.1.1",
-    "@tds/shared-form-field": "^2.1.8",
-    "react-transition-group": "^2.2.1"
+    "@tds/shared-form-field": "^2.1.8"
   }
 }


### PR DESCRIPTION
## Description

Remove `react-transition-group`

`react-transition-group` is a `devDependency` of both `core-input` and `core-select` but is never used.
## Checklist before submitting pull request

- [ ] New code is unit tested
- Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [ ] For code changes, run `npm run prepr` locally
  - make sure visual and accessibility tests pass
