### PR TITLE
fix(core-spinner): use full width given a medium and lower view

### DIFF
--- a/packages/Spinner/Spinner.jsx
+++ b/packages/Spinner/Spinner.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 import { position } from '@tds/shared-styles'
+import { media } from '@tds/core-responsive'
 
 import { deprecate, warn } from '../../shared/utils/warn'
 import safeRest from '../../shared/utils/safeRest'
@@ -12,7 +13,12 @@ const zindexModalBackdrop = 1400
 
 const SpinnerContainer = styled.div(({ inline, fullScreen }) => ({
   ...position.relative,
-  ...(inline && { display: 'inline-block' }),
+  ...(inline && {
+    display: 'block',
+    ...media.from('md').css({
+      display: 'inline-block',
+    }),
+  }),
   ...(fullScreen && position.centerVertically),
 }))
 

--- a/packages/Spinner/__tests__/__snapshots__/Spinner.spec.jsx.snap
+++ b/packages/Spinner/__tests__/__snapshots__/Spinner.spec.jsx.snap
@@ -60,7 +60,7 @@ Array [
 
 .c0 {
   position: relative;
-  display: inline-block;
+  display: block;
 }
 
 .c6 {
@@ -72,6 +72,12 @@ Array [
 
 .c7 {
   opacity: 0.06;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: inline-block;
+  }
 }
 
 <Spinner__SpinnerContainer
@@ -536,7 +542,7 @@ Array [
 
 .c0 {
   position: relative;
-  display: inline-block;
+  display: block;
 }
 
 .c6 {
@@ -548,6 +554,12 @@ Array [
 
 .c7 {
   opacity: 0.06;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: inline-block;
+  }
 }
 
 <StyledComponent
@@ -1005,7 +1017,7 @@ Array [
 
 .c0 {
   position: relative;
-  display: inline-block;
+  display: block;
 }
 
 .c6 {
@@ -1017,6 +1029,12 @@ Array [
 
 .c7 {
   opacity: 0.06;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: inline-block;
+  }
 }
 
 <div
@@ -2920,7 +2938,7 @@ Array [
 
 .c0 {
   position: relative;
-  display: inline-block;
+  display: block;
 }
 
 .c4 {
@@ -2932,6 +2950,12 @@ Array [
 
 .c5 {
   opacity: 0.06;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: inline-block;
+  }
 }
 
 <Spinner__SpinnerContainer
@@ -3278,7 +3302,7 @@ Array [
 
 .c0 {
   position: relative;
-  display: inline-block;
+  display: block;
 }
 
 .c4 {
@@ -3290,6 +3314,12 @@ Array [
 
 .c5 {
   opacity: 0.06;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: inline-block;
+  }
 }
 
 <StyledComponent
@@ -3629,7 +3659,7 @@ Array [
 
 .c0 {
   position: relative;
-  display: inline-block;
+  display: block;
 }
 
 .c4 {
@@ -3641,6 +3671,12 @@ Array [
 
 .c5 {
   opacity: 0.06;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: inline-block;
+  }
 }
 
 <div
@@ -3955,7 +3991,7 @@ Array [
 
 .c0 {
   position: relative;
-  display: inline-block;
+  display: block;
 }
 
 .c4 {
@@ -3967,6 +4003,12 @@ Array [
 
 .c5 {
   opacity: 0.06;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: inline-block;
+  }
 }
 
 <Spinner__SpinnerContainer
@@ -4313,7 +4355,7 @@ Array [
 
 .c0 {
   position: relative;
-  display: inline-block;
+  display: block;
 }
 
 .c4 {
@@ -4325,6 +4367,12 @@ Array [
 
 .c5 {
   opacity: 0.06;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: inline-block;
+  }
 }
 
 <StyledComponent
@@ -4664,7 +4712,7 @@ Array [
 
 .c0 {
   position: relative;
-  display: inline-block;
+  display: block;
 }
 
 .c4 {
@@ -4676,6 +4724,12 @@ Array [
 
 .c5 {
   opacity: 0.06;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: inline-block;
+  }
 }
 
 <div
@@ -5014,7 +5068,7 @@ Array [
 
 .c0 {
   position: relative;
-  display: inline-block;
+  display: block;
 }
 
 .c6 {
@@ -5026,6 +5080,12 @@ Array [
 
 .c7 {
   opacity: 0.06;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: inline-block;
+  }
 }
 
 <Spinner__SpinnerContainer
@@ -5490,7 +5550,7 @@ Array [
 
 .c0 {
   position: relative;
-  display: inline-block;
+  display: block;
 }
 
 .c6 {
@@ -5502,6 +5562,12 @@ Array [
 
 .c7 {
   opacity: 0.06;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: inline-block;
+  }
 }
 
 <StyledComponent
@@ -5959,7 +6025,7 @@ Array [
 
 .c0 {
   position: relative;
-  display: inline-block;
+  display: block;
 }
 
 .c6 {
@@ -5971,6 +6037,12 @@ Array [
 
 .c7 {
   opacity: 0.06;
+}
+
+@media (min-width:768px) {
+  .c0 {
+    display: inline-block;
+  }
 }
 
 <div

--- a/packages/Spinner/package.json
+++ b/packages/Spinner/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@tds/core-colours": "^2.1.0",
+    "@tds/core-responsive": "^1.3.0",
     "@tds/core-text": "^2.0.2",
     "@tds/shared-styles": "^1.4.2",
     "prop-types": "^15.5.10"


### PR DESCRIPTION
Fixes the resizing of the child component when inline='true' and a mobile view port

## Checklist before submitting pull request

- [x] New code is unit tested
- Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [ ] For code changes, run `npm run prepr` locally
  - make sure visual and accessibility tests pass
