### PR TITLE
chore(other): change main bootstrap scripts to npm ci, add slow opt

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "bootstrap": "npm install && npm run gitbook:install && npx lerna bootstrap --hoist && npm run build -- --all && docker-compose build ciboot && docker-compose build e2e",
+    "bootstrap": "npm ci && npm run gitbook:install && npx lerna bootstrap --hoist && npm run build -- --all && docker-compose build ciboot && docker-compose build e2e",
     "bootstrap:ci": "npm ci && npm run gitbook:install && npx lerna bootstrap --hoist && npm run build -- --all",
-    "bootstrap:quick": "npm install && npx lerna bootstrap --hoist && npm run build -- --all",
+    "bootstrap:quick": "npm ci && npx lerna bootstrap --hoist && npm run build -- --all",
+    "bootstrap:slow": "npm install && npm run gitbook:install && npx lerna bootstrap --hoist && npm run build -- --all && docker-compose build ciboot && docker-compose build e2e",
     "build": "node scripts/build.js",
     "build-docs:gitbook": "gitbook build guide",
     "build-docs:styleguide": "styleguidist build --config config/styleguide.config.js",


### PR DESCRIPTION
This will change all of our main bootstrap scripts to use `npm ci` over `npm install` to avoid changing the package-lock.json. I have added a `bootstrap:slow` option that will bootstrap using `npm install`. This will mostly be used for troubleshooting or local repo repair if there's something wrong with the lock file.