### PR TITLE
docs(guide): update guide pages for styled-components, minor cleanup

### DIFF
--- a/guide/contributing/codebase-overview.md
+++ b/guide/contributing/codebase-overview.md
@@ -21,18 +21,18 @@ We utilize the following tools for the development, release, and distribution pr
 - [Styleguidist](https://react-styleguidist.js.org/): isolated React component development environment with a
   living style guide
 - [Rollup](https://rollupjs.org/): Rollup is a JavaScript module bundler, similar to webpack, built with ES2015 modules
-  in mind and optimized for libraries.
+  in mind and optimized for libraries
 - [ES2015+](https://github.com/lukehoban/es6features): We write all JavaScript as ES2015 modules, generally following
   the comprehensive AirBnb style guides for JavaScript and React, and then transpile it for the browser with Babel
 - [Jest](https://facebook.github.io/jest/) and [Enzyme](https://github.com/blainekasten/enzyme-matchers):
   we use jest as our test runner and enzyme to test our React components
+- [Nightwatch](https://nightwatchjs.org/): We use Nightwatch to perform automated visual regression testing on our components
 - Linters and Prettier: standardize code style and format
-- [CSS Modules](https://github.com/css-modules/css-modules): facilitates the buildup of scoped
-  CSS while maintaining the familiar interface of SCSS
+- [styled-components](https://www.styled-components.com/): facilitates the use of CSS-In-JS
 - [NPM](https://www.npmjs.com/): we use NPM as our node package manager
 - [Openshift](https://www.openshift.com/) and [Docker](https://www.docker.com/): the CI pipeline is largely
   based on the TELUS isomorphic starter kit pipeline, using Docker as the build artifact
-- [Lerna](https://lernajs.io/): A tool for managing JavaScript projects with multiple packages.
+- [Lerna](https://lernajs.io/): A tool for managing JavaScript projects with multiple packages
 
 ## Component structure and standards
 
@@ -45,7 +45,6 @@ component named `ButtonLink`, the files are organized like this:
     └─── ButtonLink
         │  ButtonLink.md
         │  ButtonLink.jsx
-        │  ButtonLink.modules.scss
         |  index.cjs.js
         │  index.es.js
         |  package.json
@@ -63,7 +62,6 @@ Here you may notice some of our standards:
 
 - Use PascalCase for all file names
 - Every component must include a set of unit tests and snapshot
-- If a component requires custom styling, use CSS Modules and suffix your scss file with `.modules.scss`
 - To include custom documentation with a component, use `<ComponentName>.md`
 - To include documentation for the npm registry page, use `README.md`
 
@@ -90,7 +88,7 @@ Though the following practices are not strictly enforced, they are strongly enco
 
 ### Code style and conventions
 
-Here are some dos and don'ts to consider when writing code.
+Here are some guidelines to consider when writing code.
 
 #### General
 
@@ -127,12 +125,14 @@ Here are some dos and don'ts to consider when writing code.
   representations
 - If a parent component does not use props and only passes them down to its children, pass components as props
 
-#### Styling (CSS Modules, Sass)
+#### Styling (styled-components)
 
-- **DO** scope component class names
+- **DO** use object notation with styled-components
+- **DO** name your styled component starting with the word "Styled" (e.g. `StyledDiv`)
 - **DON'T** specify external margins. Components must be able to fit into various layouts
-- **DON'T** use HTML elements or IDs as CSS selectors. Only use class names
-- **DON'T** hardcode pixel values unless an absolute pixel value is required. Use tds-core components or relative values such as rem instead.
+- **DON'T** use HTML elements or IDs as CSS selectors
+- **DON'T** hardcode pixel values unless an absolute pixel value is required. Use tds-core components or relative values such as rem instead
+- **DON'T** style components directly using the `style` prop
 
 #### Utility modules
 
@@ -145,29 +145,26 @@ been modified. For an example of a utility module, look at [util-generate-id][td
 - **DO** add utility modules as a **devDependency** to components that consume one
 - **DON'T** create utility modules that cannot be reused in any other component
 
-[Here is an example of a React component that follows the above patterns](https://github.com/telus/tds-core/blob/309271bff529a690532b781e4b3dd26939642f37/src/components/Link/ButtonLink/ButtonLink.jsx).
+[Here is an example of a React component that follows the above patterns](https://github.com/telus/tds-core/blob/6c5383d95e7b92d2c313b8f2f6ccd276b5a38976/packages/ButtonLink/ButtonLink.jsx).
 
 ### Styling components
 
-TDS components use CSS Modules with Sass. You can learn about its usage and design from the
-[CSS Modules GitHub repository](https://github.com/css-modules/css-modules). TDS components derive CSS modules from
-their respective **ComponentName.modules.scss** file. The following patterns are strongly encouraged:
+TDS components use styled-components. You can learn about its usage and design from the
+[styled-components documentation site](https://www.styled-components.com/). When it comes to styled-components, the following patterns are strongly encouraged:
 
-- Use the `composes` property rather than SCSS `@extend` or comma-separated classes. Mixins are acceptable
-- Use camelCase class names
-- Use flexbox, but be aware of cross-browser limitations
-- Components should make effective use of 'layout' components such as Box or Responsive, rather than styles
+- Use object notation whenever possible
+- Use PascalCase component names
+- Deconstruct the props object when using them in a Styled Component
+  - `const StyledDiv = styled.div(({propA, propB}) => ({color: propA, height: propB}))`
+- Components should make effective use of 'layout' components such as Box or FlexGrid, rather than styles
 
-[Here is an example of a scss file that uses the `composes` property from CSS modules](https://github.com/telus/tds-core/blob/309271bff529a690532b781e4b3dd26939642f37/src/components/Link/ButtonLink/ButtonLink.modules.scss).
+See the [CSS Reference Architecture documentation](https://github.com/telus/reference-architecture/blob/master/development/css.md#how) for the most up-to-date organization-wide information.
 
 #### Rendered DOM
 
-From the `composes` example above:
-
 ```html
-<!-- the 'class' attribute contains the 'primary'
-and 'base' classes since 'primary' composes' base -->
-<a class="primary base" href="#">Find out how</a>
+<!-- the 'class' attribute contains a hash generated by styled-components. This prevents class collision. -->
+<a class="sc_hash" href="#">Find out how</a>
 ```
 
 ## Writing tests
@@ -193,7 +190,7 @@ expect(myComponent.props().someBoolean).toBeTruthy()
 // => Expected false to be truthy.
 ```
 
-Always prefer "shallow" rendering, then "render", then "mount". Only "mount" if you are testing the lifecycle methods.
+Always prefer "shallow" rendering, then "render", then "mount". Only "mount" if you are testing the lifecycle methods. Using "render" is required for snapshot testing styled components because it prints all auto-generated CSS classes.
 
 Use a snapshot test for components that do not have any logic and to increase confidence in the structure of the
 component. Snapshot tests do not replace unit tests.

--- a/guide/getting-started/developers.md
+++ b/guide/getting-started/developers.md
@@ -16,7 +16,7 @@ TDS components do not include:
 
 ## Installing
 
-If you are using the [Isomorphic Starter Kit](https://github.com/telusdigital/telus-isomorphic-starter-kit), TDS is already installed and configured. You can jump straight to [using the components](#3-use-tds-components).
+If you are using the latest version of [Isomorphic Starter Kit](https://github.com/telusdigital/telus-isomorphic-starter-kit), TDS is already installed and configured. You can jump straight to [using the components](#3-use-tds-components).
 
 To install the latest version of a component:
 
@@ -29,6 +29,8 @@ That's it! You don't need any other dependencies to use the TDS.
 ## Usage
 
 ### 1. Configure webpack to load CSS
+
+_Note: While still required for a small percentage of TDS components, this step will no longer be necessary in the future._
 
 Add an entry to the `module.rules` array to load CSS. You may also provide other configuration such as the [ExtractTextPlugin](https://github.com/webpack-contrib/extract-text-webpack-plugin) to extract all styles into a separate stylesheet file.
 
@@ -67,9 +69,15 @@ import { render } from 'react-dom'
 
 import App from './App'
 
-import '@tds/core-css-reset/dist/index.css'
+import CSSReset from '@tds/core-css-reset'
 
-render(<App />, document.getElementById('root'))
+render(
+  <>
+    <CSSReset />
+    <App />
+  </>,
+  document.getElementById('root')
+)
 ```
 
 ### 3. Include the required polyfills
@@ -129,20 +137,21 @@ export default BannerText
 
 ### 5. Use TDS colours
 
-Colour is the one exception, as the colour palette is available as Sass variables. While the TDS components already have colour baked in, you may use the TDS colour variables to add style to your own components such as setting background colours or border colours.
+While the TDS components already have colour baked in, you may use the TDS colour variables to add style to your own components such as setting background colours or border colours. These are delivered via named exports from `@tds/core-colours`.
 
 A list of the available colours and their use cases can be found [in the Design section](../design/colour.md).
 
 ```sh
-# install the @tds/core-colours package as a dependency in `ui/package.json`
+# install the @tds/core-colours package as a dependency in `app/package.json`
 npm install @tds/core-colours --save
 ```
 
-```css
-/* BannerText.scss */
-@import '~@tds/core-colours/colours';
+```jsx
+/* CustomButton.jsx */
+import { colorTelusGreen, colorTelusPurple } from '@tds/core-colours'
 
-.banner {
-  background-color: $color-purple;
-}
+const StyledButton = styled.button({
+  backgroundColor: colorTelusPurple,
+  color: colorTelusGreen,
+})
 ```

--- a/guide/v3-upgrade.md
+++ b/guide/v3-upgrade.md
@@ -1,6 +1,6 @@
 # Upgrading to TDS V3
 
-As of **July 1st, 2019** TDS will move feature support from V2: Split Components to V3: Styled Components of the design system. This is being done primarily to facilitate the use of styled-components V4. For a detailed view of our sunsetting schedule, please read our [roadmap page](roadmap.md). Additionally, more information on this subject can be found on the [Reference Architecture CSS Document](https://github.com/telus/reference-architecture/blob/bb7059d135574c380d2865aa1bbdd633c2345461/development/css.md).
+TDS has now moved feature support from V2: Split Components to V3: Styled Components of the design system. This was done primarily to facilitate the use of styled-components V4. For a detailed view of our sunsetting schedule, please read our [roadmap page](roadmap.md). Additionally, more information on this subject can be found on the [Reference Architecture CSS Document](https://github.com/telus/reference-architecture/blob/bb7059d135574c380d2865aa1bbdd633c2345461/development/css.md).
 
 We would also like to note that the following document also applies to Community. Community is now accepting components developed with styled-components, and it is recommended that all new components use it.
 
@@ -14,12 +14,15 @@ If your project utilizes Global Elements, please note that V2 of the Global Elem
 
 When switching your project over from CSS Modules to styled-components, some cleanup can be performed to reduce bloat and increase the ease of use of styled-components. TDS recommends assessing your project for configurations or packages that enable the use of SCSS, and removing them if they are no longer required. This includes, but is not limited to:
 
-- Removing scss-specific items from build and test suite configurations
-- Removing scss-specific packages, such as node-sass
+- Removing scss or css-specific items from build and test suite configurations
 - Install [babel-plugin-styled-components](https://www.npmjs.com/package/babel-plugin-styled-components) and add it to your Babel config to enable the use of styled-components
 - Install [jest-styled-components](https://github.com/styled-components/jest-styled-components) for extended functionality when using styled-components with Jest tests
 
 More cleanup/additions may be required. Please review your configurations and dependencies carefully to be sure that all your needs are met.
+
+#### Server-side rendering
+
+If your application does not use Isomorphic Starter Kit and you also want Server Side Rendering, see the [SSR with Styled Components docs](https://www.styled-components.com/docs/advanced#server-side-rendering) for more information on setting up this functionality.
 
 ### Upgrading from styled-components V3 to V4
 
@@ -44,26 +47,27 @@ To make linting, using variables, and creating shared style files easier, we hav
 Here is an example of a styled component using string literals:
 
 ```js
-const StyledDiv.styled.div`
+const StyledDiv = styled.div`
   width: 500px;
   height: 500px;
-  background-color: ${props => props.isPink ? 'hotpink' : 'green'};
+  background-color: ${props => (props.isPink ? 'hotpink' : 'green')};
   &:hover {
     background-color: purple;
-  }`
+  }
+`
 ```
 
 Here is the previous example using object notation:
 
 ```js
-const StyledDiv.styled.div((props)=>({
+const StyledDiv = styled.div(props => ({
   width: '500px',
   height: '500px',
   backgroundColor: props.isPink ? 'hotpink' : 'green',
   '&:hover': {
-    backgroundColor: 'purple'
-  }
-}));
+    backgroundColor: 'purple',
+  },
+}))
 ```
 
 ### Sanitizing inputs


### PR DESCRIPTION
Removes references to using CSS and replaces them with styled-components references. Also brings the terminology of some parts of the docs more up to date, and adds Nightwatch under our used tools.