### PR TITLE
[fix/card] - replace box-shadow in Card and Footnote

### DIFF
--- a/packages/Card/Card.jsx
+++ b/packages/Card/Card.jsx
@@ -11,7 +11,7 @@ const StyledCard = styled(({ variant, ...rest }) => <Box {...rest} />)(({ varian
   ...borders.none,
   ...borders.rounded,
   ...(variant === 'white' && {
-    boxShadow: '0 0 16px 0 rgba(213, 213, 213, 0.5)',
+    boxShadow: '0 0 16px 0 rgba(0, 0, 0, 0.1)',
     backgroundColor: colorWhite,
   }),
   ...(variant === 'lavender' && {

--- a/packages/Card/__tests__/__snapshots__/Card.spec.jsx.snap
+++ b/packages/Card/__tests__/__snapshots__/Card.spec.jsx.snap
@@ -15,7 +15,7 @@ exports[`<Card /> can be presented as one of the allowed variants 1`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  box-shadow: 0 0 16px 0 rgba(213,213,213,0.5);
+  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
   background-color: #fff;
 }
 
@@ -155,7 +155,7 @@ exports[`<Card /> can be presented as one of the allowed variants 2`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  box-shadow: 0 0 16px 0 rgba(213,213,213,0.5);
+  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
   background-color: #fff;
 }
 
@@ -573,7 +573,7 @@ exports[`<Card /> renders 1`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  box-shadow: 0 0 16px 0 rgba(213,213,213,0.5);
+  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
   background-color: #fff;
 }
 

--- a/packages/TermsAndConditions/Footnote/Footnote.jsx
+++ b/packages/TermsAndConditions/Footnote/Footnote.jsx
@@ -33,7 +33,7 @@ const StyledFootnote = styled.div(
     width: '100vw',
     backgroundColor: colorAthensGrey,
     display: 'block',
-    boxShadow: '0 0 16px 0 rgba(213, 213, 213, 0.5)',
+    boxShadow: '0 0 16px 0 rgba(0, 0, 0, 0.1)',
     transform: 'translateY(100%)',
     transition: 'transform 500ms ease-out',
     zIndex: 99999,

--- a/packages/TermsAndConditions/Footnote/__tests__/__snapshots__/Footnote.spec.jsx.snap
+++ b/packages/TermsAndConditions/Footnote/__tests__/__snapshots__/Footnote.spec.jsx.snap
@@ -118,7 +118,7 @@ div.c5 {
   width: 100vw;
   background-color: #f7f7f8;
   display: block;
-  box-shadow: 0 0 16px 0 rgba(213,213,213,0.5);
+  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
   -webkit-transform: translateY(100%);
   -ms-transform: translateY(100%);
   transform: translateY(100%);
@@ -555,7 +555,7 @@ div.c5 {
   width: 100vw;
   background-color: #f7f7f8;
   display: block;
-  box-shadow: 0 0 16px 0 rgba(213,213,213,0.5);
+  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
   -webkit-transform: translateY(100%);
   -ms-transform: translateY(100%);
   transform: translateY(100%);


### PR DESCRIPTION
## Description

The shadow value in TDS Card right now uses a grey opacity, this does not work well in instances where it overlaps an image. This PR replaces this shadow with black opacity.

## Checklist before submitting pull request

- [ ] New code is unit tested
- Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [ ] For code changes, run `npm run prepr` locally
  - make sure visual and accessibility tests pass
