### PR TITLE
chore(scripts): exit e2e docker container when finished

### DIFF
--- a/scripts/docker-e2e.sh
+++ b/scripts/docker-e2e.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 ## Used by package.json to pass arguments into the docker-compose up command.
-mode=$@ docker-compose up --abort-on-container-exit e2e
+mode=$@ docker-compose up --abort-on-container-exit e2e && docker-compose down


### PR DESCRIPTION
Fixes the issue where the e2e server will stay open after tests have completed.