### PR TITLE
fix(core-button): adding a span inside basic button to center text

### DIFF
--- a/packages/Button/Button.jsx
+++ b/packages/Button/Button.jsx
@@ -81,6 +81,8 @@ const crossBrowserTextAlignmentFix = {
   width: '100%',
 }
 
+export const ButtonTextWrapper = styled.span(crossBrowserTextAlignmentFix)
+
 /**
  * @version ./package.json
  */
@@ -89,7 +91,7 @@ const Button = ({ type, variant, children, ...rest }) => {
 
   return (
     <StyledButton {...safeRest(restNoDisabled)} variant={variant} type={type}>
-      <span style={crossBrowserTextAlignmentFix}>{children}</span>
+      <ButtonTextWrapper>{children}</ButtonTextWrapper>
     </StyledButton>
   )
 }

--- a/packages/Button/Button.jsx
+++ b/packages/Button/Button.jsx
@@ -77,6 +77,10 @@ export const StyledButton = styled.button(
   }
 )
 
+const crossBrowserTextAlignmentFix = {
+  width: '100%',
+}
+
 /**
  * @version ./package.json
  */
@@ -85,7 +89,7 @@ const Button = ({ type, variant, children, ...rest }) => {
 
   return (
     <StyledButton {...safeRest(restNoDisabled)} variant={variant} type={type}>
-      {children}
+      <span style={crossBrowserTextAlignmentFix}>{children}</span>
     </StyledButton>
   )
 }

--- a/packages/Button/Button.jsx
+++ b/packages/Button/Button.jsx
@@ -77,11 +77,9 @@ export const StyledButton = styled.button(
   }
 )
 
-const crossBrowserTextAlignmentFix = {
+export const ButtonTextWrapper = styled.span({
   width: '100%',
-}
-
-export const ButtonTextWrapper = styled.span(crossBrowserTextAlignmentFix)
+})
 
 /**
  * @version ./package.json

--- a/packages/Button/__tests__/__snapshots__/Button.spec.jsx.snap
+++ b/packages/Button/__tests__/__snapshots__/Button.spec.jsx.snap
@@ -44,6 +44,10 @@ exports[`Button can be presented as one of the allowed variants 1`] = `
   color: #4b286d;
 }
 
+.c1 {
+  width: 100%;
+}
+
 @media (min-width:768px) {
   .c0 {
     display: -webkit-inline-box;
@@ -60,7 +64,7 @@ exports[`Button can be presented as one of the allowed variants 1`] = `
   type="button"
 >
   <span
-    style="width:100%"
+    class="c1"
   >
     Submit
   </span>
@@ -111,6 +115,10 @@ exports[`Button renders 1`] = `
   color: #248700;
 }
 
+.c1 {
+  width: 100%;
+}
+
 @media (min-width:768px) {
   .c0 {
     display: -webkit-inline-box;
@@ -127,7 +135,7 @@ exports[`Button renders 1`] = `
   type="button"
 >
   <span
-    style="width:100%"
+    class="c1"
   >
     Submit
   </span>

--- a/packages/Button/__tests__/__snapshots__/Button.spec.jsx.snap
+++ b/packages/Button/__tests__/__snapshots__/Button.spec.jsx.snap
@@ -59,7 +59,11 @@ exports[`Button can be presented as one of the allowed variants 1`] = `
   class="c0"
   type="button"
 >
-  Submit
+  <span
+    style="width:100%"
+  >
+    Submit
+  </span>
 </button>
 `;
 
@@ -122,6 +126,10 @@ exports[`Button renders 1`] = `
   class="c0"
   type="button"
 >
-  Submit
+  <span
+    style="width:100%"
+  >
+    Submit
+  </span>
 </button>
 `;


### PR DESCRIPTION
## Related issues

See #794 

## Description

for iOS <= 10, by setting the `<button>` element to `inline-flex` breaks the calculation of the width of the text inside the `<button>` and hence any texts inside the button will not be centerred.

To fix this issue while not breaking IE 11, the best method so far is to wrap the text with a `<span>` element and set it to width:100%. This 'hack' seems to work for iOS <= 10 and did not break any other browser such as IE 11.

### End Solution
- Created a `<ButtonTextWrapper>` styled component to wrap button text to ensure it has a width of 100% for cross browser compatibility; this `<ButtonTextWrapper>` is exported and can be used by other components if needed.

## Checklist before submitting pull request

- [x] New code is unit tested
- [x] no issues with `npm run prepr` locally