### PR TITLE
fix(core-ordered-list): use typography styles directly

### DIFF
--- a/packages/OrderedList/OrderedItem/OrderedItem.jsx
+++ b/packages/OrderedList/OrderedItem/OrderedItem.jsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import Text from '@tds/core-text'
-
 import safeRest from '../../../shared/utils/safeRest'
 import joinClassNames from '../../../shared/utils/joinClassNames'
 
@@ -10,8 +8,8 @@ import styles from './OrderedItem.modules.scss'
 import listStyles from '../../../shared/styles/List.modules.scss'
 
 const OrderedItem = ({ children, size, ...rest }) => (
-  <li {...safeRest(rest)} className={joinClassNames(styles.base, listStyles.item)}>
-    <Text size={size}>{children}</Text>
+  <li {...safeRest(rest)} className={joinClassNames(styles.base, styles[size], listStyles.item)}>
+    {children}
   </li>
 )
 

--- a/packages/OrderedList/OrderedItem/OrderedItem.modules.scss
+++ b/packages/OrderedList/OrderedItem/OrderedItem.modules.scss
@@ -1,4 +1,30 @@
+@import '~@tds/shared-typography/Typography.modules.scss';
+
 .base {
   margin-left: -1rem;
   padding-left: 1rem;
+}
+
+.small {
+  composes: small;
+  composes: smallFont;
+  &::before {
+    line-height: 1.25rem;
+  }
+}
+
+.medium {
+  composes: medium;
+  composes: mediumFont;
+  &::before {
+    line-height: 1.6rem;
+  }
+}
+
+.large {
+  composes: large;
+  composes: largeFont;
+  &::before {
+    line-height: 2.1rem;
+  }
 }

--- a/packages/OrderedList/__tests__/__snapshots__/OrderedList.spec.jsx.snap
+++ b/packages/OrderedList/__tests__/__snapshots__/OrderedList.spec.jsx.snap
@@ -5,22 +5,14 @@ exports[`<OrderedList /> renders 1`] = `
   class="TDS_Box-modules__betweenBottomMargin-2___31zX_ TDS_Box-modules__stack___33m4D decimal medium"
 >
   <li
-    class="base item"
+    class="base medium item"
   >
-    <span
-      class="TDS_Typography-modules__medium___1rxfE TDS_Typography-modules__wordBreak___3OZx_ TDS_Typography-modules__mediumFont___XMrRj TDS_Typography-modules__color___2CNH8"
-    >
-      Lorem ipsum
-    </span>
+    Lorem ipsum
   </li>
   <li
-    class="base item"
+    class="base medium item"
   >
-    <span
-      class="TDS_Typography-modules__medium___1rxfE TDS_Typography-modules__wordBreak___3OZx_ TDS_Typography-modules__mediumFont___XMrRj TDS_Typography-modules__color___2CNH8"
-    >
-      Dolor sit amet
-    </span>
+    Dolor sit amet
   </li>
 </ol>
 `;

--- a/packages/OrderedList/package.json
+++ b/packages/OrderedList/package.json
@@ -24,8 +24,7 @@
     "react-dom": ">=15"
   },
   "dependencies": {
-    "@tds/core-box": "^1.2.3",
-    "@tds/core-text": "^1.0.11",
+    "@tds/core-box": "^1.2.2",
     "@tds/shared-typography": "^1.2.3",
     "@tds/util-prop-types": "^1.3.1",
     "prop-types": "^15.5.10"


### PR DESCRIPTION
This fixes a rendering issue in Firefox where a blank line will appear above an `OrderedList` if an item contains a `Paragraph` component.

Merge this before the Styled Components version of `OrderedList`!