### PR TITLE
Fix/spinner scaling

### DIFF
--- a/packages/Spinner/SpinnerSvg/SpinnerSvg.jsx
+++ b/packages/Spinner/SpinnerSvg/SpinnerSvg.jsx
@@ -25,7 +25,7 @@ class SpinnerSvg extends React.Component {
       >
         <svg
           {...safeRest(rest)}
-          className={styles.svg}
+          className={styles[`${size}Svg`]}
           viewBox="0 0 100 100"
           width={size === 'large' ? '100' : '50'}
           height={size === 'large' ? '100' : '50'}

--- a/packages/Spinner/SpinnerSvg/SpinnerSvg.modules.scss
+++ b/packages/Spinner/SpinnerSvg/SpinnerSvg.modules.scss
@@ -40,8 +40,16 @@ $zindex-popover: 1600;
   z-index: $zindex-popover;
 }
 
-.svg {
+.smallSvg {
   animation: spinner-rotate 1.8s linear infinite;
+  height: 3.125rem;
+  width: 3.125rem;
+}
+
+.largeSvg {
+  animation: spinner-rotate 1.8s linear infinite;
+  height: 6.25rem;
+  width: 6.25rem;
 }
 
 .primaryCircle {

--- a/packages/Spinner/__tests__/__snapshots__/Spinner.spec.jsx.snap
+++ b/packages/Spinner/__tests__/__snapshots__/Spinner.spec.jsx.snap
@@ -20,7 +20,7 @@ exports[`Spinner does not render a large secondary spinner 1`] = `
       <svg
         aria-labelledby="spinner-title-5"
         aria-live="assertive"
-        className="svg"
+        className="largeSvg"
         data-testid="svg"
         height="100"
         role="alert"
@@ -86,7 +86,7 @@ exports[`Spinner renders 1`] = `
   <svg
     aria-labelledby="spinner-title-1"
     aria-live="assertive"
-    class="svg"
+    class="largeSvg"
     data-testid="svg"
     height="100"
     role="alert"
@@ -141,7 +141,7 @@ exports[`Spinner renders a small secondary spinner 1`] = `
       <svg
         aria-labelledby="spinner-title-4"
         aria-live="assertive"
-        className="svg"
+        className="smallSvg"
         data-testid="svg"
         height="50"
         role="alert"
@@ -202,7 +202,7 @@ exports[`Spinner renders a small spinner 1`] = `
       <svg
         aria-labelledby="spinner-title-3"
         aria-live="assertive"
-        className="svg"
+        className="smallSvg"
         data-testid="svg"
         height="50"
         role="alert"
@@ -257,7 +257,7 @@ exports[`Spinner renders with children 1`] = `
     <svg
       aria-labelledby="spinner-title-2"
       aria-live="assertive"
-      class="svg"
+      class="largeSvg"
       data-testid="svg"
       height="100"
       role="alert"


### PR DESCRIPTION
- Adapt spinner size to document font size
- I'm not using `composes` since it would only apply to 1 rule across 2 inheritors, which would output more code

## Before

![image](https://user-images.githubusercontent.com/12798751/59066729-b924d880-887d-11e9-88c9-2ebb168a7890.png)

## After

![image](https://user-images.githubusercontent.com/12798751/59066771-ccd03f00-887d-11e9-9178-cbd23168bf5b.png)

