### PR TITLE
[StandaloneIcon] - render a11yText in A11yContent 

### DIFF
--- a/packages/StandaloneIcon/StandaloneIcon.jsx
+++ b/packages/StandaloneIcon/StandaloneIcon.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+import A11yContent from '@tds/core-a11y-content'
+
 import safeRest from '../../shared/utils/safeRest'
 
 import Icon from '../../shared/components/Icon/Icon'
@@ -39,7 +41,9 @@ const StandaloneIcon = ({ symbol, variant, size, onClick, a11yText, innerRef, ..
         onClick={onClick}
         style={needsExpandedTouchArea ? touchAreaStyles(size) : undefined}
       >
-        <Icon {...iconProps} />
+        <Icon {...iconProps}>
+          <A11yContent>{a11yText}</A11yContent>
+        </Icon>
       </Clickable>
     )
   }

--- a/packages/StandaloneIcon/__tests__/StandaloneIcon.spec.jsx
+++ b/packages/StandaloneIcon/__tests__/StandaloneIcon.spec.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { shallow, render } from 'enzyme'
 
+import A11yContent from '@tds/core-a11y-content'
+
 import StandaloneIcon from '../StandaloneIcon'
 
 describe('StandaloneIcon', () => {
@@ -73,6 +75,15 @@ describe('StandaloneIcon', () => {
       const { interactiveIcon } = doShallow({ onClick: jest.fn() })
 
       expect(interactiveIcon.dive()).toHaveDisplayName('button')
+    })
+
+    it('passes a11yText to the button as A11yContent', () => {
+      const { interactiveIcon } = doShallow({ onClick: jest.fn() })
+
+      expect(interactiveIcon.find('Icon')).toHaveProp(
+        'children',
+        <A11yContent>Some text for the screen readers.</A11yContent>
+      )
     })
 
     it('triggers the click handler', () => {

--- a/packages/StandaloneIcon/__tests__/__snapshots__/StandaloneIcon.spec.jsx.snap
+++ b/packages/StandaloneIcon/__tests__/__snapshots__/StandaloneIcon.spec.jsx.snap
@@ -1,6 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`StandaloneIcon Interactive icon renders 1`] = `
+.c0 {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+}
+
 <button
   class="clickable"
   style="padding:4px;margin:-4px"
@@ -9,7 +18,13 @@ exports[`StandaloneIcon Interactive icon renders 1`] = `
   <i
     aria-label="Some text for the screen readers."
     class="iconSpyglass size24"
-  />
+  >
+    <span
+      class="c0"
+    >
+      Some text for the screen readers.
+    </span>
+  </i>
 </button>
 `;
 

--- a/packages/StandaloneIcon/package.json
+++ b/packages/StandaloneIcon/package.json
@@ -25,6 +25,7 @@
     "react-dom": ">=15"
   },
   "dependencies": {
+    "@tds/core-a11y-content": "^2.1.0",
     "prop-types": "^15.5.10"
   },
   "devDependencies": {

--- a/packages/Tooltip/__tests__/__snapshots__/Tooltip.spec.jsx.snap
+++ b/packages/Tooltip/__tests__/__snapshots__/Tooltip.spec.jsx.snap
@@ -1,6 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tooltip interactivity hides the bubble when clicking outside of it 1`] = `
+.c4 {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+}
+
 .c2 {
   border-radius: 4px;
   position: absolute;
@@ -351,7 +360,47 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 1`] 
                       <i
                         aria-label="Reveal additional information."
                         className="TDS_Icon-modules__iconQuestionMarkCircle___2km-5 TDS_Icon-modules__icon___13xYd TDS_Icon-modules__size24___37pQ7"
-                      />
+                      >
+                        <A11yContent>
+                          <A11yContent__StyledA11yContent>
+                            <StyledComponent
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
+                                    "isStatic": true,
+                                    "lastClassName": "c4",
+                                    "rules": Array [
+                                      "position: absolute;",
+                                      "height: 1px;",
+                                      "width: 1px;",
+                                      "overflow: hidden;",
+                                      "clip: rect(1px, 1px, 1px, 1px);",
+                                    ],
+                                  },
+                                  "displayName": "A11yContent__StyledA11yContent",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
+                                  "target": "span",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                            >
+                              <span
+                                className="c4"
+                              >
+                                Reveal additional information.
+                              </span>
+                            </StyledComponent>
+                          </A11yContent__StyledA11yContent>
+                        </A11yContent>
+                      </i>
                     </Icon>
                   </button>
                 </Clickable>
@@ -366,6 +415,15 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 1`] 
 `;
 
 exports[`Tooltip interactivity hides the bubble when clicking outside of it 2`] = `
+.c4 {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+}
+
 .c2 {
   border-radius: 4px;
   position: absolute;
@@ -716,7 +774,47 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 2`] 
                       <i
                         aria-label="Reveal additional information."
                         className="TDS_Icon-modules__iconQuestionMarkCircle___2km-5 TDS_Icon-modules__icon___13xYd TDS_Icon-modules__size24___37pQ7"
-                      />
+                      >
+                        <A11yContent>
+                          <A11yContent__StyledA11yContent>
+                            <StyledComponent
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
+                                    "isStatic": true,
+                                    "lastClassName": "c4",
+                                    "rules": Array [
+                                      "position: absolute;",
+                                      "height: 1px;",
+                                      "width: 1px;",
+                                      "overflow: hidden;",
+                                      "clip: rect(1px, 1px, 1px, 1px);",
+                                    ],
+                                  },
+                                  "displayName": "A11yContent__StyledA11yContent",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
+                                  "target": "span",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                            >
+                              <span
+                                className="c4"
+                              >
+                                Reveal additional information.
+                              </span>
+                            </StyledComponent>
+                          </A11yContent__StyledA11yContent>
+                        </A11yContent>
+                      </i>
                     </Icon>
                   </button>
                 </Clickable>
@@ -1078,6 +1176,15 @@ exports[`Tooltip interactivity shows and hides the bubble 3`] = `
 `;
 
 exports[`Tooltip renders 1`] = `
+.c4 {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+}
+
 .c2 {
   border-radius: 4px;
   display: none;
@@ -1429,7 +1536,47 @@ exports[`Tooltip renders 1`] = `
                       <i
                         aria-label="Reveal additional information."
                         className="TDS_Icon-modules__iconQuestionMarkCircle___2km-5 TDS_Icon-modules__icon___13xYd TDS_Icon-modules__size24___37pQ7"
-                      />
+                      >
+                        <A11yContent>
+                          <A11yContent__StyledA11yContent>
+                            <StyledComponent
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
+                                    "isStatic": true,
+                                    "lastClassName": "c4",
+                                    "rules": Array [
+                                      "position: absolute;",
+                                      "height: 1px;",
+                                      "width: 1px;",
+                                      "overflow: hidden;",
+                                      "clip: rect(1px, 1px, 1px, 1px);",
+                                    ],
+                                  },
+                                  "displayName": "A11yContent__StyledA11yContent",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
+                                  "target": "span",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                            >
+                              <span
+                                className="c4"
+                              >
+                                Reveal additional information.
+                              </span>
+                            </StyledComponent>
+                          </A11yContent__StyledA11yContent>
+                        </A11yContent>
+                      </i>
                     </Icon>
                   </button>
                 </Clickable>


### PR DESCRIPTION
## Related issues

See #985 

## Description

Render a11yText in an A11yContent component instead of as an aria-label on the button which causes accessbility errors when run through WAVE

## Checklist before submitting pull request

- [x] New code is unit tested
- Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [x] For code changes, run `npm run prepr` locally
  - make sure visual and accessibility tests pass
