### PR TITLE
Reduce ExpandCollapse dist size & prevent prop error on conditional rendering

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -43,9 +43,6 @@ export default opts => {
       }),
       commonjs({
         include: '../../node_modules/**',
-        namedExports: {
-          'airbnb-prop-types': ['childrenOfType'],
-        },
       }),
       options.css &&
         postcss({

--- a/package-lock.json
+++ b/package-lock.json
@@ -3327,6 +3327,7 @@
       "version": "2.13.2",
       "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.13.2.tgz",
       "integrity": "sha512-2FN6DlHr6JCSxPPi25EnqGaXC4OC3/B3k1lCd6MMYrZ51/Gf/1qDfaR+JElzWa+Tl7cY2aYOlsYJGFeQyVHIeQ==",
+      "dev": true,
       "requires": {
         "array.prototype.find": "^2.0.4",
         "function.prototype.name": "^1.1.0",
@@ -3828,6 +3829,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
       "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "es-abstract": "^1.7.0"
@@ -7062,6 +7064,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -7727,6 +7730,7 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
@@ -7740,6 +7744,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -9790,7 +9795,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "function.name-polyfill": {
       "version": "1.0.6",
@@ -9802,6 +9808,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
       "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -13529,6 +13536,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -13551,7 +13559,8 @@
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -14420,7 +14429,8 @@
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
     },
     "is-ci": {
       "version": "1.2.1",
@@ -14468,7 +14478,8 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-decimal": {
       "version": "1.0.2",
@@ -14672,6 +14683,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -14740,6 +14752,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.0"
       }
@@ -23143,12 +23156,14 @@
     "object-is": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
+      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
+      "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -23163,6 +23178,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -23174,6 +23190,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
       "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.12.0",
@@ -25060,6 +25077,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
       "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
+      "dev": true,
       "requires": {
         "has": "^1.0.3",
         "object.assign": "^4.1.0",
@@ -26208,7 +26226,8 @@
     "reflect.ownkeys": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
-      "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA="
+      "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=",
+      "dev": true
     },
     "regenerate": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28372,9 +28372,9 @@
       }
     },
     "sister": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/sister/-/sister-3.0.1.tgz",
-      "integrity": "sha512-aG41gNRHRRxPq52MpX4vtm9tapnr6ENmHUx8LMAJWCOplEMwXzh/dp5WIo52Wl8Zlc/VUyHLJ2snX0ck+Nma9g=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sister/-/sister-3.0.2.tgz",
+      "integrity": "sha512-p19rtTs+NksBRKW9qn0UhZ8/TUI9BPw9lmtHny+Y3TinWlOa9jWh9xB0AtPSdmOy49NJJJSSe0Ey4C7h0TrcYA=="
     },
     "sisteransi": {
       "version": "1.0.0",

--- a/packages/ExpandCollapse/Accordion/Accordion.jsx
+++ b/packages/ExpandCollapse/Accordion/Accordion.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { childrenOfType } from 'airbnb-prop-types'
+import { componentWithName } from '@tds/util-prop-types'
 
 import Panels from '../Panels'
 import Panel from '../Panel/Panel'
@@ -73,7 +73,7 @@ Accordion.propTypes = {
   /**
    * The expandable panels. Must be at least one `Accordion.Panel`.
    */
-  children: childrenOfType(Panel).isRequired,
+  children: componentWithName('Panel').isRequired,
 }
 
 Accordion.defaultProps = {

--- a/packages/ExpandCollapse/ExpandCollapse.jsx
+++ b/packages/ExpandCollapse/ExpandCollapse.jsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { childrenOfType } from 'airbnb-prop-types'
-
-import arrayFrom from 'core-js/fn/array/from'
+import { componentWithName } from '@tds/util-prop-types'
 
 import { isEqual } from '../../shared/utils/sets'
 
@@ -44,7 +42,7 @@ class ExpandCollapse extends React.Component {
       },
       () => {
         if (onToggle) {
-          onToggle(arrayFrom(this.state.openPanels))
+          onToggle(Array.from(this.state.openPanels))
         }
       }
     )
@@ -87,7 +85,7 @@ ExpandCollapse.propTypes = {
   /**
    * The expandable panels. Must be at least one `ExpandCollapse.Panel`.
    */
-  children: childrenOfType(Panel).isRequired,
+  children: componentWithName('Panel').isRequired,
 }
 
 ExpandCollapse.defaultProps = {

--- a/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
+++ b/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { childrenOfType } from 'airbnb-prop-types'
+import { componentWithName } from '@tds/util-prop-types'
 
 import Box from '@tds/core-box'
 import DecorativeIcon from '@tds/core-decorative-icon'
@@ -11,8 +11,6 @@ import { Reveal, Translate } from '@tds/shared-animation'
 
 import Clickable from '../../../shared/components/Clickable/Clickable'
 import Flexbox from '../../../shared/components/Flexbox/Flexbox'
-
-import Panel from '../Panel/Panel'
 
 import joinClassNames from '../../../shared/utils/joinClassNames'
 
@@ -208,7 +206,7 @@ PanelWrapper.propTypes = {
   open: PropTypes.bool,
   tag: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4']),
   onClick: PropTypes.func.isRequired,
-  children: childrenOfType(Panel).isRequired,
+  children: componentWithName('Panel').isRequired,
 }
 
 PanelWrapper.defaultProps = {

--- a/packages/ExpandCollapse/Panels.jsx
+++ b/packages/ExpandCollapse/Panels.jsx
@@ -1,13 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { childrenOfType } from 'airbnb-prop-types'
+import { componentWithName } from '@tds/util-prop-types'
 
 import HairlineDivider from '@tds/core-hairline-divider'
 
 import safeRest from '../../shared/utils/safeRest'
 
 import PanelWrapper from './PanelWrapper/PanelWrapper'
-import Panel from './Panel/Panel'
 
 import styles from './ExpandCollapse.modules.scss'
 
@@ -44,7 +43,7 @@ Panels.propTypes = {
   topDivider: PropTypes.bool.isRequired,
   isPanelOpen: PropTypes.func.isRequired,
   togglePanel: PropTypes.func.isRequired,
-  children: childrenOfType(Panel).isRequired,
+  children: componentWithName('Panel').isRequired,
   tag: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4']),
 }
 

--- a/packages/ExpandCollapse/package.json
+++ b/packages/ExpandCollapse/package.json
@@ -31,12 +31,11 @@
     "@tds/core-hairline-divider": "^1.0.6",
     "@tds/core-text": "^1.0.11",
     "@tds/shared-animation": "^1.1.2",
+    "@tds/util-prop-types": "^1.3.1",
     "prop-types": "^15.5.10"
   },
   "devDependencies": {
     "@tds/core-colours": "^1.1.2",
-    "@tds/core-responsive": "^1.2.0",
-    "airbnb-prop-types": "^2.8.1",
-    "core-js": "^2.5.3"
+    "@tds/core-responsive": "^1.2.0"
   }
 }

--- a/packages/prop-types/componentWithName.js
+++ b/packages/prop-types/componentWithName.js
@@ -3,7 +3,7 @@ const componentWithName = (passedName, checkDisplayName) => {
     throw new Error('passedName must be a string')
   }
   const checkProp = (props, propName, componentName) => {
-    if (typeof props[propName] === 'undefined') {
+    if (typeof props[propName] === 'undefined' || props[propName] === null) {
       return undefined
     }
 
@@ -25,7 +25,9 @@ const componentWithName = (passedName, checkDisplayName) => {
         (checkDisplayName && props[propName].displayName !== passedName))
 
     if (
-      (typeof props[propName] !== 'object' && typeof props[propName] !== 'function') ||
+      (props[propName] &&
+        typeof props[propName] !== 'object' &&
+        typeof props[propName] !== 'function') ||
       testNameInObject() ||
       testNameInFunction()
     ) {


### PR DESCRIPTION
This PR dramatically reduces the diff size of ExpandCollapse by replacing `airbnb-prop-types` with our own. `core-js` has also been removed as a dependency, opting to use `Array.from` and having Babel handle the IE 11 compatibility.

There is also a fix for `util-prop-types` that prevents errors on conditional rendering.
Example : `{false && <ExpandCollapse.Panel>stuff</ExpandCollapse.Panel>}`