### PR TITLE
fix(core-standalone-icon): remove aria-label attribute

### DIFF
--- a/packages/Input/__tests__/__snapshots__/Input.spec.jsx.snap
+++ b/packages/Input/__tests__/__snapshots__/Input.spec.jsx.snap
@@ -149,7 +149,6 @@ exports[`Input feedback states ensures that the contents do not overlap the icon
           class="c4"
         >
           <i
-            aria-label="The value of this input field is valid."
             class="TDS_Icon-modules__iconCheckmark___3cAol TDS_Icon-modules__icon___13xYd TDS_Icon-modules__primary___2UY-N TDS_Icon-modules__size16___1pm12"
           />
         </div>
@@ -920,7 +919,6 @@ exports[`Input renders with a feedback state and icon 1`] = `
           class="c4"
         >
           <i
-            aria-label="The value of this input field is invalid."
             class="TDS_Icon-modules__iconExclamationPointCircle___1HgRN TDS_Icon-modules__icon___13xYd TDS_Icon-modules__error___yuB9x TDS_Icon-modules__size16___1pm12"
           />
         </div>

--- a/packages/Select/__tests__/__snapshots__/Select.spec.jsx.snap
+++ b/packages/Select/__tests__/__snapshots__/Select.spec.jsx.snap
@@ -596,13 +596,11 @@ exports[`Select can have an error message 1`] = `
                                           variant="error"
                                         >
                                           <Icon
-                                            aria-label="The value of this input field is invalid."
                                             size={16}
                                             symbol="exclamationPointCircle"
                                             variant="error"
                                           >
                                             <i
-                                              aria-label="The value of this input field is invalid."
                                               className="TDS_Icon-modules__iconExclamationPointCircle___1HgRN TDS_Icon-modules__icon___13xYd TDS_Icon-modules__error___yuB9x TDS_Icon-modules__size16___1pm12"
                                             />
                                           </Icon>
@@ -1211,7 +1209,6 @@ exports[`Select renders with a feedback state and icon 1`] = `
             class="c5"
           >
             <i
-              aria-label="The value of this input field is invalid."
               class="TDS_Icon-modules__iconExclamationPointCircle___1HgRN TDS_Icon-modules__icon___13xYd TDS_Icon-modules__error___yuB9x TDS_Icon-modules__size16___1pm12"
             />
           </div>

--- a/packages/StandaloneIcon/StandaloneIcon.jsx
+++ b/packages/StandaloneIcon/StandaloneIcon.jsx
@@ -28,7 +28,6 @@ const StandaloneIcon = ({ symbol, variant, size, onClick, a11yText, innerRef, ..
     symbol,
     variant,
     size,
-    'aria-label': a11yText,
   }
 
   if (onClick) {

--- a/packages/StandaloneIcon/__tests__/StandaloneIcon.spec.jsx
+++ b/packages/StandaloneIcon/__tests__/StandaloneIcon.spec.jsx
@@ -32,13 +32,6 @@ describe('StandaloneIcon', () => {
       expect(icon).toHaveProp('id', 'the-icon')
     })
 
-    it('is accessible for screen readers', () => {
-      const icon = doShallow({ a11yText: 'Some screen reader text' })
-
-      expect(icon).not.toHaveProp('aria-hidden')
-      expect(icon).toHaveProp('aria-label', 'Some screen reader text')
-    })
-
     it('does not allow custom CSS', () => {
       const icon = doShallow({
         className: 'my-custom-class',

--- a/packages/StandaloneIcon/__tests__/__snapshots__/StandaloneIcon.spec.jsx.snap
+++ b/packages/StandaloneIcon/__tests__/__snapshots__/StandaloneIcon.spec.jsx.snap
@@ -16,7 +16,6 @@ exports[`StandaloneIcon Interactive icon renders 1`] = `
   type="button"
 >
   <i
-    aria-label="Some text for the screen readers."
     class="iconSpyglass size24"
   >
     <span
@@ -30,7 +29,6 @@ exports[`StandaloneIcon Interactive icon renders 1`] = `
 
 exports[`StandaloneIcon Plain StandaloneIcon renders 1`] = `
 <i
-  aria-label="Some text for the screen readers."
   class="iconSpyglass size24"
 />
 `;

--- a/packages/TextArea/__tests__/__snapshots__/TextArea.spec.jsx.snap
+++ b/packages/TextArea/__tests__/__snapshots__/TextArea.spec.jsx.snap
@@ -563,7 +563,6 @@ exports[`TextArea renders with a feedback state and icon 1`] = `
           class="c4"
         >
           <i
-            aria-label="The value of this input field is invalid."
             class="TDS_Icon-modules__iconExclamationPointCircle___1HgRN TDS_Icon-modules__icon___13xYd TDS_Icon-modules__error___yuB9x TDS_Icon-modules__size16___1pm12"
           />
         </div>

--- a/packages/Tooltip/__tests__/__snapshots__/Tooltip.spec.jsx.snap
+++ b/packages/Tooltip/__tests__/__snapshots__/Tooltip.spec.jsx.snap
@@ -353,12 +353,10 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 1`] 
                     type="button"
                   >
                     <Icon
-                      aria-label="Reveal additional information."
                       size={24}
                       symbol="questionMarkCircle"
                     >
                       <i
-                        aria-label="Reveal additional information."
                         className="TDS_Icon-modules__iconQuestionMarkCircle___2km-5 TDS_Icon-modules__icon___13xYd TDS_Icon-modules__size24___37pQ7"
                       >
                         <A11yContent>
@@ -767,12 +765,10 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 2`] 
                     type="button"
                   >
                     <Icon
-                      aria-label="Reveal additional information."
                       size={24}
                       symbol="questionMarkCircle"
                     >
                       <i
-                        aria-label="Reveal additional information."
                         className="TDS_Icon-modules__iconQuestionMarkCircle___2km-5 TDS_Icon-modules__icon___13xYd TDS_Icon-modules__size24___37pQ7"
                       >
                         <A11yContent>
@@ -1529,12 +1525,10 @@ exports[`Tooltip renders 1`] = `
                     type="button"
                   >
                     <Icon
-                      aria-label="Reveal additional information."
                       size={24}
                       symbol="questionMarkCircle"
                     >
                       <i
-                        aria-label="Reveal additional information."
                         className="TDS_Icon-modules__iconQuestionMarkCircle___2km-5 TDS_Icon-modules__icon___13xYd TDS_Icon-modules__size24___37pQ7"
                       >
                         <A11yContent>


### PR DESCRIPTION
This removes the `aria-label` attribute in StandaloneIcon so it will pase WAVE tests.