### PR TITLE
Add forwardRef to interactive components

### DIFF
--- a/packages/Breadcrumbs/Breadcrumbs.jsx
+++ b/packages/Breadcrumbs/Breadcrumbs.jsx
@@ -93,9 +93,10 @@ const Breadcrumbs = ({
   let items
   if (children) {
     items = React.Children.toArray(children).map(
-      ({ props: { href, children: breadcrumbName, ...itemRest } }) => ({
+      ({ props: { href, children: breadcrumbName, ...itemRest }, ref }) => ({
         path: href,
         breadcrumbName,
+        ref,
         ...itemRest,
       })
     )

--- a/packages/Breadcrumbs/Breadcrumbs.jsx
+++ b/packages/Breadcrumbs/Breadcrumbs.jsx
@@ -160,7 +160,7 @@ Breadcrumbs.propTypes = {
   /**
    * A list of Items to be used as an alternative to the `routes` prop.
    */
-  children: componentWithName('Item'),
+  children: componentWithName('Item', true),
 }
 
 Breadcrumbs.defaultProps = {

--- a/packages/Breadcrumbs/Item/Item.jsx
+++ b/packages/Breadcrumbs/Item/Item.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
@@ -38,7 +38,7 @@ const StyledSlash = styled.span({
   margin: '0 0.5rem',
 })
 
-const Item = ({ href, reactRouterLinkComponent, children, current, ...rest }) => {
+const Item = forwardRef(({ href, reactRouterLinkComponent, children, current, ...rest }, ref) => {
   const linkOptions = { ...rest }
   if (reactRouterLinkComponent) {
     linkOptions.to = href
@@ -52,13 +52,17 @@ const Item = ({ href, reactRouterLinkComponent, children, current, ...rest }) =>
         <Text>{children}</Text>
       ) : (
         <span>
-          <Link {...linkOptions}>{children}</Link>
+          <Link {...linkOptions} ref={ref}>
+            {children}
+          </Link>
           <StyledSlash aria-hidden="true">/</StyledSlash>
         </span>
       )}
     </StyledItemContainer>
   )
-}
+})
+
+Item.displayName = 'Item'
 
 Item.propTypes = {
   /**

--- a/packages/Breadcrumbs/__tests__/Breadcrumbs.spec.jsx
+++ b/packages/Breadcrumbs/__tests__/Breadcrumbs.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, shallow, mount } from 'enzyme'
+import { mount } from 'enzyme'
 
 import Link from '@tds/core-link'
 import Text from '@tds/core-text'
@@ -26,23 +26,21 @@ describe('Breadcrumbs', () => {
     ],
   }
 
-  const doRender = (props = {}) => render(<Breadcrumbs {...defaultProps} {...props} />)
-  const doShallow = (props = {}) => shallow(<Breadcrumbs {...defaultProps} {...props} />)
   const doMount = (props = {}) => mount(<Breadcrumbs {...defaultProps} {...props} />)
 
   it('does not allow custom CSS', () => {
-    const breadcrumbs = doShallow({
+    const breadcrumbs = doMount({
       className: 'my-custom-class',
       style: { color: 'hotpink' },
     })
 
-    expect(breadcrumbs).not.toHaveProp('className', 'my-custom-class')
-    expect(breadcrumbs).not.toHaveProp('style')
+    expect(breadcrumbs.find('nav')).not.toHaveProp('className', 'my-custom-class')
+    expect(breadcrumbs.find('nav')).not.toHaveProp('style')
   })
 
   describe('with routes', () => {
     it('renders', () => {
-      const breadcrumbs = doRender()
+      const breadcrumbs = doMount()
 
       expect(breadcrumbs).toMatchSnapshot()
     })
@@ -88,9 +86,29 @@ describe('Breadcrumbs', () => {
     }
 
     it('renders', () => {
-      const breadcrumbs = doRender(defaultPropsWithChildren)
+      const breadcrumbs = doMount(defaultPropsWithChildren)
 
       expect(breadcrumbs).toMatchSnapshot()
+    })
+
+    it('Item forwards refs', () => {
+      const ref = React.createRef()
+      const item = mount(
+        <>
+          <Breadcrumbs.Item ref={ref} href="/">
+            Home
+          </Breadcrumbs.Item>
+        </>
+      )
+
+      const target = item
+        .find('Link')
+        .at(0)
+        .find('StyledComponent')
+        .childAt(0)
+        .instance()
+
+      expect(target).toEqual(ref.current)
     })
 
     it('doest not concatenate paths', () => {
@@ -114,27 +132,27 @@ describe('Breadcrumbs', () => {
   })
 })
 
-describe('Breadcrumbs.Item', () => {
+describe('Item', () => {
   const defaultProps = {
     href: '/',
     children: 'Link',
     current: false,
   }
 
-  const doShallow = (props = {}) => shallow(<Breadcrumbs.Item {...defaultProps} {...props} />)
+  const doMount = (props = {}) => mount(<Breadcrumbs.Item {...defaultProps} {...props} />)
 
   it('renders a TDS Link if Item is not current', () => {
-    const breadcrumbsItem = doShallow()
+    const breadcrumbsItem = doMount()
     expect(breadcrumbsItem.find(Link)).toExist()
   })
 
   it('renders a Text component for the last item', () => {
-    const breadcrumbsItem = doShallow({ current: true })
+    const breadcrumbsItem = doMount({ current: true })
     expect(breadcrumbsItem.find(Text)).toExist()
   })
 
   it('renders a Text when reactRouterLinkComponent is provided and is current', () => {
-    const breadcrumbsItem = doShallow({
+    const breadcrumbsItem = doMount({
       current: true,
       reactRouterLinkComponent: ReactRouterLinkComponent,
     })

--- a/packages/Breadcrumbs/__tests__/__snapshots__/Breadcrumbs.spec.jsx.snap
+++ b/packages/Breadcrumbs/__tests__/__snapshots__/Breadcrumbs.spec.jsx.snap
@@ -121,57 +121,546 @@ exports[`Breadcrumbs with children renders 1`] = `
   }
 }
 
-<nav>
-  <ol
-    class="c0"
-  >
-    <li
-      class="c1"
-    >
-      <span>
-        <a
-          class="c2"
-          href="/"
-        >
-          Home
-        </a>
-        <span
-          aria-hidden="true"
-          class="c3"
-        >
-          /
-        </span>
-      </span>
-    </li>
-    <li
-      class="c1"
-    >
-      <span>
-        <a
-          class="c2"
-          href="/mobility"
-        >
-          Mobility
-        </a>
-        <span
-          aria-hidden="true"
-          class="c3"
-        >
-          /
-        </span>
-      </span>
-    </li>
-    <li
-      class="c4"
-    >
-      <span
-        class="c5"
+<Breadcrumbs
+  baseUrl="http://localhost:6060/en"
+  params={Object {}}
+>
+  <nav>
+    <Breadcrumbs__StyledList>
+      <StyledComponent
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "Breadcrumbs__StyledList-sc-1wkmsz5-0",
+              "isStatic": true,
+              "lastClassName": "c0",
+              "rules": Array [
+                "display: flex;",
+                "flex-wrap: wrap;",
+              ],
+            },
+            "displayName": "Breadcrumbs__StyledList",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "Breadcrumbs__StyledList-sc-1wkmsz5-0",
+            "target": "ol",
+            "toString": [Function],
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
+        }
+        forwardedRef={null}
       >
-        Accessories
-      </span>
-    </li>
-  </ol>
-</nav>
+        <ol
+          className="c0"
+        >
+          <Item
+            current={false}
+            href="/"
+            key="/"
+          >
+            <Styled(ColoredTextProvider)
+              isCurrent={false}
+              tag="li"
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "sc-bdVaJa",
+                      "isStatic": false,
+                      "lastClassName": "c4",
+                      "rules": Array [
+                        [Function],
+                      ],
+                    },
+                    "displayName": "Styled(ColoredTextProvider)",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "sc-bdVaJa",
+                    "target": [Function],
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                isCurrent={false}
+                tag="li"
+              >
+                <ColoredTextProvider
+                  className="c1"
+                  isCurrent={false}
+                  tag="li"
+                >
+                  <li
+                    className="c1"
+                  >
+                    <span>
+                      <WithForwardedRef(Link)
+                        href="/"
+                      >
+                        <Link
+                          forwardedRef={null}
+                          href="/"
+                          invert={false}
+                          reactRouterLinkComponent={null}
+                          to={null}
+                        >
+                          <Link__StyledLink
+                            as="a"
+                            context={
+                              Object {
+                                "inheritColor": true,
+                              }
+                            }
+                            href="/"
+                            invert={false}
+                            to={null}
+                          >
+                            <StyledComponent
+                              as="a"
+                              context={
+                                Object {
+                                  "inheritColor": true,
+                                }
+                              }
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "Link__StyledLink-sc-1bokult-0",
+                                    "isStatic": false,
+                                    "lastClassName": "c2",
+                                    "rules": Array [
+                                      ":focus {",
+                                      "outline: auto 5px -webkit-focus-ring-color;",
+                                      "}",
+                                      "&:link,&:visited {",
+                                      "color: #2a2c2e;",
+                                      "text-decoration: underline;",
+                                      "}",
+                                      "&:hover {",
+                                      "text-decoration: none;",
+                                      "}",
+                                      [Function],
+                                    ],
+                                  },
+                                  "displayName": "Link__StyledLink",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "Link__StyledLink-sc-1bokult-0",
+                                  "target": "a",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              href="/"
+                              invert={false}
+                              to={null}
+                            >
+                              <a
+                                className="c2"
+                                href="/"
+                                to={null}
+                              >
+                                Home
+                              </a>
+                            </StyledComponent>
+                          </Link__StyledLink>
+                        </Link>
+                      </WithForwardedRef(Link)>
+                      <Item__StyledSlash
+                        aria-hidden="true"
+                      >
+                        <StyledComponent
+                          aria-hidden="true"
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "Item__StyledSlash-sc-16xtipq-0",
+                                "isStatic": true,
+                                "lastClassName": "c3",
+                                "rules": Array [
+                                  "display: inline;",
+                                  "font-size: 0.875rem;",
+                                  "letter-spacing: -0.6px;",
+                                  "line-height: 1.42857;",
+                                  "@media (min-width: 768px) {",
+                                  "font-size: 1rem;",
+                                  "letter-spacing: -0.8px;",
+                                  "line-height: 1.5;",
+                                  "}",
+                                  "margin: 0 0.5rem;",
+                                ],
+                              },
+                              "displayName": "Item__StyledSlash",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "Item__StyledSlash-sc-16xtipq-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <span
+                            aria-hidden="true"
+                            className="c3"
+                          >
+                            /
+                          </span>
+                        </StyledComponent>
+                      </Item__StyledSlash>
+                    </span>
+                  </li>
+                </ColoredTextProvider>
+              </StyledComponent>
+            </Styled(ColoredTextProvider)>
+          </Item>
+          <Item
+            current={false}
+            href="/mobility"
+            key="/mobility"
+          >
+            <Styled(ColoredTextProvider)
+              isCurrent={false}
+              tag="li"
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "sc-bdVaJa",
+                      "isStatic": false,
+                      "lastClassName": "c4",
+                      "rules": Array [
+                        [Function],
+                      ],
+                    },
+                    "displayName": "Styled(ColoredTextProvider)",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "sc-bdVaJa",
+                    "target": [Function],
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                isCurrent={false}
+                tag="li"
+              >
+                <ColoredTextProvider
+                  className="c1"
+                  isCurrent={false}
+                  tag="li"
+                >
+                  <li
+                    className="c1"
+                  >
+                    <span>
+                      <WithForwardedRef(Link)
+                        href="/mobility"
+                      >
+                        <Link
+                          forwardedRef={null}
+                          href="/mobility"
+                          invert={false}
+                          reactRouterLinkComponent={null}
+                          to={null}
+                        >
+                          <Link__StyledLink
+                            as="a"
+                            context={
+                              Object {
+                                "inheritColor": true,
+                              }
+                            }
+                            href="/mobility"
+                            invert={false}
+                            to={null}
+                          >
+                            <StyledComponent
+                              as="a"
+                              context={
+                                Object {
+                                  "inheritColor": true,
+                                }
+                              }
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "Link__StyledLink-sc-1bokult-0",
+                                    "isStatic": false,
+                                    "lastClassName": "c2",
+                                    "rules": Array [
+                                      ":focus {",
+                                      "outline: auto 5px -webkit-focus-ring-color;",
+                                      "}",
+                                      "&:link,&:visited {",
+                                      "color: #2a2c2e;",
+                                      "text-decoration: underline;",
+                                      "}",
+                                      "&:hover {",
+                                      "text-decoration: none;",
+                                      "}",
+                                      [Function],
+                                    ],
+                                  },
+                                  "displayName": "Link__StyledLink",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "Link__StyledLink-sc-1bokult-0",
+                                  "target": "a",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              href="/mobility"
+                              invert={false}
+                              to={null}
+                            >
+                              <a
+                                className="c2"
+                                href="/mobility"
+                                to={null}
+                              >
+                                Mobility
+                              </a>
+                            </StyledComponent>
+                          </Link__StyledLink>
+                        </Link>
+                      </WithForwardedRef(Link)>
+                      <Item__StyledSlash
+                        aria-hidden="true"
+                      >
+                        <StyledComponent
+                          aria-hidden="true"
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "Item__StyledSlash-sc-16xtipq-0",
+                                "isStatic": true,
+                                "lastClassName": "c3",
+                                "rules": Array [
+                                  "display: inline;",
+                                  "font-size: 0.875rem;",
+                                  "letter-spacing: -0.6px;",
+                                  "line-height: 1.42857;",
+                                  "@media (min-width: 768px) {",
+                                  "font-size: 1rem;",
+                                  "letter-spacing: -0.8px;",
+                                  "line-height: 1.5;",
+                                  "}",
+                                  "margin: 0 0.5rem;",
+                                ],
+                              },
+                              "displayName": "Item__StyledSlash",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "Item__StyledSlash-sc-16xtipq-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <span
+                            aria-hidden="true"
+                            className="c3"
+                          >
+                            /
+                          </span>
+                        </StyledComponent>
+                      </Item__StyledSlash>
+                    </span>
+                  </li>
+                </ColoredTextProvider>
+              </StyledComponent>
+            </Styled(ColoredTextProvider)>
+          </Item>
+          <Item
+            current={true}
+            href="/mobility/accessories"
+            key="/mobility/accessories"
+          >
+            <Styled(ColoredTextProvider)
+              isCurrent={true}
+              tag="li"
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "sc-bdVaJa",
+                      "isStatic": false,
+                      "lastClassName": "c4",
+                      "rules": Array [
+                        [Function],
+                      ],
+                    },
+                    "displayName": "Styled(ColoredTextProvider)",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "sc-bdVaJa",
+                    "target": [Function],
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                isCurrent={true}
+                tag="li"
+              >
+                <ColoredTextProvider
+                  className="c4"
+                  isCurrent={true}
+                  tag="li"
+                >
+                  <li
+                    className="c4"
+                  >
+                    <Text
+                      block={false}
+                      bold={false}
+                      invert={false}
+                      size="base"
+                    >
+                      <Text__StyledText
+                        block={false}
+                        bold={false}
+                        inheritColor={true}
+                        invert={false}
+                        size="base"
+                      >
+                        <StyledComponent
+                          block={false}
+                          bold={false}
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "Text__StyledText-sc-1m0rr67-0",
+                                "isStatic": false,
+                                "lastClassName": "c5",
+                                "rules": Array [
+                                  [Function],
+                                  [Function],
+                                  [Function],
+                                  [Function],
+                                  [Function],
+                                  "sup {",
+                                  "top: -0.5em;",
+                                  "font-size: 0.875rem;",
+                                  "position: relative;",
+                                  "vertical-align: baseline;",
+                                  "padding-left: 0.1em;",
+                                  "}",
+                                ],
+                              },
+                              "displayName": "Text__StyledText",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          inheritColor={true}
+                          invert={false}
+                          size="base"
+                        >
+                          <span
+                            className="c5"
+                            size="base"
+                          >
+                            Accessories
+                          </span>
+                        </StyledComponent>
+                      </Text__StyledText>
+                    </Text>
+                  </li>
+                </ColoredTextProvider>
+              </StyledComponent>
+            </Styled(ColoredTextProvider)>
+          </Item>
+        </ol>
+      </StyledComponent>
+    </Breadcrumbs__StyledList>
+    <HelmetWrapper
+      defer={true}
+      encodeSpecialCharacters={true}
+    >
+      <SideEffect(NullComponent)
+        defer={true}
+        encodeSpecialCharacters={true}
+        script={
+          Array [
+            Object {
+              "innerHTML": "
+{
+  \\"@context\\": \\"http://schema.org\\",
+  \\"@type\\": \\"BreadcrumbList\\",
+  \\"itemListElement\\": [{\\"@type\\":\\"ListItem\\",\\"position\\":1,\\"item\\":{\\"@id\\":\\"http://localhost:6060/en/\\",\\"name\\":\\"Home\\"}},{\\"@type\\":\\"ListItem\\",\\"position\\":2,\\"item\\":{\\"@id\\":\\"http://localhost:6060/en/mobility\\",\\"name\\":\\"Mobility\\"}},{\\"@type\\":\\"ListItem\\",\\"position\\":3,\\"item\\":{\\"@id\\":\\"http://localhost:6060/en/mobility/accessories\\",\\"name\\":\\"Accessories\\"}}]
+}
+",
+              "type": "application/ld+json",
+            },
+          ]
+        }
+      >
+        <NullComponent
+          defer={true}
+          encodeSpecialCharacters={true}
+          script={
+            Array [
+              Object {
+                "innerHTML": "
+{
+  \\"@context\\": \\"http://schema.org\\",
+  \\"@type\\": \\"BreadcrumbList\\",
+  \\"itemListElement\\": [{\\"@type\\":\\"ListItem\\",\\"position\\":1,\\"item\\":{\\"@id\\":\\"http://localhost:6060/en/\\",\\"name\\":\\"Home\\"}},{\\"@type\\":\\"ListItem\\",\\"position\\":2,\\"item\\":{\\"@id\\":\\"http://localhost:6060/en/mobility\\",\\"name\\":\\"Mobility\\"}},{\\"@type\\":\\"ListItem\\",\\"position\\":3,\\"item\\":{\\"@id\\":\\"http://localhost:6060/en/mobility/accessories\\",\\"name\\":\\"Accessories\\"}}]
+}
+",
+                "type": "application/ld+json",
+              },
+            ]
+          }
+        />
+      </SideEffect(NullComponent)>
+    </HelmetWrapper>
+  </nav>
+</Breadcrumbs>
 `;
 
 exports[`Breadcrumbs with routes renders 1`] = `
@@ -295,55 +784,559 @@ exports[`Breadcrumbs with routes renders 1`] = `
   }
 }
 
-<nav>
-  <ol
-    class="c0"
-  >
-    <li
-      class="c1"
-    >
-      <span>
-        <a
-          class="c2"
-          href="/"
-        >
-          Home
-        </a>
-        <span
-          aria-hidden="true"
-          class="c3"
-        >
-          /
-        </span>
-      </span>
-    </li>
-    <li
-      class="c1"
-    >
-      <span>
-        <a
-          class="c2"
-          href="/mobility"
-        >
-          Mobility
-        </a>
-        <span
-          aria-hidden="true"
-          class="c3"
-        >
-          /
-        </span>
-      </span>
-    </li>
-    <li
-      class="c4"
-    >
-      <span
-        class="c5"
+<Breadcrumbs
+  params={Object {}}
+  routes={
+    Array [
+      Object {
+        "breadcrumbName": "Home",
+        "path": "/",
+      },
+      Object {
+        "breadcrumbName": "Mobility",
+        "path": "/mobility",
+      },
+      Object {
+        "breadcrumbName": "Accessories",
+        "path": "/accessories",
+      },
+    ]
+  }
+>
+  <nav>
+    <Breadcrumbs__StyledList>
+      <StyledComponent
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "Breadcrumbs__StyledList-sc-1wkmsz5-0",
+              "isStatic": true,
+              "lastClassName": "c0",
+              "rules": Array [
+                "display: flex;",
+                "flex-wrap: wrap;",
+              ],
+            },
+            "displayName": "Breadcrumbs__StyledList",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "Breadcrumbs__StyledList-sc-1wkmsz5-0",
+            "target": "ol",
+            "toString": [Function],
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
+        }
+        forwardedRef={null}
       >
-        Accessories
-      </span>
-    </li>
-  </ol>
-</nav>
+        <ol
+          className="c0"
+        >
+          <Item
+            current={false}
+            href="/"
+            key="/"
+          >
+            <Styled(ColoredTextProvider)
+              isCurrent={false}
+              tag="li"
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "sc-bdVaJa",
+                      "isStatic": false,
+                      "lastClassName": "c4",
+                      "rules": Array [
+                        [Function],
+                      ],
+                    },
+                    "displayName": "Styled(ColoredTextProvider)",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "sc-bdVaJa",
+                    "target": [Function],
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                isCurrent={false}
+                tag="li"
+              >
+                <ColoredTextProvider
+                  className="c1"
+                  isCurrent={false}
+                  tag="li"
+                >
+                  <li
+                    className="c1"
+                  >
+                    <span>
+                      <WithForwardedRef(Link)
+                        href="/"
+                      >
+                        <Link
+                          forwardedRef={null}
+                          href="/"
+                          invert={false}
+                          reactRouterLinkComponent={null}
+                          to={null}
+                        >
+                          <Link__StyledLink
+                            as="a"
+                            context={
+                              Object {
+                                "inheritColor": true,
+                              }
+                            }
+                            href="/"
+                            invert={false}
+                            to={null}
+                          >
+                            <StyledComponent
+                              as="a"
+                              context={
+                                Object {
+                                  "inheritColor": true,
+                                }
+                              }
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "Link__StyledLink-sc-1bokult-0",
+                                    "isStatic": false,
+                                    "lastClassName": "c2",
+                                    "rules": Array [
+                                      ":focus {",
+                                      "outline: auto 5px -webkit-focus-ring-color;",
+                                      "}",
+                                      "&:link,&:visited {",
+                                      "color: #2a2c2e;",
+                                      "text-decoration: underline;",
+                                      "}",
+                                      "&:hover {",
+                                      "text-decoration: none;",
+                                      "}",
+                                      [Function],
+                                    ],
+                                  },
+                                  "displayName": "Link__StyledLink",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "Link__StyledLink-sc-1bokult-0",
+                                  "target": "a",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              href="/"
+                              invert={false}
+                              to={null}
+                            >
+                              <a
+                                className="c2"
+                                href="/"
+                                to={null}
+                              >
+                                Home
+                              </a>
+                            </StyledComponent>
+                          </Link__StyledLink>
+                        </Link>
+                      </WithForwardedRef(Link)>
+                      <Item__StyledSlash
+                        aria-hidden="true"
+                      >
+                        <StyledComponent
+                          aria-hidden="true"
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "Item__StyledSlash-sc-16xtipq-0",
+                                "isStatic": true,
+                                "lastClassName": "c3",
+                                "rules": Array [
+                                  "display: inline;",
+                                  "font-size: 0.875rem;",
+                                  "letter-spacing: -0.6px;",
+                                  "line-height: 1.42857;",
+                                  "@media (min-width: 768px) {",
+                                  "font-size: 1rem;",
+                                  "letter-spacing: -0.8px;",
+                                  "line-height: 1.5;",
+                                  "}",
+                                  "margin: 0 0.5rem;",
+                                ],
+                              },
+                              "displayName": "Item__StyledSlash",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "Item__StyledSlash-sc-16xtipq-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <span
+                            aria-hidden="true"
+                            className="c3"
+                          >
+                            /
+                          </span>
+                        </StyledComponent>
+                      </Item__StyledSlash>
+                    </span>
+                  </li>
+                </ColoredTextProvider>
+              </StyledComponent>
+            </Styled(ColoredTextProvider)>
+          </Item>
+          <Item
+            current={false}
+            href="/mobility"
+            key="/mobility"
+          >
+            <Styled(ColoredTextProvider)
+              isCurrent={false}
+              tag="li"
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "sc-bdVaJa",
+                      "isStatic": false,
+                      "lastClassName": "c4",
+                      "rules": Array [
+                        [Function],
+                      ],
+                    },
+                    "displayName": "Styled(ColoredTextProvider)",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "sc-bdVaJa",
+                    "target": [Function],
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                isCurrent={false}
+                tag="li"
+              >
+                <ColoredTextProvider
+                  className="c1"
+                  isCurrent={false}
+                  tag="li"
+                >
+                  <li
+                    className="c1"
+                  >
+                    <span>
+                      <WithForwardedRef(Link)
+                        href="/mobility"
+                      >
+                        <Link
+                          forwardedRef={null}
+                          href="/mobility"
+                          invert={false}
+                          reactRouterLinkComponent={null}
+                          to={null}
+                        >
+                          <Link__StyledLink
+                            as="a"
+                            context={
+                              Object {
+                                "inheritColor": true,
+                              }
+                            }
+                            href="/mobility"
+                            invert={false}
+                            to={null}
+                          >
+                            <StyledComponent
+                              as="a"
+                              context={
+                                Object {
+                                  "inheritColor": true,
+                                }
+                              }
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "Link__StyledLink-sc-1bokult-0",
+                                    "isStatic": false,
+                                    "lastClassName": "c2",
+                                    "rules": Array [
+                                      ":focus {",
+                                      "outline: auto 5px -webkit-focus-ring-color;",
+                                      "}",
+                                      "&:link,&:visited {",
+                                      "color: #2a2c2e;",
+                                      "text-decoration: underline;",
+                                      "}",
+                                      "&:hover {",
+                                      "text-decoration: none;",
+                                      "}",
+                                      [Function],
+                                    ],
+                                  },
+                                  "displayName": "Link__StyledLink",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "Link__StyledLink-sc-1bokult-0",
+                                  "target": "a",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              href="/mobility"
+                              invert={false}
+                              to={null}
+                            >
+                              <a
+                                className="c2"
+                                href="/mobility"
+                                to={null}
+                              >
+                                Mobility
+                              </a>
+                            </StyledComponent>
+                          </Link__StyledLink>
+                        </Link>
+                      </WithForwardedRef(Link)>
+                      <Item__StyledSlash
+                        aria-hidden="true"
+                      >
+                        <StyledComponent
+                          aria-hidden="true"
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "Item__StyledSlash-sc-16xtipq-0",
+                                "isStatic": true,
+                                "lastClassName": "c3",
+                                "rules": Array [
+                                  "display: inline;",
+                                  "font-size: 0.875rem;",
+                                  "letter-spacing: -0.6px;",
+                                  "line-height: 1.42857;",
+                                  "@media (min-width: 768px) {",
+                                  "font-size: 1rem;",
+                                  "letter-spacing: -0.8px;",
+                                  "line-height: 1.5;",
+                                  "}",
+                                  "margin: 0 0.5rem;",
+                                ],
+                              },
+                              "displayName": "Item__StyledSlash",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "Item__StyledSlash-sc-16xtipq-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                        >
+                          <span
+                            aria-hidden="true"
+                            className="c3"
+                          >
+                            /
+                          </span>
+                        </StyledComponent>
+                      </Item__StyledSlash>
+                    </span>
+                  </li>
+                </ColoredTextProvider>
+              </StyledComponent>
+            </Styled(ColoredTextProvider)>
+          </Item>
+          <Item
+            current={true}
+            href="/mobility/accessories"
+            key="/mobility/accessories"
+          >
+            <Styled(ColoredTextProvider)
+              isCurrent={true}
+              tag="li"
+            >
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "sc-bdVaJa",
+                      "isStatic": false,
+                      "lastClassName": "c4",
+                      "rules": Array [
+                        [Function],
+                      ],
+                    },
+                    "displayName": "Styled(ColoredTextProvider)",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "sc-bdVaJa",
+                    "target": [Function],
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                isCurrent={true}
+                tag="li"
+              >
+                <ColoredTextProvider
+                  className="c4"
+                  isCurrent={true}
+                  tag="li"
+                >
+                  <li
+                    className="c4"
+                  >
+                    <Text
+                      block={false}
+                      bold={false}
+                      invert={false}
+                      size="base"
+                    >
+                      <Text__StyledText
+                        block={false}
+                        bold={false}
+                        inheritColor={true}
+                        invert={false}
+                        size="base"
+                      >
+                        <StyledComponent
+                          block={false}
+                          bold={false}
+                          forwardedComponent={
+                            Object {
+                              "$$typeof": Symbol(react.forward_ref),
+                              "attrs": Array [],
+                              "componentStyle": ComponentStyle {
+                                "componentId": "Text__StyledText-sc-1m0rr67-0",
+                                "isStatic": false,
+                                "lastClassName": "c5",
+                                "rules": Array [
+                                  [Function],
+                                  [Function],
+                                  [Function],
+                                  [Function],
+                                  [Function],
+                                  "sup {",
+                                  "top: -0.5em;",
+                                  "font-size: 0.875rem;",
+                                  "position: relative;",
+                                  "vertical-align: baseline;",
+                                  "padding-left: 0.1em;",
+                                  "}",
+                                ],
+                              },
+                              "displayName": "Text__StyledText",
+                              "foldedComponentIds": Array [],
+                              "render": [Function],
+                              "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
+                              "target": "span",
+                              "toString": [Function],
+                              "warnTooManyClasses": [Function],
+                              "withComponent": [Function],
+                            }
+                          }
+                          forwardedRef={null}
+                          inheritColor={true}
+                          invert={false}
+                          size="base"
+                        >
+                          <span
+                            className="c5"
+                            size="base"
+                          >
+                            Accessories
+                          </span>
+                        </StyledComponent>
+                      </Text__StyledText>
+                    </Text>
+                  </li>
+                </ColoredTextProvider>
+              </StyledComponent>
+            </Styled(ColoredTextProvider)>
+          </Item>
+        </ol>
+      </StyledComponent>
+    </Breadcrumbs__StyledList>
+    <HelmetWrapper
+      defer={true}
+      encodeSpecialCharacters={true}
+    >
+      <SideEffect(NullComponent)
+        defer={true}
+        encodeSpecialCharacters={true}
+        script={
+          Array [
+            Object {
+              "innerHTML": "
+{
+  \\"@context\\": \\"http://schema.org\\",
+  \\"@type\\": \\"BreadcrumbList\\",
+  \\"itemListElement\\": [{\\"@type\\":\\"ListItem\\",\\"position\\":1,\\"item\\":{\\"@id\\":\\"/\\",\\"name\\":\\"Home\\"}},{\\"@type\\":\\"ListItem\\",\\"position\\":2,\\"item\\":{\\"@id\\":\\"/mobility\\",\\"name\\":\\"Mobility\\"}},{\\"@type\\":\\"ListItem\\",\\"position\\":3,\\"item\\":{\\"@id\\":\\"/mobility/accessories\\",\\"name\\":\\"Accessories\\"}}]
+}
+",
+              "type": "application/ld+json",
+            },
+          ]
+        }
+      >
+        <NullComponent
+          defer={true}
+          encodeSpecialCharacters={true}
+          script={
+            Array [
+              Object {
+                "innerHTML": "
+{
+  \\"@context\\": \\"http://schema.org\\",
+  \\"@type\\": \\"BreadcrumbList\\",
+  \\"itemListElement\\": [{\\"@type\\":\\"ListItem\\",\\"position\\":1,\\"item\\":{\\"@id\\":\\"/\\",\\"name\\":\\"Home\\"}},{\\"@type\\":\\"ListItem\\",\\"position\\":2,\\"item\\":{\\"@id\\":\\"/mobility\\",\\"name\\":\\"Mobility\\"}},{\\"@type\\":\\"ListItem\\",\\"position\\":3,\\"item\\":{\\"@id\\":\\"/mobility/accessories\\",\\"name\\":\\"Accessories\\"}}]
+}
+",
+                "type": "application/ld+json",
+              },
+            ]
+          }
+        />
+      </SideEffect(NullComponent)>
+    </HelmetWrapper>
+  </nav>
+</Breadcrumbs>
 `;

--- a/packages/ChevronLink/ChevronLink.jsx
+++ b/packages/ChevronLink/ChevronLink.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
@@ -54,30 +54,35 @@ const getIcon = (symbol, direction) => (
  *
  * @version ./package.json
  */
-const ChevronLink = ({ reactRouterLinkComponent, variant, direction, children, ...rest }) => {
-  if ((reactRouterLinkComponent || rest.to) && !(reactRouterLinkComponent && rest.to)) {
-    warn('Chevron Link', 'The props `reactRouterLinkComponent` and `to` must be used together.')
+const ChevronLink = forwardRef(
+  ({ reactRouterLinkComponent, variant, direction, children, ...rest }, ref) => {
+    if ((reactRouterLinkComponent || rest.to) && !(reactRouterLinkComponent && rest.to)) {
+      warn('Chevron Link', 'The props `reactRouterLinkComponent` and `to` must be used together.')
+    }
+
+    const innerLink = (
+      <Box tag="span" inline between={2}>
+        {direction === 'left' ? getIcon('leftChevron', direction) : undefined}
+        <span>{children}</span>
+        {direction === 'right' ? getIcon('chevron', direction) : undefined}
+      </Box>
+    )
+
+    return (
+      <StyledChevronLink
+        {...safeRest(rest)}
+        as={reactRouterLinkComponent || 'a'}
+        variant={variant}
+        direction={direction}
+        ref={ref}
+      >
+        {innerLink}
+      </StyledChevronLink>
+    )
   }
+)
 
-  const innerLink = (
-    <Box tag="span" inline between={2}>
-      {direction === 'left' ? getIcon('leftChevron', direction) : undefined}
-      <span>{children}</span>
-      {direction === 'right' ? getIcon('chevron', direction) : undefined}
-    </Box>
-  )
-
-  return (
-    <StyledChevronLink
-      {...safeRest(rest)}
-      as={reactRouterLinkComponent || 'a'}
-      variant={variant}
-      direction={direction}
-    >
-      {innerLink}
-    </StyledChevronLink>
-  )
-}
+ChevronLink.displayName = 'ChevronLink'
 
 ChevronLink.propTypes = {
   /**

--- a/packages/ChevronLink/__tests__/ChevronLink.spec.jsx
+++ b/packages/ChevronLink/__tests__/ChevronLink.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { shallow, render } from 'enzyme'
+import { shallow, render, mount } from 'enzyme'
 
 import DecorativeIcon from '@tds/core-decorative-icon'
 import A11yContent from '../../A11yContent'
@@ -99,5 +99,27 @@ describe('ChevronLink', () => {
 
     expect(link).not.toHaveProp('className', 'my-custom-class')
     expect(link).not.toHaveProp('style')
+  })
+
+  it('forwards refs', () => {
+    const ref = React.createRef()
+
+    // Link component needs to be wrapped in order for the ref instance to work with Enzyme's mount
+    // https://github.com/airbnb/enzyme/issues/1852#issuecomment-433145879
+    const link = mount(
+      <>
+        <ChevronLink ref={ref} href="https://telus.com">
+          Go home
+        </ChevronLink>
+      </>
+    )
+
+    const target = link
+      .find('StyledComponent')
+      .at(0)
+      .childAt(0)
+      .instance()
+
+    expect(target).toEqual(ref.current)
   })
 })

--- a/packages/InteractiveIcon/InteractiveIcon.jsx
+++ b/packages/InteractiveIcon/InteractiveIcon.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import styled, { ThemeProvider } from 'styled-components'
 
@@ -78,15 +78,25 @@ const getTheme = variant => {
 /**
  * @version ./package.json
  */
-const InteractiveIcon = ({ a11yText, variant, onClick, children, tag, ...rest }) => (
-  <ThemeProvider theme={getTheme(variant)}>
-    <StyledInteractiveIconButton {...safeRest(rest)} variant={variant} onClick={onClick} as={tag}>
-      <A11yContent>{a11yText}</A11yContent>
-      <StyledInteractiveIconHover />
-      {children}
-    </StyledInteractiveIconButton>
-  </ThemeProvider>
+const InteractiveIcon = forwardRef(
+  ({ a11yText, variant, onClick, children, tag, ...rest }, ref) => (
+    <ThemeProvider theme={getTheme(variant)}>
+      <StyledInteractiveIconButton
+        {...safeRest(rest)}
+        variant={variant}
+        onClick={onClick}
+        as={tag}
+        ref={ref}
+      >
+        <A11yContent>{a11yText}</A11yContent>
+        <StyledInteractiveIconHover />
+        {children}
+      </StyledInteractiveIconButton>
+    </ThemeProvider>
+  )
 )
+
+InteractiveIcon.displayName = 'InteractiveIcon'
 
 InteractiveIcon.propTypes = {
   /**

--- a/packages/InteractiveIcon/__tests__/InteractiveIcon.spec.jsx
+++ b/packages/InteractiveIcon/__tests__/InteractiveIcon.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { shallow, render } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 
 import InteractiveIcon from '../InteractiveIcon'
 
@@ -12,7 +12,7 @@ describe('InteractiveIcon', () => {
     )
 
   it('renders', () => {
-    const interactiveIcon = render(
+    const interactiveIcon = mount(
       <InteractiveIcon a11yText="This is an interactive icon">
         <svg />
       </InteractiveIcon>
@@ -44,5 +44,23 @@ describe('InteractiveIcon', () => {
 
     expect(interactiveIcon).not.toHaveProp('className', 'my-custom-class')
     expect(interactiveIcon).not.toHaveProp('style')
+  })
+
+  it('forwards refs', () => {
+    const ref = React.createRef()
+    const interactiveIcon = mount(
+      <>
+        <InteractiveIcon ref={ref} a11yText="This is an interactive icon">
+          <svg />
+        </InteractiveIcon>
+      </>
+    )
+    const target = interactiveIcon
+      .find('StyledComponent')
+      .at(0)
+      .childAt(0)
+      .instance()
+
+    expect(target).toEqual(ref.current)
   })
 })

--- a/packages/InteractiveIcon/__tests__/__snapshots__/InteractiveIcon.spec.jsx.snap
+++ b/packages/InteractiveIcon/__tests__/__snapshots__/InteractiveIcon.spec.jsx.snap
@@ -84,17 +84,164 @@ exports[`InteractiveIcon renders 1`] = `
   }
 }
 
-<button
-  class="c0 c1"
+<InteractiveIcon
+  a11yText="This is an interactive icon"
+  tag="button"
+  variant="default"
 >
-  <span
-    class="c2"
+  <ThemeProvider
+    theme={
+      Object {
+        "backgroundColor": "#d8d8d8",
+        "iconColor": "#2a2c2e",
+      }
+    }
   >
-    This is an interactive icon
-  </span>
-  <span
-    class="c3"
-  />
-  <svg />
-</button>
+    <InteractiveIcon__StyledInteractiveIconButton
+      as="button"
+      variant="default"
+    >
+      <StyledComponent
+        as="button"
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "c0",
+              "isStatic": false,
+              "lastClassName": "c1",
+              "rules": Array [
+                "padding: 0;",
+                "margin: 0;",
+                "border-width: 0;",
+                "font-family: \\"TELUS-Web\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif;",
+                "color: #2a2c2e;",
+                "appearance: none;",
+                "background: none;",
+                "box-shadow: none;",
+                "cursor: pointer;",
+                [Function],
+                "width: 40px;",
+                "height: 40px;",
+                "display: inline-flex;",
+                "justify-content: center;",
+                "align-items: center;",
+                "position: relative;",
+                "&:hover svg {",
+                "transform: scale(1.1, 1.1);",
+                "}",
+                "&:active svg {",
+                "transform: scale(1, 1);",
+                "}",
+                "-webkit-tap-highlight-color: transparent;",
+              ],
+            },
+            "displayName": "InteractiveIcon__StyledInteractiveIconButton",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "c0",
+            "target": "button",
+            "toString": [Function],
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
+        }
+        forwardedRef={null}
+        variant="default"
+      >
+        <button
+          className="c0 c1"
+        >
+          <A11yContent>
+            <A11yContent__StyledA11yContent>
+              <StyledComponent
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
+                      "isStatic": true,
+                      "lastClassName": "c2",
+                      "rules": Array [
+                        "position: absolute;",
+                        "height: 1px;",
+                        "width: 1px;",
+                        "overflow: hidden;",
+                        "clip: rect(1px, 1px, 1px, 1px);",
+                      ],
+                    },
+                    "displayName": "A11yContent__StyledA11yContent",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
+                    "target": "span",
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+              >
+                <span
+                  className="c2"
+                >
+                  This is an interactive icon
+                </span>
+              </StyledComponent>
+            </A11yContent__StyledA11yContent>
+          </A11yContent>
+          <InteractiveIcon__StyledInteractiveIconHover>
+            <StyledComponent
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "InteractiveIcon__StyledInteractiveIconHover-sc-1pxz8wd-2",
+                    "isStatic": false,
+                    "lastClassName": "c3",
+                    "rules": Array [
+                      [Function],
+                      "position: absolute;",
+                      "top: 0;",
+                      "left: 0;",
+                      "width: 100%;",
+                      "height: 100%;",
+                      "z-index: 1;",
+                      "border-radius: 50%;",
+                      "transition: transform 200ms ease-in-out;",
+                      "@media (prefers-reduced-motion: reduce) {",
+                      "transition: none;",
+                      "}",
+                      "transform: scale(0,0);",
+                      ".c0:focus &, .c0:active & {",
+                      "transform: scale(1,1);",
+                      "}",
+                    ],
+                  },
+                  "displayName": "InteractiveIcon__StyledInteractiveIconHover",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "InteractiveIcon__StyledInteractiveIconHover-sc-1pxz8wd-2",
+                  "target": "span",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
+                }
+              }
+              forwardedRef={null}
+            >
+              <span
+                className="c3"
+              />
+            </StyledComponent>
+          </InteractiveIcon__StyledInteractiveIconHover>
+          <svg />
+        </button>
+      </StyledComponent>
+    </InteractiveIcon__StyledInteractiveIconButton>
+  </ThemeProvider>
+</InteractiveIcon>
 `;

--- a/packages/InteractiveIcon/svgs/Add.jsx
+++ b/packages/InteractiveIcon/svgs/Add.jsx
@@ -1,9 +1,9 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 
 import InteractiveIcon, { StyledInteractiveIconSVG } from '../InteractiveIcon'
 
-const Add = props => (
-  <InteractiveIcon {...props}>
+const Add = forwardRef((props, ref) => (
+  <InteractiveIcon {...props} ref={ref}>
     <StyledInteractiveIconSVG width="24" height="24" viewBox="0 0 24 24">
       <path
         d="M12 24C5.383 24 0 18.617 0 12S5.383 0 12 0s12 5.383 12 12-5.383 12-12 12zm0-22.957C5.958 1.043 1.043 5.958 1.043 12c0 6.042 4.915 10.957 10.957 10.957 6.042 0 10.957-4.915 10.957-10.957 0-6.042-4.915-10.957-10.957-10.957zm-.697 11.654l-5.7-.176A.632.632 0 0 1 5 11.892v.21c0-.332.27-.605.602-.605h5.697v-.1l.178-5.791a.64.64 0 0 1 .63-.606h-.209c.334 0 .605.267.605.602v5.895h5.895c.335 0 .602.27.602.605v-.21a.64.64 0 0 1-.606.63l-5.79.178-.101.001v5.697a.605.605 0 0 1-.605.602h.21a.632.632 0 0 1-.63-.603l-.175-5.7z"
@@ -11,6 +11,8 @@ const Add = props => (
       />
     </StyledInteractiveIconSVG>
   </InteractiveIcon>
-)
+))
+
+Add.displayName = 'Add'
 
 export default Add

--- a/packages/InteractiveIcon/svgs/Close.jsx
+++ b/packages/InteractiveIcon/svgs/Close.jsx
@@ -1,9 +1,9 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 
 import InteractiveIcon, { StyledInteractiveIconSVG } from '../InteractiveIcon'
 
-const Close = props => (
-  <InteractiveIcon {...props}>
+const Close = forwardRef((props, ref) => (
+  <InteractiveIcon {...props} ref={ref}>
     <StyledInteractiveIconSVG width="24" height="24" viewBox="0 0 24 24">
       <path
         d="M12 12.707l-4.147 4.146a.498.498 0 0 1-.707 0 .5.5 0 0 1 0-.707L11.293 12 7.146 7.853a.5.5 0 0 1 .707-.707L12 11.293l4.146-4.147a.5.5 0 0 1 .707.707L12.707 12l4.146 4.146a.5.5 0 0 1-.707.707L12 12.707zM12 24C5.383 24 0 18.617 0 12S5.383 0 12 0s12 5.383 12 12-5.383 12-12 12zm0-22.957C5.958 1.043 1.043 5.958 1.043 12c0 6.042 4.915 10.957 10.957 10.957 6.042 0 10.957-4.915 10.957-10.957 0-6.042-4.915-10.957-10.957-10.957z"
@@ -11,6 +11,8 @@ const Close = props => (
       />
     </StyledInteractiveIconSVG>
   </InteractiveIcon>
-)
+))
+
+Close.displayName = 'Close'
 
 export default Close

--- a/packages/InteractiveIcon/svgs/PlayVideo.jsx
+++ b/packages/InteractiveIcon/svgs/PlayVideo.jsx
@@ -1,9 +1,9 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 
 import InteractiveIcon, { StyledInteractiveIconSVG } from '../InteractiveIcon'
 
-const PlayVideo = props => (
-  <InteractiveIcon {...props}>
+const PlayVideo = forwardRef((props, ref) => (
+  <InteractiveIcon {...props} ref={ref}>
     <StyledInteractiveIconSVG width="24" height="24" viewBox="0 0 24 24">
       <path
         d="M12 24C5.383 24 0 18.617 0 12S5.383 0 12 0s12 5.383 12 12-5.383 12-12 12zm0-22.957C5.958 1.043 1.043 5.958 1.043 12c0 6.042 4.915 10.957 10.957 10.957 6.042 0 10.957-4.915 10.957-10.957 0-6.042-4.915-10.957-10.957-10.957zM9.4 17c-.08 0-.16 0-.16-.077-.16 0-.24-.155-.24-.31v-9.27c0-.154.08-.309.24-.309.16 0 .32-.077.4 0l7.2 4.636c.08.077.16.154.16.309 0 .154-.08.231-.16.309l-7.2 4.635C9.56 17 9.48 17 9.4 17zm.4-8.961v7.802l6.08-3.94L9.8 8.04z"
@@ -11,6 +11,8 @@ const PlayVideo = props => (
       />
     </StyledInteractiveIconSVG>
   </InteractiveIcon>
-)
+))
+
+PlayVideo.displayName = 'PlayVideo'
 
 export default PlayVideo

--- a/packages/InteractiveIcon/svgs/Subtract.jsx
+++ b/packages/InteractiveIcon/svgs/Subtract.jsx
@@ -1,9 +1,9 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 
 import InteractiveIcon, { StyledInteractiveIconSVG } from '../InteractiveIcon'
 
-const Subtract = props => (
-  <InteractiveIcon {...props}>
+const Subtract = forwardRef((props, ref) => (
+  <InteractiveIcon {...props} ref={ref}>
     <StyledInteractiveIconSVG width="24" height="24" viewBox="0 0 24 24">
       <path
         d="M12 24C5.383 24 0 18.617 0 12S5.383 0 12 0s12 5.383 12 12-5.383 12-12 12zm0-22.957C5.958 1.043 1.043 5.958 1.043 12c0 6.042 4.915 10.957 10.957 10.957 6.042 0 10.957-4.915 10.957-10.957 0-6.042-4.915-10.957-10.957-10.957zM12 11l6.303.162c.387.01.697.329.697.712v-.388a.737.737 0 0 1-.7.723s-3.96.178-6.3.178c-1.994 0-6.3-.18-6.3-.18a.726.726 0 0 1-.7-.721v.388c0-.378.312-.702.697-.712L12 11z"
@@ -11,6 +11,8 @@ const Subtract = props => (
       />
     </StyledInteractiveIconSVG>
   </InteractiveIcon>
-)
+))
+
+Subtract.displayName = 'Subtract'
 
 export default Subtract

--- a/packages/Link/Link.jsx
+++ b/packages/Link/Link.jsx
@@ -6,6 +6,8 @@ import { colorShark, colorWhite } from '@tds/core-colours'
 import { links } from '@tds/shared-styles'
 import { safeRest } from '@tds/util-helpers'
 
+import { withForwardedRef } from '@tds/shared-hocs'
+
 import { warn } from '../../shared/utils/warn'
 
 const base = {
@@ -39,7 +41,7 @@ const StyledLink = styled.a(base, ({ invert, context }) => {
 /**
  * @version ./package.json
  */
-const Link = ({ reactRouterLinkComponent, invert, children, ...rest }, context) => {
+const Link = ({ reactRouterLinkComponent, invert, children, forwardedRef, ...rest }, context) => {
   if (!(reactRouterLinkComponent && rest.to) && (reactRouterLinkComponent || rest.to)) {
     warn('Link', 'The props `reactRouterLinkComponent` and `to` must be used together.')
   }
@@ -50,6 +52,7 @@ const Link = ({ reactRouterLinkComponent, invert, children, ...rest }, context) 
       as={reactRouterLinkComponent || 'a'}
       invert={invert}
       context={context}
+      ref={forwardedRef}
     >
       {children}
     </StyledLink>
@@ -76,16 +79,19 @@ Link.propTypes = {
    * Link text.
    */
   children: PropTypes.node.isRequired,
+  /* @ignore */
+  forwardedRef: PropTypes.object,
 }
 Link.defaultProps = {
   reactRouterLinkComponent: null,
   to: null,
   href: null,
   invert: false,
+  forwardedRef: undefined,
 }
 
 Link.contextTypes = {
   inheritColor: PropTypes.bool,
 }
 
-export default Link
+export default withForwardedRef(Link)

--- a/packages/Link/__tests__/Link.spec.jsx
+++ b/packages/Link/__tests__/Link.spec.jsx
@@ -13,6 +13,7 @@ describe('Link', () => {
     const link = mount(<Link {...overrides}>Some content</Link>)
     return {
       link: link.find(overrides.reactRouterLinkComponent || 'a'),
+      wrapper: link,
     }
   }
   afterEach(() => {
@@ -45,8 +46,6 @@ describe('Link', () => {
 
     expect(warn).toHaveBeenCalled()
 
-    jest.clearAllMocks()
-
     link = doShallow({ to: '/about' })
 
     expect(link).toHaveProp('to')
@@ -71,9 +70,28 @@ describe('Link', () => {
   })
 
   it('does not allow custom CSS', () => {
-    const link = doShallow({ className: 'my-custom-class', style: { color: 'hotpink' } })
+    const link = doMount({ className: 'my-custom-class', style: { color: 'hotpink' } })
 
-    expect(link).not.toHaveProp('className', 'my-custom-class')
-    expect(link).not.toHaveProp('style')
+    expect(link.link.hasClass('my-custom-class')).toEqual(false)
+    expect(link.link).not.toHaveProp('style')
+  })
+
+  it('forwards refs', () => {
+    const ref = React.createRef()
+
+    // Link component needs to be wrapped in order for the ref instance to work with Enzyme's mount
+    // https://github.com/airbnb/enzyme/issues/1852#issuecomment-433145879
+    const link = mount(
+      <>
+        <Link ref={ref}>Link</Link>
+      </>
+    )
+
+    const target = link
+      .find('StyledComponent')
+      .childAt(0)
+      .instance()
+
+    expect(target).toEqual(ref.current)
   })
 })

--- a/packages/Link/__tests__/__snapshots__/Link.spec.jsx.snap
+++ b/packages/Link/__tests__/__snapshots__/Link.spec.jsx.snap
@@ -25,6 +25,96 @@ Object {
   >
     Some content
   </a>,
+  "wrapper": .c0:focus {
+  outline: auto 5px -webkit-focus-ring-color;
+}
+
+.c0:link,
+.c0:visited {
+  color: #2a2c2e;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+<WithForwardedRef(Link)>
+    <Link
+      forwardedRef={null}
+      href={null}
+      invert={false}
+      reactRouterLinkComponent={null}
+      to={null}
+    >
+      <Link__StyledLink
+        as="a"
+        context={
+          Object {
+            "inheritColor": undefined,
+          }
+        }
+        href={null}
+        invert={false}
+        to={null}
+      >
+        <StyledComponent
+          as="a"
+          context={
+            Object {
+              "inheritColor": undefined,
+            }
+          }
+          forwardedComponent={
+            Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "attrs": Array [],
+              "componentStyle": ComponentStyle {
+                "componentId": "Link__StyledLink-sc-1bokult-0",
+                "isStatic": false,
+                "lastClassName": "c0",
+                "rules": Array [
+                  ":focus {",
+                  "outline: auto 5px -webkit-focus-ring-color;",
+                  "}",
+                  "&:link,&:visited {",
+                  "color: #2a2c2e;",
+                  "text-decoration: underline;",
+                  "}",
+                  "&:hover {",
+                  "text-decoration: none;",
+                  "}",
+                  [Function],
+                ],
+              },
+              "displayName": "Link__StyledLink",
+              "foldedComponentIds": Array [],
+              "render": [Function],
+              "styledComponentId": "Link__StyledLink-sc-1bokult-0",
+              "target": "a",
+              "toString": [Function],
+              "warnTooManyClasses": [Function],
+              "withComponent": [Function],
+            }
+          }
+          forwardedRef={null}
+          href={null}
+          invert={false}
+          to={null}
+        >
+          <a
+            className="c0"
+            href={null}
+            to={null}
+          >
+            Some content
+          </a>
+        </StyledComponent>
+      </Link__StyledLink>
+    </Link>
+  </WithForwardedRef(Link)>,
 }
 `;
 
@@ -58,21 +148,114 @@ Object {
   >
     Some content
   </a>,
+  "wrapper": .c0:focus {
+  outline: auto 5px -webkit-focus-ring-color;
+}
+
+.c0:link,
+.c0:visited {
+  color: #2a2c2e;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0:link,
+.c0:visited {
+  color: #fff;
+}
+
+<WithForwardedRef(Link)
+    invert={true}
+  >
+    <Link
+      forwardedRef={null}
+      href={null}
+      invert={true}
+      reactRouterLinkComponent={null}
+      to={null}
+    >
+      <Link__StyledLink
+        as="a"
+        context={
+          Object {
+            "inheritColor": undefined,
+          }
+        }
+        href={null}
+        invert={true}
+        to={null}
+      >
+        <StyledComponent
+          as="a"
+          context={
+            Object {
+              "inheritColor": undefined,
+            }
+          }
+          forwardedComponent={
+            Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "attrs": Array [],
+              "componentStyle": ComponentStyle {
+                "componentId": "Link__StyledLink-sc-1bokult-0",
+                "isStatic": false,
+                "lastClassName": "c0",
+                "rules": Array [
+                  ":focus {",
+                  "outline: auto 5px -webkit-focus-ring-color;",
+                  "}",
+                  "&:link,&:visited {",
+                  "color: #2a2c2e;",
+                  "text-decoration: underline;",
+                  "}",
+                  "&:hover {",
+                  "text-decoration: none;",
+                  "}",
+                  [Function],
+                ],
+              },
+              "displayName": "Link__StyledLink",
+              "foldedComponentIds": Array [],
+              "render": [Function],
+              "styledComponentId": "Link__StyledLink-sc-1bokult-0",
+              "target": "a",
+              "toString": [Function],
+              "warnTooManyClasses": [Function],
+              "withComponent": [Function],
+            }
+          }
+          forwardedRef={null}
+          href={null}
+          invert={true}
+          to={null}
+        >
+          <a
+            className="c0"
+            href={null}
+            to={null}
+          >
+            Some content
+          </a>
+        </StyledComponent>
+      </Link__StyledLink>
+    </Link>
+  </WithForwardedRef(Link)>,
 }
 `;
 
 exports[`Link renders 1`] = `
-<Link__StyledLink
-  as="a"
-  context={
-    Object {
-      "inheritColor": undefined,
-    }
-  }
+<Link
+  forwardedRef={null}
   href={null}
   invert={false}
+  reactRouterLinkComponent={null}
   to={null}
 >
   Go home
-</Link__StyledLink>
+</Link>
 `;

--- a/packages/Link/package.json
+++ b/packages/Link/package.json
@@ -25,6 +25,7 @@
     "styled-components": "^4.1.3"
   },
   "dependencies": {
+    "@tds/shared-hocs": "^1.1.0",
     "@tds/shared-styles": "^1.5.0",
     "@tds/util-helpers": "^1.2.0",
     "prop-types": "^15.5.10"

--- a/packages/TermsAndConditions/TermsAndConditions.jsx
+++ b/packages/TermsAndConditions/TermsAndConditions.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef, forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
@@ -52,114 +52,120 @@ const calculateSpeed = (height, isExpanding) => {
 /**
  * @version ./package.json
  */
-const TermsAndConditions = ({ copy, indexedContent, nonIndexedContent, ...rest }) => {
-  const contentWrapper = useRef(null)
-  const [isOpen, setOpen] = useState(false)
-  const [contentWrapperHeight, setContentWrapperHeight] = useState(0)
-  const speed = calculateSpeed(contentWrapperHeight, isOpen)
+const TermsAndConditions = forwardRef(
+  ({ copy, indexedContent, nonIndexedContent, ...rest }, ref) => {
+    const contentWrapper = useRef(null)
+    const [isOpen, setOpen] = useState(false)
+    const [contentWrapperHeight, setContentWrapperHeight] = useState(0)
+    const speed = calculateSpeed(contentWrapperHeight, isOpen)
 
-  const hasIndexedContent = indexedContent.length > 0
-  const hasNonIndexedContent = nonIndexedContent.length > 0
+    const hasIndexedContent = indexedContent.length > 0
+    const hasNonIndexedContent = nonIndexedContent.length > 0
 
-  useEffect(() => {
-    if (contentWrapper.current.offsetHeight !== contentWrapperHeight) {
-      setContentWrapperHeight(() => {
-        return contentWrapper.current.offsetHeight
-      })
-    }
-  }, [contentWrapperHeight])
+    useEffect(() => {
+      if (contentWrapper.current.offsetHeight !== contentWrapperHeight) {
+        setContentWrapperHeight(() => {
+          return contentWrapper.current.offsetHeight
+        })
+      }
+    }, [contentWrapperHeight])
 
-  return (
-    <div {...safeRest(rest)}>
-      <HairlineDivider />
-      <FlexGrid gutter={false} limitWidth={false}>
-        <FlexGrid.Row>
-          <FlexGrid.Col>
-            <StyledClickableHeading onClick={() => setOpen(!isOpen)}>
-              <StyledExpandCollapseHeading inline vertical={3} between={3}>
-                <StyledChevronContainer>
-                  <Circle />
-                  <Chevron isOpen={isOpen} />
-                </StyledChevronContainer>
-                <Heading level="h4" tag="h2">
-                  {!isOpen
-                    ? getCopy(copyDictionary, copy).headingView
-                    : getCopy(copyDictionary, copy).headingHide}
-                </Heading>
-              </StyledExpandCollapseHeading>
-            </StyledClickableHeading>
-          </FlexGrid.Col>
-        </FlexGrid.Row>
-      </FlexGrid>
-      <FadeAndReveal
-        timeout={isOpen ? speed : 0}
-        duration={speed}
-        in={isOpen}
-        height={contentWrapperHeight}
-      >
-        {() => (
-          <div ref={contentWrapper}>
-            <FlexGrid gutter={false} limitWidth={false}>
-              <FlexGrid.Row>
-                <FlexGrid.Col>
-                  <DimpleDivider />
-                </FlexGrid.Col>
-              </FlexGrid.Row>
-            </FlexGrid>
-            <Translate
-              timeout={speed}
-              in={isOpen}
-              direction="y"
-              distance={isOpen ? '0rem' : '1rem'}
-              initialStyle={{ transform: 'translateY(1rem)' }}
-            >
-              {() => (
-                <>
-                  {hasIndexedContent > 0 && (
-                    <FlexGrid>
-                      <FlexGrid.Row>
-                        <FlexGrid.Col xs={12} mdOffset={1} md={10}>
-                          <List size="small" below={4} type="indexed">
-                            {indexedContent.map(c => (
-                              <List.Item key={c}>{renderContent(c)}</List.Item>
-                            ))}
-                          </List>
-                        </FlexGrid.Col>
-                      </FlexGrid.Row>
-                    </FlexGrid>
-                  )}
-                  {hasNonIndexedContent && (
-                    <FlexGrid>
-                      <FlexGrid.Row>
-                        <FlexGrid.Col xs={12} mdOffset={1} md={10}>
-                          <Box between={3}>
-                            {hasIndexedContent && (
-                              <div css={{ paddingLeft: '2rem' }}>
-                                <Heading level="h4" tag="span">
-                                  {getCopy(copyDictionary, copy).nonIndexedTitle}
-                                </Heading>
-                              </div>
-                            )}
-                            <List size="small" below={4} type="nonIndexed">
-                              {nonIndexedContent.map(c => (
+    return (
+      <div {...safeRest(rest)}>
+        <HairlineDivider />
+        <FlexGrid gutter={false} limitWidth={false}>
+          <FlexGrid.Row>
+            <FlexGrid.Col>
+              <StyledClickableHeading ref={ref} onClick={() => setOpen(!isOpen)}>
+                <StyledExpandCollapseHeading inline vertical={3} between={3}>
+                  <StyledChevronContainer>
+                    <Circle />
+                    <Chevron isOpen={isOpen} />
+                  </StyledChevronContainer>
+                  <Heading level="h4" tag="h2">
+                    {!isOpen
+                      ? getCopy(copyDictionary, copy).headingView
+                      : getCopy(copyDictionary, copy).headingHide}
+                  </Heading>
+                </StyledExpandCollapseHeading>
+              </StyledClickableHeading>
+            </FlexGrid.Col>
+          </FlexGrid.Row>
+        </FlexGrid>
+        <FadeAndReveal
+          timeout={isOpen ? speed : 0}
+          duration={speed}
+          in={isOpen}
+          height={contentWrapperHeight}
+        >
+          {() => (
+            <div ref={contentWrapper}>
+              <FlexGrid gutter={false} limitWidth={false}>
+                <FlexGrid.Row>
+                  <FlexGrid.Col>
+                    <DimpleDivider />
+                  </FlexGrid.Col>
+                </FlexGrid.Row>
+              </FlexGrid>
+              <Translate
+                timeout={speed}
+                in={isOpen}
+                direction="y"
+                distance={isOpen ? '0rem' : '1rem'}
+                initialStyle={{ transform: 'translateY(1rem)' }}
+              >
+                {() => (
+                  <>
+                    {hasIndexedContent > 0 && (
+                      <FlexGrid>
+                        <FlexGrid.Row>
+                          <FlexGrid.Col xs={12} mdOffset={1} md={10}>
+                            <List size="small" below={4} type="indexed">
+                              {indexedContent.map(c => (
                                 <List.Item key={c}>{renderContent(c)}</List.Item>
                               ))}
                             </List>
-                          </Box>
-                        </FlexGrid.Col>
-                      </FlexGrid.Row>
-                    </FlexGrid>
-                  )}
-                </>
-              )}
-            </Translate>
-          </div>
-        )}
-      </FadeAndReveal>
-      <HairlineDivider />
-    </div>
-  )
-}
+                          </FlexGrid.Col>
+                        </FlexGrid.Row>
+                      </FlexGrid>
+                    )}
+                    {hasNonIndexedContent && (
+                      <FlexGrid>
+                        <FlexGrid.Row>
+                          <FlexGrid.Col xs={12} mdOffset={1} md={10}>
+                            <Box between={3}>
+                              {hasIndexedContent && (
+                                <div css={{ paddingLeft: '2rem' }}>
+                                  <Heading level="h4" tag="span">
+                                    {getCopy(copyDictionary, copy).nonIndexedTitle}
+                                  </Heading>
+                                </div>
+                              )}
+                              <List size="small" below={4} type="nonIndexed">
+                                {nonIndexedContent.map(c => (
+                                  <List.Item key={c}>{renderContent(c)}</List.Item>
+                                ))}
+                              </List>
+                            </Box>
+                          </FlexGrid.Col>
+                        </FlexGrid.Row>
+                      </FlexGrid>
+                    )}
+                  </>
+                )}
+              </Translate>
+            </div>
+          )}
+        </FadeAndReveal>
+        <HairlineDivider />
+      </div>
+    )
+  }
+)
+
+// StyledClickableHeading.displayName = 'StyledClickableHeading'
+
+TermsAndConditions.displayName = 'TermsAndConditions'
 
 TermsAndConditions.propTypes = {
   /**

--- a/packages/TermsAndConditions/__tests__/TermsAndConditions.spec.jsx
+++ b/packages/TermsAndConditions/__tests__/TermsAndConditions.spec.jsx
@@ -61,4 +61,20 @@ describe('TermsAndConditions', () => {
     expect(termsAndConditions).not.toHaveProp('className', 'my-custom-class')
     expect(termsAndConditions).not.toHaveProp('style')
   })
+
+  it('forwards refs', () => {
+    const ref = React.createRef()
+    const termsAndConditions = mount(
+      <>
+        <TermsAndConditions ref={ref} {...defaultProps} />
+      </>
+    )
+
+    const target = termsAndConditions
+      .find('Styled(StyledClickable)')
+      .find('button')
+      .instance()
+
+    expect(target).toEqual(ref.current)
+  })
 })

--- a/packages/Tooltip/Tooltip.jsx
+++ b/packages/Tooltip/Tooltip.jsx
@@ -6,6 +6,7 @@ import StandaloneIcon from '@tds/core-standalone-icon'
 
 import { iconWrapper } from '@tds/shared-styles'
 import { getCopy, uniqueId, safeRest } from '@tds/util-helpers'
+import { withForwardedRef } from '@tds/shared-hocs'
 
 import generateId from '../../shared/utils/generateId/generateId'
 import closest from './element-closest'
@@ -118,7 +119,7 @@ class Tooltip extends React.Component {
   }
 
   render() {
-    const { direction, connectedFieldLabel, copy, children, ...rest } = this.props
+    const { direction, connectedFieldLabel, copy, children, forwardedRef, ...rest } = this.props
 
     const { bubbleId, triggerId } = this.getIds(connectedFieldLabel)
 
@@ -140,7 +141,7 @@ class Tooltip extends React.Component {
     }
 
     return (
-      <StyledTooltip {...safeRest(rest)} ref={this.setTooltipRef}>
+      <StyledTooltip {...safeRest(rest)} ref={forwardedRef || this.setTooltipRef}>
         <TooltipContainer data-testid="tooltipContainer">
           <Bubble id={bubbleId} direction={trueDirection} open={this.state.open} width={width}>
             {children}
@@ -195,12 +196,15 @@ Tooltip.propTypes = {
    * If a tooltip id is not provided, a unique tooltip id will be generated.
    */
   tooltipId: PropTypes.string,
+  /* @ignore */
+  forwardedRef: PropTypes.object,
 }
 
 Tooltip.defaultProps = {
   direction: 'auto',
   connectedFieldLabel: undefined,
   tooltipId: undefined,
+  forwardedRef: undefined,
 }
 
-export default Tooltip
+export default withForwardedRef(Tooltip)

--- a/packages/Tooltip/__tests__/Tooltip.spec.jsx
+++ b/packages/Tooltip/__tests__/Tooltip.spec.jsx
@@ -166,4 +166,23 @@ describe('Tooltip', () => {
 
     expect(tooltip.find(StandaloneIcon)).toHaveProp('a11yText', 'Reveal additional information.')
   })
+
+  it('forwards refs', () => {
+    const ref = React.createRef()
+    const tooltip = mount(
+      <>
+        <Tooltip ref={ref} copy="en">
+          Tooltip text
+        </Tooltip>
+      </>
+    )
+
+    const target = tooltip
+      .find('StyledComponent')
+      .at(0)
+      .childAt(0)
+      .instance()
+
+    expect(target).toEqual(ref.current)
+  })
 })

--- a/packages/Tooltip/__tests__/__snapshots__/Tooltip.spec.jsx.snap
+++ b/packages/Tooltip/__tests__/__snapshots__/Tooltip.spec.jsx.snap
@@ -136,109 +136,98 @@ exports[`Tooltip accessibility accepts custom copy 1`] = `
   }
 }
 
-<Tooltip
+<WithForwardedRef(Tooltip)
   copy={
     Object {
       "a11yText": "This is custom copy.",
     }
   }
-  direction="auto"
 >
-  <Tooltip__StyledTooltip>
-    <StyledComponent
-      forwardedComponent={
-        Object {
-          "$$typeof": Symbol(react.forward_ref),
-          "attrs": Array [],
-          "componentStyle": ComponentStyle {
-            "componentId": "Tooltip__StyledTooltip-sc-2tc47i-0",
-            "isStatic": true,
-            "lastClassName": "c0",
-            "rules": Array [
-              "line-height: 1;",
-              "position: relative;",
-              "width: 1rem;",
-              "height: 1.3rem;",
-            ],
-          },
-          "displayName": "Tooltip__StyledTooltip",
-          "foldedComponentIds": Array [],
-          "render": [Function],
-          "styledComponentId": "Tooltip__StyledTooltip-sc-2tc47i-0",
-          "target": "div",
-          "toString": [Function],
-          "warnTooManyClasses": [Function],
-          "withComponent": [Function],
-        }
+  <Tooltip
+    copy={
+      Object {
+        "a11yText": "This is custom copy.",
       }
-      forwardedRef={[Function]}
-    >
-      <div
-        className="c0"
+    }
+    direction="auto"
+    forwardedRef={null}
+  >
+    <Tooltip__StyledTooltip>
+      <StyledComponent
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "Tooltip__StyledTooltip-sc-2tc47i-0",
+              "isStatic": true,
+              "lastClassName": "c0",
+              "rules": Array [
+                "line-height: 1;",
+                "position: relative;",
+                "width: 1rem;",
+                "height: 1.3rem;",
+              ],
+            },
+            "displayName": "Tooltip__StyledTooltip",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "Tooltip__StyledTooltip-sc-2tc47i-0",
+            "target": "div",
+            "toString": [Function],
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
+        }
+        forwardedRef={[Function]}
       >
-        <Tooltip__TooltipContainer
-          data-testid="tooltipContainer"
+        <div
+          className="c0"
         >
-          <StyledComponent
+          <Tooltip__TooltipContainer
             data-testid="tooltipContainer"
-            forwardedComponent={
-              Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "attrs": Array [],
-                "componentStyle": ComponentStyle {
-                  "componentId": "Tooltip__TooltipContainer-sc-2tc47i-1",
-                  "isStatic": true,
-                  "lastClassName": "c1",
-                  "rules": Array [
-                    "position: absolute;",
-                  ],
-                },
-                "displayName": "Tooltip__TooltipContainer",
-                "foldedComponentIds": Array [],
-                "render": [Function],
-                "styledComponentId": "Tooltip__TooltipContainer-sc-2tc47i-1",
-                "target": "div",
-                "toString": [Function],
-                "warnTooManyClasses": [Function],
-                "withComponent": [Function],
-              }
-            }
-            forwardedRef={null}
           >
-            <div
-              className="c1"
+            <StyledComponent
               data-testid="tooltipContainer"
-            >
-              <Bubble
-                direction="right"
-                id="standalone-tooltip-tooltip9_tooltip"
-                open={false}
-                width={
-                  Object {
-                    "width": "calc(1008px - 1rem - 0.5rem)",
-                  }
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "Tooltip__TooltipContainer-sc-2tc47i-1",
+                    "isStatic": true,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "position: absolute;",
+                    ],
+                  },
+                  "displayName": "Tooltip__TooltipContainer",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "Tooltip__TooltipContainer-sc-2tc47i-1",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
                 }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="c1"
+                data-testid="tooltipContainer"
               >
-                <Styled(Component)
-                  aria-hidden="true"
-                  aria-live="assertive"
-                  bubbleDimensions={
-                    Object {
-                      "bubbleOffset": "7px",
-                      "bubbleTriangleHeight": "10px",
-                      "bubbleTrianglePosition": "12px",
-                      "bubbleTriangleWidth": "7px",
-                      "bubbleTriggerSize": "24px",
-                    }
-                  }
+                <Bubble
                   direction="right"
-                  horizontal={3}
                   id="standalone-tooltip-tooltip9_tooltip"
                   open={false}
-                  role="tooltip"
-                  vertical={2}
+                  width={
+                    Object {
+                      "width": "calc(1008px - 1rem - 0.5rem)",
+                    }
+                  }
                 >
-                  <StyledComponent
+                  <Styled(Component)
                     aria-hidden="true"
                     aria-live="assertive"
                     bubbleDimensions={
@@ -251,39 +240,13 @@ exports[`Tooltip accessibility accepts custom copy 1`] = `
                       }
                     }
                     direction="right"
-                    forwardedComponent={
-                      Object {
-                        "$$typeof": Symbol(react.forward_ref),
-                        "attrs": Array [
-                          [Function],
-                        ],
-                        "componentStyle": ComponentStyle {
-                          "componentId": "sc-bwzfXH",
-                          "isStatic": false,
-                          "lastClassName": "c2",
-                          "rules": Array [
-                            "border-radius: 4px;",
-                            [Function],
-                          ],
-                        },
-                        "displayName": "Styled(Component)",
-                        "foldedComponentIds": Array [],
-                        "render": [Function],
-                        "styledComponentId": "sc-bwzfXH",
-                        "target": [Function],
-                        "toString": [Function],
-                        "warnTooManyClasses": [Function],
-                        "withComponent": [Function],
-                      }
-                    }
-                    forwardedRef={null}
                     horizontal={3}
                     id="standalone-tooltip-tooltip9_tooltip"
                     open={false}
                     role="tooltip"
                     vertical={2}
                   >
-                    <Component
+                    <StyledComponent
                       aria-hidden="true"
                       aria-live="assertive"
                       bubbleDimensions={
@@ -295,28 +258,61 @@ exports[`Tooltip accessibility accepts custom copy 1`] = `
                           "bubbleTriggerSize": "24px",
                         }
                       }
-                      className="c2"
-                      data-testid="bubble"
                       direction="right"
+                      forwardedComponent={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "attrs": Array [
+                            [Function],
+                          ],
+                          "componentStyle": ComponentStyle {
+                            "componentId": "sc-bwzfXH",
+                            "isStatic": false,
+                            "lastClassName": "c2",
+                            "rules": Array [
+                              "border-radius: 4px;",
+                              [Function],
+                            ],
+                          },
+                          "displayName": "Styled(Component)",
+                          "foldedComponentIds": Array [],
+                          "render": [Function],
+                          "styledComponentId": "sc-bwzfXH",
+                          "target": [Function],
+                          "toString": [Function],
+                          "warnTooManyClasses": [Function],
+                          "withComponent": [Function],
+                        }
+                      }
+                      forwardedRef={null}
                       horizontal={3}
                       id="standalone-tooltip-tooltip9_tooltip"
                       open={false}
                       role="tooltip"
                       vertical={2}
                     >
-                      <Box
+                      <Component
                         aria-hidden="true"
                         aria-live="assertive"
+                        bubbleDimensions={
+                          Object {
+                            "bubbleOffset": "7px",
+                            "bubbleTriangleHeight": "10px",
+                            "bubbleTrianglePosition": "12px",
+                            "bubbleTriangleWidth": "7px",
+                            "bubbleTriggerSize": "24px",
+                          }
+                        }
                         className="c2"
                         data-testid="bubble"
+                        direction="right"
                         horizontal={3}
                         id="standalone-tooltip-tooltip9_tooltip"
-                        inline={false}
+                        open={false}
                         role="tooltip"
-                        tag="div"
                         vertical={2}
                       >
-                        <styled.div
+                        <Box
                           aria-hidden="true"
                           aria-live="assertive"
                           className="c2"
@@ -328,41 +324,11 @@ exports[`Tooltip accessibility accepts custom copy 1`] = `
                           tag="div"
                           vertical={2}
                         >
-                          <StyledComponent
+                          <styled.div
                             aria-hidden="true"
                             aria-live="assertive"
                             className="c2"
                             data-testid="bubble"
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "attrs": Array [
-                                  [Function],
-                                ],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "sc-bdVaJa",
-                                  "isStatic": false,
-                                  "lastClassName": "c3",
-                                  "rules": Array [
-                                    [Function],
-                                    [Function],
-                                    [Function],
-                                    [Function],
-                                    [Function],
-                                    [Function],
-                                  ],
-                                },
-                                "displayName": "styled.div",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "sc-bdVaJa",
-                                "target": "div",
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
-                            }
-                            forwardedRef={null}
                             horizontal={3}
                             id="standalone-tooltip-tooltip9_tooltip"
                             inline={false}
@@ -370,186 +336,183 @@ exports[`Tooltip accessibility accepts custom copy 1`] = `
                             tag="div"
                             vertical={2}
                           >
-                            <div
+                            <StyledComponent
                               aria-hidden="true"
                               aria-live="assertive"
-                              className="c2 sc-bwzfXH c2 c3"
+                              className="c2"
                               data-testid="bubble"
-                              id="standalone-tooltip-tooltip9_tooltip"
-                              role="tooltip"
-                            >
-                              <Bubble__InnerBubbleStyle
-                                bubbleWidth={
-                                  Object {
-                                    "width": "calc(1008px - 1rem - 0.5rem)",
-                                  }
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [
+                                    [Function],
+                                  ],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bdVaJa",
+                                    "isStatic": false,
+                                    "lastClassName": "c3",
+                                    "rules": Array [
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bdVaJa",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
                                 }
+                              }
+                              forwardedRef={null}
+                              horizontal={3}
+                              id="standalone-tooltip-tooltip9_tooltip"
+                              inline={false}
+                              role="tooltip"
+                              tag="div"
+                              vertical={2}
+                            >
+                              <div
+                                aria-hidden="true"
+                                aria-live="assertive"
+                                className="c2 sc-bwzfXH c2 c3"
+                                data-testid="bubble"
+                                id="standalone-tooltip-tooltip9_tooltip"
+                                role="tooltip"
                               >
-                                <StyledComponent
+                                <Bubble__InnerBubbleStyle
                                   bubbleWidth={
                                     Object {
                                       "width": "calc(1008px - 1rem - 0.5rem)",
                                     }
                                   }
-                                  forwardedComponent={
-                                    Object {
-                                      "$$typeof": Symbol(react.forward_ref),
-                                      "attrs": Array [],
-                                      "componentStyle": ComponentStyle {
-                                        "componentId": "Bubble__InnerBubbleStyle-sc-15jatun-0",
-                                        "isStatic": false,
-                                        "lastClassName": "c4",
-                                        "rules": Array [
-                                          [Function],
-                                        ],
-                                      },
-                                      "displayName": "Bubble__InnerBubbleStyle",
-                                      "foldedComponentIds": Array [],
-                                      "render": [Function],
-                                      "styledComponentId": "Bubble__InnerBubbleStyle-sc-15jatun-0",
-                                      "target": "div",
-                                      "toString": [Function],
-                                      "warnTooManyClasses": [Function],
-                                      "withComponent": [Function],
-                                    }
-                                  }
-                                  forwardedRef={null}
                                 >
-                                  <div
-                                    className="c4"
+                                  <StyledComponent
+                                    bubbleWidth={
+                                      Object {
+                                        "width": "calc(1008px - 1rem - 0.5rem)",
+                                      }
+                                    }
+                                    forwardedComponent={
+                                      Object {
+                                        "$$typeof": Symbol(react.forward_ref),
+                                        "attrs": Array [],
+                                        "componentStyle": ComponentStyle {
+                                          "componentId": "Bubble__InnerBubbleStyle-sc-15jatun-0",
+                                          "isStatic": false,
+                                          "lastClassName": "c4",
+                                          "rules": Array [
+                                            [Function],
+                                          ],
+                                        },
+                                        "displayName": "Bubble__InnerBubbleStyle",
+                                        "foldedComponentIds": Array [],
+                                        "render": [Function],
+                                        "styledComponentId": "Bubble__InnerBubbleStyle-sc-15jatun-0",
+                                        "target": "div",
+                                        "toString": [Function],
+                                        "warnTooManyClasses": [Function],
+                                        "withComponent": [Function],
+                                      }
+                                    }
+                                    forwardedRef={null}
                                   >
-                                    <Text
-                                      block={false}
-                                      bold={false}
-                                      invert={false}
-                                      size="small"
+                                    <div
+                                      className="c4"
                                     >
-                                      <Text__StyledText
+                                      <Text
                                         block={false}
                                         bold={false}
                                         invert={false}
                                         size="small"
                                       >
-                                        <StyledComponent
+                                        <Text__StyledText
                                           block={false}
                                           bold={false}
-                                          forwardedComponent={
-                                            Object {
-                                              "$$typeof": Symbol(react.forward_ref),
-                                              "attrs": Array [],
-                                              "componentStyle": ComponentStyle {
-                                                "componentId": "Text__StyledText-sc-1m0rr67-0",
-                                                "isStatic": false,
-                                                "lastClassName": "c5",
-                                                "rules": Array [
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  "sup {",
-                                                  "top: -0.5em;",
-                                                  "font-size: 0.875rem;",
-                                                  "position: relative;",
-                                                  "vertical-align: baseline;",
-                                                  "padding-left: 0.1em;",
-                                                  "}",
-                                                ],
-                                              },
-                                              "displayName": "Text__StyledText",
-                                              "foldedComponentIds": Array [],
-                                              "render": [Function],
-                                              "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
-                                              "target": "span",
-                                              "toString": [Function],
-                                              "warnTooManyClasses": [Function],
-                                              "withComponent": [Function],
-                                            }
-                                          }
-                                          forwardedRef={null}
                                           invert={false}
                                           size="small"
                                         >
-                                          <span
-                                            className="c5"
+                                          <StyledComponent
+                                            block={false}
+                                            bold={false}
+                                            forwardedComponent={
+                                              Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "attrs": Array [],
+                                                "componentStyle": ComponentStyle {
+                                                  "componentId": "Text__StyledText-sc-1m0rr67-0",
+                                                  "isStatic": false,
+                                                  "lastClassName": "c5",
+                                                  "rules": Array [
+                                                    [Function],
+                                                    [Function],
+                                                    [Function],
+                                                    [Function],
+                                                    [Function],
+                                                    "sup {",
+                                                    "top: -0.5em;",
+                                                    "font-size: 0.875rem;",
+                                                    "position: relative;",
+                                                    "vertical-align: baseline;",
+                                                    "padding-left: 0.1em;",
+                                                    "}",
+                                                  ],
+                                                },
+                                                "displayName": "Text__StyledText",
+                                                "foldedComponentIds": Array [],
+                                                "render": [Function],
+                                                "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
+                                                "target": "span",
+                                                "toString": [Function],
+                                                "warnTooManyClasses": [Function],
+                                                "withComponent": [Function],
+                                              }
+                                            }
+                                            forwardedRef={null}
+                                            invert={false}
                                             size="small"
                                           >
-                                            Tooltip text
-                                          </span>
-                                        </StyledComponent>
-                                      </Text__StyledText>
-                                    </Text>
-                                  </div>
-                                </StyledComponent>
-                              </Bubble__InnerBubbleStyle>
-                            </div>
-                          </StyledComponent>
-                        </styled.div>
-                      </Box>
-                    </Component>
-                  </StyledComponent>
-                </Styled(Component)>
-              </Bubble>
-              <StandaloneIcon
-                a11yText="This is custom copy."
-                aria-controls="standalone-tooltip-tooltip9_tooltip"
-                aria-expanded="false"
-                aria-haspopup="true"
-                id="standalone-tooltip-tooltip9_trigger"
-                onClick={[Function]}
-                size={24}
-                symbol="questionMarkCircle"
-                type="button"
-              >
-                <StandaloneIcon__StandaloneIconClickable
+                                            <span
+                                              className="c5"
+                                              size="small"
+                                            >
+                                              Tooltip text
+                                            </span>
+                                          </StyledComponent>
+                                        </Text__StyledText>
+                                      </Text>
+                                    </div>
+                                  </StyledComponent>
+                                </Bubble__InnerBubbleStyle>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </Box>
+                      </Component>
+                    </StyledComponent>
+                  </Styled(Component)>
+                </Bubble>
+                <StandaloneIcon
+                  a11yText="This is custom copy."
                   aria-controls="standalone-tooltip-tooltip9_tooltip"
                   aria-expanded="false"
                   aria-haspopup="true"
                   id="standalone-tooltip-tooltip9_trigger"
                   onClick={[Function]}
-                  style={
-                    Object {
-                      "margin": "-4px",
-                      "padding": "4px",
-                    }
-                  }
+                  size={24}
+                  symbol="questionMarkCircle"
                   type="button"
                 >
-                  <StyledComponent
+                  <StandaloneIcon__StandaloneIconClickable
                     aria-controls="standalone-tooltip-tooltip9_tooltip"
                     aria-expanded="false"
                     aria-haspopup="true"
-                    forwardedComponent={
-                      Object {
-                        "$$typeof": Symbol(react.forward_ref),
-                        "attrs": Array [],
-                        "componentStyle": ComponentStyle {
-                          "componentId": "StandaloneIcon__StandaloneIconClickable-ukibfn-0",
-                          "isStatic": true,
-                          "lastClassName": "c6",
-                          "rules": Array [
-                            "padding: 0;",
-                            "margin: 0;",
-                            "border-width: 0;",
-                            "font-family: \\"TELUS-Web\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif;",
-                            "color: #2a2c2e;",
-                            "appearance: none;",
-                            "background: none;",
-                            "box-shadow: none;",
-                            "cursor: pointer;",
-                          ],
-                        },
-                        "displayName": "StandaloneIcon__StandaloneIconClickable",
-                        "foldedComponentIds": Array [],
-                        "render": [Function],
-                        "styledComponentId": "StandaloneIcon__StandaloneIconClickable-ukibfn-0",
-                        "target": "button",
-                        "toString": [Function],
-                        "warnTooManyClasses": [Function],
-                        "withComponent": [Function],
-                      }
-                    }
-                    forwardedRef={null}
                     id="standalone-tooltip-tooltip9_trigger"
                     onClick={[Function]}
                     style={
@@ -560,11 +523,41 @@ exports[`Tooltip accessibility accepts custom copy 1`] = `
                     }
                     type="button"
                   >
-                    <button
+                    <StyledComponent
                       aria-controls="standalone-tooltip-tooltip9_tooltip"
                       aria-expanded="false"
                       aria-haspopup="true"
-                      className="c6"
+                      forwardedComponent={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "attrs": Array [],
+                          "componentStyle": ComponentStyle {
+                            "componentId": "StandaloneIcon__StandaloneIconClickable-ukibfn-0",
+                            "isStatic": true,
+                            "lastClassName": "c6",
+                            "rules": Array [
+                              "padding: 0;",
+                              "margin: 0;",
+                              "border-width: 0;",
+                              "font-family: \\"TELUS-Web\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif;",
+                              "color: #2a2c2e;",
+                              "appearance: none;",
+                              "background: none;",
+                              "box-shadow: none;",
+                              "cursor: pointer;",
+                            ],
+                          },
+                          "displayName": "StandaloneIcon__StandaloneIconClickable",
+                          "foldedComponentIds": Array [],
+                          "render": [Function],
+                          "styledComponentId": "StandaloneIcon__StandaloneIconClickable-ukibfn-0",
+                          "target": "button",
+                          "toString": [Function],
+                          "warnTooManyClasses": [Function],
+                          "withComponent": [Function],
+                        }
+                      }
+                      forwardedRef={null}
                       id="standalone-tooltip-tooltip9_trigger"
                       onClick={[Function]}
                       style={
@@ -575,100 +568,116 @@ exports[`Tooltip accessibility accepts custom copy 1`] = `
                       }
                       type="button"
                     >
-                      <Icon
-                        size={24}
-                        symbol="questionMarkCircle"
+                      <button
+                        aria-controls="standalone-tooltip-tooltip9_tooltip"
+                        aria-expanded="false"
+                        aria-haspopup="true"
+                        className="c6"
+                        id="standalone-tooltip-tooltip9_trigger"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "margin": "-4px",
+                            "padding": "4px",
+                          }
+                        }
+                        type="button"
                       >
-                        <Icon__StyledIcon
-                          iSize={24}
+                        <Icon
+                          size={24}
                           symbol="questionMarkCircle"
                         >
-                          <StyledComponent
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "attrs": Array [],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "Icon__StyledIcon-sc-1g20dn8-0",
-                                  "isStatic": false,
-                                  "lastClassName": "c7",
-                                  "rules": Array [
-                                    [Function],
-                                    [Function],
-                                    [Function],
-                                  ],
-                                },
-                                "displayName": "Icon__StyledIcon",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "Icon__StyledIcon-sc-1g20dn8-0",
-                                "target": "i",
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
-                            }
-                            forwardedRef={null}
+                          <Icon__StyledIcon
                             iSize={24}
                             symbol="questionMarkCircle"
                           >
-                            <i
-                              className="c7"
+                            <StyledComponent
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "Icon__StyledIcon-sc-1g20dn8-0",
+                                    "isStatic": false,
+                                    "lastClassName": "c7",
+                                    "rules": Array [
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                    ],
+                                  },
+                                  "displayName": "Icon__StyledIcon",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "Icon__StyledIcon-sc-1g20dn8-0",
+                                  "target": "i",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              iSize={24}
+                              symbol="questionMarkCircle"
                             >
-                              <A11yContent>
-                                <A11yContent__StyledA11yContent>
-                                  <StyledComponent
-                                    forwardedComponent={
-                                      Object {
-                                        "$$typeof": Symbol(react.forward_ref),
-                                        "attrs": Array [],
-                                        "componentStyle": ComponentStyle {
-                                          "componentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
-                                          "isStatic": true,
-                                          "lastClassName": "c8",
-                                          "rules": Array [
-                                            "position: absolute;",
-                                            "height: 1px;",
-                                            "width: 1px;",
-                                            "overflow: hidden;",
-                                            "clip: rect(1px, 1px, 1px, 1px);",
-                                          ],
-                                        },
-                                        "displayName": "A11yContent__StyledA11yContent",
-                                        "foldedComponentIds": Array [],
-                                        "render": [Function],
-                                        "styledComponentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
-                                        "target": "span",
-                                        "toString": [Function],
-                                        "warnTooManyClasses": [Function],
-                                        "withComponent": [Function],
+                              <i
+                                className="c7"
+                              >
+                                <A11yContent>
+                                  <A11yContent__StyledA11yContent>
+                                    <StyledComponent
+                                      forwardedComponent={
+                                        Object {
+                                          "$$typeof": Symbol(react.forward_ref),
+                                          "attrs": Array [],
+                                          "componentStyle": ComponentStyle {
+                                            "componentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
+                                            "isStatic": true,
+                                            "lastClassName": "c8",
+                                            "rules": Array [
+                                              "position: absolute;",
+                                              "height: 1px;",
+                                              "width: 1px;",
+                                              "overflow: hidden;",
+                                              "clip: rect(1px, 1px, 1px, 1px);",
+                                            ],
+                                          },
+                                          "displayName": "A11yContent__StyledA11yContent",
+                                          "foldedComponentIds": Array [],
+                                          "render": [Function],
+                                          "styledComponentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
+                                          "target": "span",
+                                          "toString": [Function],
+                                          "warnTooManyClasses": [Function],
+                                          "withComponent": [Function],
+                                        }
                                       }
-                                    }
-                                    forwardedRef={null}
-                                  >
-                                    <span
-                                      className="c8"
+                                      forwardedRef={null}
                                     >
-                                      This is custom copy.
-                                    </span>
-                                  </StyledComponent>
-                                </A11yContent__StyledA11yContent>
-                              </A11yContent>
-                            </i>
-                          </StyledComponent>
-                        </Icon__StyledIcon>
-                      </Icon>
-                    </button>
-                  </StyledComponent>
-                </StandaloneIcon__StandaloneIconClickable>
-              </StandaloneIcon>
-            </div>
-          </StyledComponent>
-        </Tooltip__TooltipContainer>
-      </div>
-    </StyledComponent>
-  </Tooltip__StyledTooltip>
-</Tooltip>
+                                      <span
+                                        className="c8"
+                                      >
+                                        This is custom copy.
+                                      </span>
+                                    </StyledComponent>
+                                  </A11yContent__StyledA11yContent>
+                                </A11yContent>
+                              </i>
+                            </StyledComponent>
+                          </Icon__StyledIcon>
+                        </Icon>
+                      </button>
+                    </StyledComponent>
+                  </StandaloneIcon__StandaloneIconClickable>
+                </StandaloneIcon>
+              </div>
+            </StyledComponent>
+          </Tooltip__TooltipContainer>
+        </div>
+      </StyledComponent>
+    </Tooltip__StyledTooltip>
+  </Tooltip>
+</WithForwardedRef(Tooltip)>
 `;
 
 exports[`Tooltip interactivity hides the bubble when clicking outside of it 1`] = `
@@ -806,105 +815,90 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 1`] 
   }
 }
 
-<Tooltip
+<WithForwardedRef(Tooltip)
   copy="en"
-  direction="auto"
 >
-  <Tooltip__StyledTooltip>
-    <StyledComponent
-      forwardedComponent={
-        Object {
-          "$$typeof": Symbol(react.forward_ref),
-          "attrs": Array [],
-          "componentStyle": ComponentStyle {
-            "componentId": "Tooltip__StyledTooltip-sc-2tc47i-0",
-            "isStatic": true,
-            "lastClassName": "c0",
-            "rules": Array [
-              "line-height: 1;",
-              "position: relative;",
-              "width: 1rem;",
-              "height: 1.3rem;",
-            ],
-          },
-          "displayName": "Tooltip__StyledTooltip",
-          "foldedComponentIds": Array [],
-          "render": [Function],
-          "styledComponentId": "Tooltip__StyledTooltip-sc-2tc47i-0",
-          "target": "div",
-          "toString": [Function],
-          "warnTooManyClasses": [Function],
-          "withComponent": [Function],
+  <Tooltip
+    copy="en"
+    direction="auto"
+    forwardedRef={null}
+  >
+    <Tooltip__StyledTooltip>
+      <StyledComponent
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "Tooltip__StyledTooltip-sc-2tc47i-0",
+              "isStatic": true,
+              "lastClassName": "c0",
+              "rules": Array [
+                "line-height: 1;",
+                "position: relative;",
+                "width: 1rem;",
+                "height: 1.3rem;",
+              ],
+            },
+            "displayName": "Tooltip__StyledTooltip",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "Tooltip__StyledTooltip-sc-2tc47i-0",
+            "target": "div",
+            "toString": [Function],
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
         }
-      }
-      forwardedRef={[Function]}
-    >
-      <div
-        className="c0"
+        forwardedRef={[Function]}
       >
-        <Tooltip__TooltipContainer
-          data-testid="tooltipContainer"
+        <div
+          className="c0"
         >
-          <StyledComponent
+          <Tooltip__TooltipContainer
             data-testid="tooltipContainer"
-            forwardedComponent={
-              Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "attrs": Array [],
-                "componentStyle": ComponentStyle {
-                  "componentId": "Tooltip__TooltipContainer-sc-2tc47i-1",
-                  "isStatic": true,
-                  "lastClassName": "c1",
-                  "rules": Array [
-                    "position: absolute;",
-                  ],
-                },
-                "displayName": "Tooltip__TooltipContainer",
-                "foldedComponentIds": Array [],
-                "render": [Function],
-                "styledComponentId": "Tooltip__TooltipContainer-sc-2tc47i-1",
-                "target": "div",
-                "toString": [Function],
-                "warnTooManyClasses": [Function],
-                "withComponent": [Function],
-              }
-            }
-            forwardedRef={null}
           >
-            <div
-              className="c1"
+            <StyledComponent
               data-testid="tooltipContainer"
-            >
-              <Bubble
-                direction="right"
-                id="standalone-tooltip-tooltip5_tooltip"
-                open={true}
-                width={
-                  Object {
-                    "width": "calc(1008px - 1rem - 0.5rem)",
-                  }
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "Tooltip__TooltipContainer-sc-2tc47i-1",
+                    "isStatic": true,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "position: absolute;",
+                    ],
+                  },
+                  "displayName": "Tooltip__TooltipContainer",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "Tooltip__TooltipContainer-sc-2tc47i-1",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
                 }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="c1"
+                data-testid="tooltipContainer"
               >
-                <Styled(Component)
-                  aria-hidden="false"
-                  aria-live="assertive"
-                  bubbleDimensions={
-                    Object {
-                      "bubbleOffset": "7px",
-                      "bubbleTriangleHeight": "10px",
-                      "bubbleTrianglePosition": "12px",
-                      "bubbleTriangleWidth": "7px",
-                      "bubbleTriggerSize": "24px",
-                    }
-                  }
+                <Bubble
                   direction="right"
-                  horizontal={3}
                   id="standalone-tooltip-tooltip5_tooltip"
                   open={true}
-                  role="tooltip"
-                  vertical={2}
+                  width={
+                    Object {
+                      "width": "calc(1008px - 1rem - 0.5rem)",
+                    }
+                  }
                 >
-                  <StyledComponent
+                  <Styled(Component)
                     aria-hidden="false"
                     aria-live="assertive"
                     bubbleDimensions={
@@ -917,39 +911,13 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 1`] 
                       }
                     }
                     direction="right"
-                    forwardedComponent={
-                      Object {
-                        "$$typeof": Symbol(react.forward_ref),
-                        "attrs": Array [
-                          [Function],
-                        ],
-                        "componentStyle": ComponentStyle {
-                          "componentId": "sc-bwzfXH",
-                          "isStatic": false,
-                          "lastClassName": "eqAxCt",
-                          "rules": Array [
-                            "border-radius: 4px;",
-                            [Function],
-                          ],
-                        },
-                        "displayName": "Styled(Component)",
-                        "foldedComponentIds": Array [],
-                        "render": [Function],
-                        "styledComponentId": "sc-bwzfXH",
-                        "target": [Function],
-                        "toString": [Function],
-                        "warnTooManyClasses": [Function],
-                        "withComponent": [Function],
-                      }
-                    }
-                    forwardedRef={null}
                     horizontal={3}
                     id="standalone-tooltip-tooltip5_tooltip"
                     open={true}
                     role="tooltip"
                     vertical={2}
                   >
-                    <Component
+                    <StyledComponent
                       aria-hidden="false"
                       aria-live="assertive"
                       bubbleDimensions={
@@ -961,28 +929,61 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 1`] 
                           "bubbleTriggerSize": "24px",
                         }
                       }
-                      className="c2"
-                      data-testid="bubble"
                       direction="right"
+                      forwardedComponent={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "attrs": Array [
+                            [Function],
+                          ],
+                          "componentStyle": ComponentStyle {
+                            "componentId": "sc-bwzfXH",
+                            "isStatic": false,
+                            "lastClassName": "eqAxCt",
+                            "rules": Array [
+                              "border-radius: 4px;",
+                              [Function],
+                            ],
+                          },
+                          "displayName": "Styled(Component)",
+                          "foldedComponentIds": Array [],
+                          "render": [Function],
+                          "styledComponentId": "sc-bwzfXH",
+                          "target": [Function],
+                          "toString": [Function],
+                          "warnTooManyClasses": [Function],
+                          "withComponent": [Function],
+                        }
+                      }
+                      forwardedRef={null}
                       horizontal={3}
                       id="standalone-tooltip-tooltip5_tooltip"
                       open={true}
                       role="tooltip"
                       vertical={2}
                     >
-                      <Box
+                      <Component
                         aria-hidden="false"
                         aria-live="assertive"
+                        bubbleDimensions={
+                          Object {
+                            "bubbleOffset": "7px",
+                            "bubbleTriangleHeight": "10px",
+                            "bubbleTrianglePosition": "12px",
+                            "bubbleTriangleWidth": "7px",
+                            "bubbleTriggerSize": "24px",
+                          }
+                        }
                         className="c2"
                         data-testid="bubble"
+                        direction="right"
                         horizontal={3}
                         id="standalone-tooltip-tooltip5_tooltip"
-                        inline={false}
+                        open={true}
                         role="tooltip"
-                        tag="div"
                         vertical={2}
                       >
-                        <styled.div
+                        <Box
                           aria-hidden="false"
                           aria-live="assertive"
                           className="c2"
@@ -994,41 +995,11 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 1`] 
                           tag="div"
                           vertical={2}
                         >
-                          <StyledComponent
+                          <styled.div
                             aria-hidden="false"
                             aria-live="assertive"
                             className="c2"
                             data-testid="bubble"
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "attrs": Array [
-                                  [Function],
-                                ],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "sc-bdVaJa",
-                                  "isStatic": false,
-                                  "lastClassName": "c3",
-                                  "rules": Array [
-                                    [Function],
-                                    [Function],
-                                    [Function],
-                                    [Function],
-                                    [Function],
-                                    [Function],
-                                  ],
-                                },
-                                "displayName": "styled.div",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "sc-bdVaJa",
-                                "target": "div",
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
-                            }
-                            forwardedRef={null}
                             horizontal={3}
                             id="standalone-tooltip-tooltip5_tooltip"
                             inline={false}
@@ -1036,186 +1007,183 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 1`] 
                             tag="div"
                             vertical={2}
                           >
-                            <div
+                            <StyledComponent
                               aria-hidden="false"
                               aria-live="assertive"
-                              className="c2 sc-bwzfXH c2 c3"
+                              className="c2"
                               data-testid="bubble"
-                              id="standalone-tooltip-tooltip5_tooltip"
-                              role="tooltip"
-                            >
-                              <Bubble__InnerBubbleStyle
-                                bubbleWidth={
-                                  Object {
-                                    "width": "calc(1008px - 1rem - 0.5rem)",
-                                  }
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [
+                                    [Function],
+                                  ],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bdVaJa",
+                                    "isStatic": false,
+                                    "lastClassName": "c3",
+                                    "rules": Array [
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bdVaJa",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
                                 }
+                              }
+                              forwardedRef={null}
+                              horizontal={3}
+                              id="standalone-tooltip-tooltip5_tooltip"
+                              inline={false}
+                              role="tooltip"
+                              tag="div"
+                              vertical={2}
+                            >
+                              <div
+                                aria-hidden="false"
+                                aria-live="assertive"
+                                className="c2 sc-bwzfXH c2 c3"
+                                data-testid="bubble"
+                                id="standalone-tooltip-tooltip5_tooltip"
+                                role="tooltip"
                               >
-                                <StyledComponent
+                                <Bubble__InnerBubbleStyle
                                   bubbleWidth={
                                     Object {
                                       "width": "calc(1008px - 1rem - 0.5rem)",
                                     }
                                   }
-                                  forwardedComponent={
-                                    Object {
-                                      "$$typeof": Symbol(react.forward_ref),
-                                      "attrs": Array [],
-                                      "componentStyle": ComponentStyle {
-                                        "componentId": "Bubble__InnerBubbleStyle-sc-15jatun-0",
-                                        "isStatic": false,
-                                        "lastClassName": "c4",
-                                        "rules": Array [
-                                          [Function],
-                                        ],
-                                      },
-                                      "displayName": "Bubble__InnerBubbleStyle",
-                                      "foldedComponentIds": Array [],
-                                      "render": [Function],
-                                      "styledComponentId": "Bubble__InnerBubbleStyle-sc-15jatun-0",
-                                      "target": "div",
-                                      "toString": [Function],
-                                      "warnTooManyClasses": [Function],
-                                      "withComponent": [Function],
-                                    }
-                                  }
-                                  forwardedRef={null}
                                 >
-                                  <div
-                                    className="c4"
+                                  <StyledComponent
+                                    bubbleWidth={
+                                      Object {
+                                        "width": "calc(1008px - 1rem - 0.5rem)",
+                                      }
+                                    }
+                                    forwardedComponent={
+                                      Object {
+                                        "$$typeof": Symbol(react.forward_ref),
+                                        "attrs": Array [],
+                                        "componentStyle": ComponentStyle {
+                                          "componentId": "Bubble__InnerBubbleStyle-sc-15jatun-0",
+                                          "isStatic": false,
+                                          "lastClassName": "c4",
+                                          "rules": Array [
+                                            [Function],
+                                          ],
+                                        },
+                                        "displayName": "Bubble__InnerBubbleStyle",
+                                        "foldedComponentIds": Array [],
+                                        "render": [Function],
+                                        "styledComponentId": "Bubble__InnerBubbleStyle-sc-15jatun-0",
+                                        "target": "div",
+                                        "toString": [Function],
+                                        "warnTooManyClasses": [Function],
+                                        "withComponent": [Function],
+                                      }
+                                    }
+                                    forwardedRef={null}
                                   >
-                                    <Text
-                                      block={false}
-                                      bold={false}
-                                      invert={false}
-                                      size="small"
+                                    <div
+                                      className="c4"
                                     >
-                                      <Text__StyledText
+                                      <Text
                                         block={false}
                                         bold={false}
                                         invert={false}
                                         size="small"
                                       >
-                                        <StyledComponent
+                                        <Text__StyledText
                                           block={false}
                                           bold={false}
-                                          forwardedComponent={
-                                            Object {
-                                              "$$typeof": Symbol(react.forward_ref),
-                                              "attrs": Array [],
-                                              "componentStyle": ComponentStyle {
-                                                "componentId": "Text__StyledText-sc-1m0rr67-0",
-                                                "isStatic": false,
-                                                "lastClassName": "c5",
-                                                "rules": Array [
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  "sup {",
-                                                  "top: -0.5em;",
-                                                  "font-size: 0.875rem;",
-                                                  "position: relative;",
-                                                  "vertical-align: baseline;",
-                                                  "padding-left: 0.1em;",
-                                                  "}",
-                                                ],
-                                              },
-                                              "displayName": "Text__StyledText",
-                                              "foldedComponentIds": Array [],
-                                              "render": [Function],
-                                              "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
-                                              "target": "span",
-                                              "toString": [Function],
-                                              "warnTooManyClasses": [Function],
-                                              "withComponent": [Function],
-                                            }
-                                          }
-                                          forwardedRef={null}
                                           invert={false}
                                           size="small"
                                         >
-                                          <span
-                                            className="c5"
+                                          <StyledComponent
+                                            block={false}
+                                            bold={false}
+                                            forwardedComponent={
+                                              Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "attrs": Array [],
+                                                "componentStyle": ComponentStyle {
+                                                  "componentId": "Text__StyledText-sc-1m0rr67-0",
+                                                  "isStatic": false,
+                                                  "lastClassName": "c5",
+                                                  "rules": Array [
+                                                    [Function],
+                                                    [Function],
+                                                    [Function],
+                                                    [Function],
+                                                    [Function],
+                                                    "sup {",
+                                                    "top: -0.5em;",
+                                                    "font-size: 0.875rem;",
+                                                    "position: relative;",
+                                                    "vertical-align: baseline;",
+                                                    "padding-left: 0.1em;",
+                                                    "}",
+                                                  ],
+                                                },
+                                                "displayName": "Text__StyledText",
+                                                "foldedComponentIds": Array [],
+                                                "render": [Function],
+                                                "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
+                                                "target": "span",
+                                                "toString": [Function],
+                                                "warnTooManyClasses": [Function],
+                                                "withComponent": [Function],
+                                              }
+                                            }
+                                            forwardedRef={null}
+                                            invert={false}
                                             size="small"
                                           >
-                                            Tooltip text
-                                          </span>
-                                        </StyledComponent>
-                                      </Text__StyledText>
-                                    </Text>
-                                  </div>
-                                </StyledComponent>
-                              </Bubble__InnerBubbleStyle>
-                            </div>
-                          </StyledComponent>
-                        </styled.div>
-                      </Box>
-                    </Component>
-                  </StyledComponent>
-                </Styled(Component)>
-              </Bubble>
-              <StandaloneIcon
-                a11yText="Reveal additional information."
-                aria-controls="standalone-tooltip-tooltip5_tooltip"
-                aria-expanded="true"
-                aria-haspopup="true"
-                id="standalone-tooltip-tooltip5_trigger"
-                onClick={[Function]}
-                size={24}
-                symbol="questionMarkCircle"
-                type="button"
-              >
-                <StandaloneIcon__StandaloneIconClickable
+                                            <span
+                                              className="c5"
+                                              size="small"
+                                            >
+                                              Tooltip text
+                                            </span>
+                                          </StyledComponent>
+                                        </Text__StyledText>
+                                      </Text>
+                                    </div>
+                                  </StyledComponent>
+                                </Bubble__InnerBubbleStyle>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </Box>
+                      </Component>
+                    </StyledComponent>
+                  </Styled(Component)>
+                </Bubble>
+                <StandaloneIcon
+                  a11yText="Reveal additional information."
                   aria-controls="standalone-tooltip-tooltip5_tooltip"
                   aria-expanded="true"
                   aria-haspopup="true"
                   id="standalone-tooltip-tooltip5_trigger"
                   onClick={[Function]}
-                  style={
-                    Object {
-                      "margin": "-4px",
-                      "padding": "4px",
-                    }
-                  }
+                  size={24}
+                  symbol="questionMarkCircle"
                   type="button"
                 >
-                  <StyledComponent
+                  <StandaloneIcon__StandaloneIconClickable
                     aria-controls="standalone-tooltip-tooltip5_tooltip"
                     aria-expanded="true"
                     aria-haspopup="true"
-                    forwardedComponent={
-                      Object {
-                        "$$typeof": Symbol(react.forward_ref),
-                        "attrs": Array [],
-                        "componentStyle": ComponentStyle {
-                          "componentId": "StandaloneIcon__StandaloneIconClickable-ukibfn-0",
-                          "isStatic": true,
-                          "lastClassName": "c6",
-                          "rules": Array [
-                            "padding: 0;",
-                            "margin: 0;",
-                            "border-width: 0;",
-                            "font-family: \\"TELUS-Web\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif;",
-                            "color: #2a2c2e;",
-                            "appearance: none;",
-                            "background: none;",
-                            "box-shadow: none;",
-                            "cursor: pointer;",
-                          ],
-                        },
-                        "displayName": "StandaloneIcon__StandaloneIconClickable",
-                        "foldedComponentIds": Array [],
-                        "render": [Function],
-                        "styledComponentId": "StandaloneIcon__StandaloneIconClickable-ukibfn-0",
-                        "target": "button",
-                        "toString": [Function],
-                        "warnTooManyClasses": [Function],
-                        "withComponent": [Function],
-                      }
-                    }
-                    forwardedRef={null}
                     id="standalone-tooltip-tooltip5_trigger"
                     onClick={[Function]}
                     style={
@@ -1226,11 +1194,41 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 1`] 
                     }
                     type="button"
                   >
-                    <button
+                    <StyledComponent
                       aria-controls="standalone-tooltip-tooltip5_tooltip"
                       aria-expanded="true"
                       aria-haspopup="true"
-                      className="c6"
+                      forwardedComponent={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "attrs": Array [],
+                          "componentStyle": ComponentStyle {
+                            "componentId": "StandaloneIcon__StandaloneIconClickable-ukibfn-0",
+                            "isStatic": true,
+                            "lastClassName": "c6",
+                            "rules": Array [
+                              "padding: 0;",
+                              "margin: 0;",
+                              "border-width: 0;",
+                              "font-family: \\"TELUS-Web\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif;",
+                              "color: #2a2c2e;",
+                              "appearance: none;",
+                              "background: none;",
+                              "box-shadow: none;",
+                              "cursor: pointer;",
+                            ],
+                          },
+                          "displayName": "StandaloneIcon__StandaloneIconClickable",
+                          "foldedComponentIds": Array [],
+                          "render": [Function],
+                          "styledComponentId": "StandaloneIcon__StandaloneIconClickable-ukibfn-0",
+                          "target": "button",
+                          "toString": [Function],
+                          "warnTooManyClasses": [Function],
+                          "withComponent": [Function],
+                        }
+                      }
+                      forwardedRef={null}
                       id="standalone-tooltip-tooltip5_trigger"
                       onClick={[Function]}
                       style={
@@ -1241,100 +1239,116 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 1`] 
                       }
                       type="button"
                     >
-                      <Icon
-                        size={24}
-                        symbol="questionMarkCircle"
+                      <button
+                        aria-controls="standalone-tooltip-tooltip5_tooltip"
+                        aria-expanded="true"
+                        aria-haspopup="true"
+                        className="c6"
+                        id="standalone-tooltip-tooltip5_trigger"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "margin": "-4px",
+                            "padding": "4px",
+                          }
+                        }
+                        type="button"
                       >
-                        <Icon__StyledIcon
-                          iSize={24}
+                        <Icon
+                          size={24}
                           symbol="questionMarkCircle"
                         >
-                          <StyledComponent
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "attrs": Array [],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "Icon__StyledIcon-sc-1g20dn8-0",
-                                  "isStatic": false,
-                                  "lastClassName": "c7",
-                                  "rules": Array [
-                                    [Function],
-                                    [Function],
-                                    [Function],
-                                  ],
-                                },
-                                "displayName": "Icon__StyledIcon",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "Icon__StyledIcon-sc-1g20dn8-0",
-                                "target": "i",
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
-                            }
-                            forwardedRef={null}
+                          <Icon__StyledIcon
                             iSize={24}
                             symbol="questionMarkCircle"
                           >
-                            <i
-                              className="c7"
+                            <StyledComponent
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "Icon__StyledIcon-sc-1g20dn8-0",
+                                    "isStatic": false,
+                                    "lastClassName": "c7",
+                                    "rules": Array [
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                    ],
+                                  },
+                                  "displayName": "Icon__StyledIcon",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "Icon__StyledIcon-sc-1g20dn8-0",
+                                  "target": "i",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              iSize={24}
+                              symbol="questionMarkCircle"
                             >
-                              <A11yContent>
-                                <A11yContent__StyledA11yContent>
-                                  <StyledComponent
-                                    forwardedComponent={
-                                      Object {
-                                        "$$typeof": Symbol(react.forward_ref),
-                                        "attrs": Array [],
-                                        "componentStyle": ComponentStyle {
-                                          "componentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
-                                          "isStatic": true,
-                                          "lastClassName": "c8",
-                                          "rules": Array [
-                                            "position: absolute;",
-                                            "height: 1px;",
-                                            "width: 1px;",
-                                            "overflow: hidden;",
-                                            "clip: rect(1px, 1px, 1px, 1px);",
-                                          ],
-                                        },
-                                        "displayName": "A11yContent__StyledA11yContent",
-                                        "foldedComponentIds": Array [],
-                                        "render": [Function],
-                                        "styledComponentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
-                                        "target": "span",
-                                        "toString": [Function],
-                                        "warnTooManyClasses": [Function],
-                                        "withComponent": [Function],
+                              <i
+                                className="c7"
+                              >
+                                <A11yContent>
+                                  <A11yContent__StyledA11yContent>
+                                    <StyledComponent
+                                      forwardedComponent={
+                                        Object {
+                                          "$$typeof": Symbol(react.forward_ref),
+                                          "attrs": Array [],
+                                          "componentStyle": ComponentStyle {
+                                            "componentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
+                                            "isStatic": true,
+                                            "lastClassName": "c8",
+                                            "rules": Array [
+                                              "position: absolute;",
+                                              "height: 1px;",
+                                              "width: 1px;",
+                                              "overflow: hidden;",
+                                              "clip: rect(1px, 1px, 1px, 1px);",
+                                            ],
+                                          },
+                                          "displayName": "A11yContent__StyledA11yContent",
+                                          "foldedComponentIds": Array [],
+                                          "render": [Function],
+                                          "styledComponentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
+                                          "target": "span",
+                                          "toString": [Function],
+                                          "warnTooManyClasses": [Function],
+                                          "withComponent": [Function],
+                                        }
                                       }
-                                    }
-                                    forwardedRef={null}
-                                  >
-                                    <span
-                                      className="c8"
+                                      forwardedRef={null}
                                     >
-                                      Reveal additional information.
-                                    </span>
-                                  </StyledComponent>
-                                </A11yContent__StyledA11yContent>
-                              </A11yContent>
-                            </i>
-                          </StyledComponent>
-                        </Icon__StyledIcon>
-                      </Icon>
-                    </button>
-                  </StyledComponent>
-                </StandaloneIcon__StandaloneIconClickable>
-              </StandaloneIcon>
-            </div>
-          </StyledComponent>
-        </Tooltip__TooltipContainer>
-      </div>
-    </StyledComponent>
-  </Tooltip__StyledTooltip>
-</Tooltip>
+                                      <span
+                                        className="c8"
+                                      >
+                                        Reveal additional information.
+                                      </span>
+                                    </StyledComponent>
+                                  </A11yContent__StyledA11yContent>
+                                </A11yContent>
+                              </i>
+                            </StyledComponent>
+                          </Icon__StyledIcon>
+                        </Icon>
+                      </button>
+                    </StyledComponent>
+                  </StandaloneIcon__StandaloneIconClickable>
+                </StandaloneIcon>
+              </div>
+            </StyledComponent>
+          </Tooltip__TooltipContainer>
+        </div>
+      </StyledComponent>
+    </Tooltip__StyledTooltip>
+  </Tooltip>
+</WithForwardedRef(Tooltip)>
 `;
 
 exports[`Tooltip interactivity hides the bubble when clicking outside of it 2`] = `
@@ -1472,105 +1486,90 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 2`] 
   }
 }
 
-<Tooltip
+<WithForwardedRef(Tooltip)
   copy="en"
-  direction="auto"
 >
-  <Tooltip__StyledTooltip>
-    <StyledComponent
-      forwardedComponent={
-        Object {
-          "$$typeof": Symbol(react.forward_ref),
-          "attrs": Array [],
-          "componentStyle": ComponentStyle {
-            "componentId": "Tooltip__StyledTooltip-sc-2tc47i-0",
-            "isStatic": true,
-            "lastClassName": "c0",
-            "rules": Array [
-              "line-height: 1;",
-              "position: relative;",
-              "width: 1rem;",
-              "height: 1.3rem;",
-            ],
-          },
-          "displayName": "Tooltip__StyledTooltip",
-          "foldedComponentIds": Array [],
-          "render": [Function],
-          "styledComponentId": "Tooltip__StyledTooltip-sc-2tc47i-0",
-          "target": "div",
-          "toString": [Function],
-          "warnTooManyClasses": [Function],
-          "withComponent": [Function],
+  <Tooltip
+    copy="en"
+    direction="auto"
+    forwardedRef={null}
+  >
+    <Tooltip__StyledTooltip>
+      <StyledComponent
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "Tooltip__StyledTooltip-sc-2tc47i-0",
+              "isStatic": true,
+              "lastClassName": "c0",
+              "rules": Array [
+                "line-height: 1;",
+                "position: relative;",
+                "width: 1rem;",
+                "height: 1.3rem;",
+              ],
+            },
+            "displayName": "Tooltip__StyledTooltip",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "Tooltip__StyledTooltip-sc-2tc47i-0",
+            "target": "div",
+            "toString": [Function],
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
         }
-      }
-      forwardedRef={[Function]}
-    >
-      <div
-        className="c0"
+        forwardedRef={[Function]}
       >
-        <Tooltip__TooltipContainer
-          data-testid="tooltipContainer"
+        <div
+          className="c0"
         >
-          <StyledComponent
+          <Tooltip__TooltipContainer
             data-testid="tooltipContainer"
-            forwardedComponent={
-              Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "attrs": Array [],
-                "componentStyle": ComponentStyle {
-                  "componentId": "Tooltip__TooltipContainer-sc-2tc47i-1",
-                  "isStatic": true,
-                  "lastClassName": "c1",
-                  "rules": Array [
-                    "position: absolute;",
-                  ],
-                },
-                "displayName": "Tooltip__TooltipContainer",
-                "foldedComponentIds": Array [],
-                "render": [Function],
-                "styledComponentId": "Tooltip__TooltipContainer-sc-2tc47i-1",
-                "target": "div",
-                "toString": [Function],
-                "warnTooManyClasses": [Function],
-                "withComponent": [Function],
-              }
-            }
-            forwardedRef={null}
           >
-            <div
-              className="c1"
+            <StyledComponent
               data-testid="tooltipContainer"
-            >
-              <Bubble
-                direction="right"
-                id="standalone-tooltip-tooltip5_tooltip"
-                open={true}
-                width={
-                  Object {
-                    "width": "calc(1008px - 1rem - 0.5rem)",
-                  }
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "Tooltip__TooltipContainer-sc-2tc47i-1",
+                    "isStatic": true,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "position: absolute;",
+                    ],
+                  },
+                  "displayName": "Tooltip__TooltipContainer",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "Tooltip__TooltipContainer-sc-2tc47i-1",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
                 }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="c1"
+                data-testid="tooltipContainer"
               >
-                <Styled(Component)
-                  aria-hidden="false"
-                  aria-live="assertive"
-                  bubbleDimensions={
-                    Object {
-                      "bubbleOffset": "7px",
-                      "bubbleTriangleHeight": "10px",
-                      "bubbleTrianglePosition": "12px",
-                      "bubbleTriangleWidth": "7px",
-                      "bubbleTriggerSize": "24px",
-                    }
-                  }
+                <Bubble
                   direction="right"
-                  horizontal={3}
                   id="standalone-tooltip-tooltip5_tooltip"
                   open={true}
-                  role="tooltip"
-                  vertical={2}
+                  width={
+                    Object {
+                      "width": "calc(1008px - 1rem - 0.5rem)",
+                    }
+                  }
                 >
-                  <StyledComponent
+                  <Styled(Component)
                     aria-hidden="false"
                     aria-live="assertive"
                     bubbleDimensions={
@@ -1583,39 +1582,13 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 2`] 
                       }
                     }
                     direction="right"
-                    forwardedComponent={
-                      Object {
-                        "$$typeof": Symbol(react.forward_ref),
-                        "attrs": Array [
-                          [Function],
-                        ],
-                        "componentStyle": ComponentStyle {
-                          "componentId": "sc-bwzfXH",
-                          "isStatic": false,
-                          "lastClassName": "eqAxCt",
-                          "rules": Array [
-                            "border-radius: 4px;",
-                            [Function],
-                          ],
-                        },
-                        "displayName": "Styled(Component)",
-                        "foldedComponentIds": Array [],
-                        "render": [Function],
-                        "styledComponentId": "sc-bwzfXH",
-                        "target": [Function],
-                        "toString": [Function],
-                        "warnTooManyClasses": [Function],
-                        "withComponent": [Function],
-                      }
-                    }
-                    forwardedRef={null}
                     horizontal={3}
                     id="standalone-tooltip-tooltip5_tooltip"
                     open={true}
                     role="tooltip"
                     vertical={2}
                   >
-                    <Component
+                    <StyledComponent
                       aria-hidden="false"
                       aria-live="assertive"
                       bubbleDimensions={
@@ -1627,28 +1600,61 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 2`] 
                           "bubbleTriggerSize": "24px",
                         }
                       }
-                      className="c2"
-                      data-testid="bubble"
                       direction="right"
+                      forwardedComponent={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "attrs": Array [
+                            [Function],
+                          ],
+                          "componentStyle": ComponentStyle {
+                            "componentId": "sc-bwzfXH",
+                            "isStatic": false,
+                            "lastClassName": "eqAxCt",
+                            "rules": Array [
+                              "border-radius: 4px;",
+                              [Function],
+                            ],
+                          },
+                          "displayName": "Styled(Component)",
+                          "foldedComponentIds": Array [],
+                          "render": [Function],
+                          "styledComponentId": "sc-bwzfXH",
+                          "target": [Function],
+                          "toString": [Function],
+                          "warnTooManyClasses": [Function],
+                          "withComponent": [Function],
+                        }
+                      }
+                      forwardedRef={null}
                       horizontal={3}
                       id="standalone-tooltip-tooltip5_tooltip"
                       open={true}
                       role="tooltip"
                       vertical={2}
                     >
-                      <Box
+                      <Component
                         aria-hidden="false"
                         aria-live="assertive"
+                        bubbleDimensions={
+                          Object {
+                            "bubbleOffset": "7px",
+                            "bubbleTriangleHeight": "10px",
+                            "bubbleTrianglePosition": "12px",
+                            "bubbleTriangleWidth": "7px",
+                            "bubbleTriggerSize": "24px",
+                          }
+                        }
                         className="c2"
                         data-testid="bubble"
+                        direction="right"
                         horizontal={3}
                         id="standalone-tooltip-tooltip5_tooltip"
-                        inline={false}
+                        open={true}
                         role="tooltip"
-                        tag="div"
                         vertical={2}
                       >
-                        <styled.div
+                        <Box
                           aria-hidden="false"
                           aria-live="assertive"
                           className="c2"
@@ -1660,41 +1666,11 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 2`] 
                           tag="div"
                           vertical={2}
                         >
-                          <StyledComponent
+                          <styled.div
                             aria-hidden="false"
                             aria-live="assertive"
                             className="c2"
                             data-testid="bubble"
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "attrs": Array [
-                                  [Function],
-                                ],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "sc-bdVaJa",
-                                  "isStatic": false,
-                                  "lastClassName": "c3",
-                                  "rules": Array [
-                                    [Function],
-                                    [Function],
-                                    [Function],
-                                    [Function],
-                                    [Function],
-                                    [Function],
-                                  ],
-                                },
-                                "displayName": "styled.div",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "sc-bdVaJa",
-                                "target": "div",
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
-                            }
-                            forwardedRef={null}
                             horizontal={3}
                             id="standalone-tooltip-tooltip5_tooltip"
                             inline={false}
@@ -1702,186 +1678,183 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 2`] 
                             tag="div"
                             vertical={2}
                           >
-                            <div
+                            <StyledComponent
                               aria-hidden="false"
                               aria-live="assertive"
-                              className="c2 sc-bwzfXH c2 c3"
+                              className="c2"
                               data-testid="bubble"
-                              id="standalone-tooltip-tooltip5_tooltip"
-                              role="tooltip"
-                            >
-                              <Bubble__InnerBubbleStyle
-                                bubbleWidth={
-                                  Object {
-                                    "width": "calc(1008px - 1rem - 0.5rem)",
-                                  }
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [
+                                    [Function],
+                                  ],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bdVaJa",
+                                    "isStatic": false,
+                                    "lastClassName": "c3",
+                                    "rules": Array [
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bdVaJa",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
                                 }
+                              }
+                              forwardedRef={null}
+                              horizontal={3}
+                              id="standalone-tooltip-tooltip5_tooltip"
+                              inline={false}
+                              role="tooltip"
+                              tag="div"
+                              vertical={2}
+                            >
+                              <div
+                                aria-hidden="false"
+                                aria-live="assertive"
+                                className="c2 sc-bwzfXH c2 c3"
+                                data-testid="bubble"
+                                id="standalone-tooltip-tooltip5_tooltip"
+                                role="tooltip"
                               >
-                                <StyledComponent
+                                <Bubble__InnerBubbleStyle
                                   bubbleWidth={
                                     Object {
                                       "width": "calc(1008px - 1rem - 0.5rem)",
                                     }
                                   }
-                                  forwardedComponent={
-                                    Object {
-                                      "$$typeof": Symbol(react.forward_ref),
-                                      "attrs": Array [],
-                                      "componentStyle": ComponentStyle {
-                                        "componentId": "Bubble__InnerBubbleStyle-sc-15jatun-0",
-                                        "isStatic": false,
-                                        "lastClassName": "c4",
-                                        "rules": Array [
-                                          [Function],
-                                        ],
-                                      },
-                                      "displayName": "Bubble__InnerBubbleStyle",
-                                      "foldedComponentIds": Array [],
-                                      "render": [Function],
-                                      "styledComponentId": "Bubble__InnerBubbleStyle-sc-15jatun-0",
-                                      "target": "div",
-                                      "toString": [Function],
-                                      "warnTooManyClasses": [Function],
-                                      "withComponent": [Function],
-                                    }
-                                  }
-                                  forwardedRef={null}
                                 >
-                                  <div
-                                    className="c4"
+                                  <StyledComponent
+                                    bubbleWidth={
+                                      Object {
+                                        "width": "calc(1008px - 1rem - 0.5rem)",
+                                      }
+                                    }
+                                    forwardedComponent={
+                                      Object {
+                                        "$$typeof": Symbol(react.forward_ref),
+                                        "attrs": Array [],
+                                        "componentStyle": ComponentStyle {
+                                          "componentId": "Bubble__InnerBubbleStyle-sc-15jatun-0",
+                                          "isStatic": false,
+                                          "lastClassName": "c4",
+                                          "rules": Array [
+                                            [Function],
+                                          ],
+                                        },
+                                        "displayName": "Bubble__InnerBubbleStyle",
+                                        "foldedComponentIds": Array [],
+                                        "render": [Function],
+                                        "styledComponentId": "Bubble__InnerBubbleStyle-sc-15jatun-0",
+                                        "target": "div",
+                                        "toString": [Function],
+                                        "warnTooManyClasses": [Function],
+                                        "withComponent": [Function],
+                                      }
+                                    }
+                                    forwardedRef={null}
                                   >
-                                    <Text
-                                      block={false}
-                                      bold={false}
-                                      invert={false}
-                                      size="small"
+                                    <div
+                                      className="c4"
                                     >
-                                      <Text__StyledText
+                                      <Text
                                         block={false}
                                         bold={false}
                                         invert={false}
                                         size="small"
                                       >
-                                        <StyledComponent
+                                        <Text__StyledText
                                           block={false}
                                           bold={false}
-                                          forwardedComponent={
-                                            Object {
-                                              "$$typeof": Symbol(react.forward_ref),
-                                              "attrs": Array [],
-                                              "componentStyle": ComponentStyle {
-                                                "componentId": "Text__StyledText-sc-1m0rr67-0",
-                                                "isStatic": false,
-                                                "lastClassName": "c5",
-                                                "rules": Array [
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  "sup {",
-                                                  "top: -0.5em;",
-                                                  "font-size: 0.875rem;",
-                                                  "position: relative;",
-                                                  "vertical-align: baseline;",
-                                                  "padding-left: 0.1em;",
-                                                  "}",
-                                                ],
-                                              },
-                                              "displayName": "Text__StyledText",
-                                              "foldedComponentIds": Array [],
-                                              "render": [Function],
-                                              "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
-                                              "target": "span",
-                                              "toString": [Function],
-                                              "warnTooManyClasses": [Function],
-                                              "withComponent": [Function],
-                                            }
-                                          }
-                                          forwardedRef={null}
                                           invert={false}
                                           size="small"
                                         >
-                                          <span
-                                            className="c5"
+                                          <StyledComponent
+                                            block={false}
+                                            bold={false}
+                                            forwardedComponent={
+                                              Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "attrs": Array [],
+                                                "componentStyle": ComponentStyle {
+                                                  "componentId": "Text__StyledText-sc-1m0rr67-0",
+                                                  "isStatic": false,
+                                                  "lastClassName": "c5",
+                                                  "rules": Array [
+                                                    [Function],
+                                                    [Function],
+                                                    [Function],
+                                                    [Function],
+                                                    [Function],
+                                                    "sup {",
+                                                    "top: -0.5em;",
+                                                    "font-size: 0.875rem;",
+                                                    "position: relative;",
+                                                    "vertical-align: baseline;",
+                                                    "padding-left: 0.1em;",
+                                                    "}",
+                                                  ],
+                                                },
+                                                "displayName": "Text__StyledText",
+                                                "foldedComponentIds": Array [],
+                                                "render": [Function],
+                                                "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
+                                                "target": "span",
+                                                "toString": [Function],
+                                                "warnTooManyClasses": [Function],
+                                                "withComponent": [Function],
+                                              }
+                                            }
+                                            forwardedRef={null}
+                                            invert={false}
                                             size="small"
                                           >
-                                            Tooltip text
-                                          </span>
-                                        </StyledComponent>
-                                      </Text__StyledText>
-                                    </Text>
-                                  </div>
-                                </StyledComponent>
-                              </Bubble__InnerBubbleStyle>
-                            </div>
-                          </StyledComponent>
-                        </styled.div>
-                      </Box>
-                    </Component>
-                  </StyledComponent>
-                </Styled(Component)>
-              </Bubble>
-              <StandaloneIcon
-                a11yText="Reveal additional information."
-                aria-controls="standalone-tooltip-tooltip5_tooltip"
-                aria-expanded="true"
-                aria-haspopup="true"
-                id="standalone-tooltip-tooltip5_trigger"
-                onClick={[Function]}
-                size={24}
-                symbol="questionMarkCircle"
-                type="button"
-              >
-                <StandaloneIcon__StandaloneIconClickable
+                                            <span
+                                              className="c5"
+                                              size="small"
+                                            >
+                                              Tooltip text
+                                            </span>
+                                          </StyledComponent>
+                                        </Text__StyledText>
+                                      </Text>
+                                    </div>
+                                  </StyledComponent>
+                                </Bubble__InnerBubbleStyle>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </Box>
+                      </Component>
+                    </StyledComponent>
+                  </Styled(Component)>
+                </Bubble>
+                <StandaloneIcon
+                  a11yText="Reveal additional information."
                   aria-controls="standalone-tooltip-tooltip5_tooltip"
                   aria-expanded="true"
                   aria-haspopup="true"
                   id="standalone-tooltip-tooltip5_trigger"
                   onClick={[Function]}
-                  style={
-                    Object {
-                      "margin": "-4px",
-                      "padding": "4px",
-                    }
-                  }
+                  size={24}
+                  symbol="questionMarkCircle"
                   type="button"
                 >
-                  <StyledComponent
+                  <StandaloneIcon__StandaloneIconClickable
                     aria-controls="standalone-tooltip-tooltip5_tooltip"
                     aria-expanded="true"
                     aria-haspopup="true"
-                    forwardedComponent={
-                      Object {
-                        "$$typeof": Symbol(react.forward_ref),
-                        "attrs": Array [],
-                        "componentStyle": ComponentStyle {
-                          "componentId": "StandaloneIcon__StandaloneIconClickable-ukibfn-0",
-                          "isStatic": true,
-                          "lastClassName": "c6",
-                          "rules": Array [
-                            "padding: 0;",
-                            "margin: 0;",
-                            "border-width: 0;",
-                            "font-family: \\"TELUS-Web\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif;",
-                            "color: #2a2c2e;",
-                            "appearance: none;",
-                            "background: none;",
-                            "box-shadow: none;",
-                            "cursor: pointer;",
-                          ],
-                        },
-                        "displayName": "StandaloneIcon__StandaloneIconClickable",
-                        "foldedComponentIds": Array [],
-                        "render": [Function],
-                        "styledComponentId": "StandaloneIcon__StandaloneIconClickable-ukibfn-0",
-                        "target": "button",
-                        "toString": [Function],
-                        "warnTooManyClasses": [Function],
-                        "withComponent": [Function],
-                      }
-                    }
-                    forwardedRef={null}
                     id="standalone-tooltip-tooltip5_trigger"
                     onClick={[Function]}
                     style={
@@ -1892,11 +1865,41 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 2`] 
                     }
                     type="button"
                   >
-                    <button
+                    <StyledComponent
                       aria-controls="standalone-tooltip-tooltip5_tooltip"
                       aria-expanded="true"
                       aria-haspopup="true"
-                      className="c6"
+                      forwardedComponent={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "attrs": Array [],
+                          "componentStyle": ComponentStyle {
+                            "componentId": "StandaloneIcon__StandaloneIconClickable-ukibfn-0",
+                            "isStatic": true,
+                            "lastClassName": "c6",
+                            "rules": Array [
+                              "padding: 0;",
+                              "margin: 0;",
+                              "border-width: 0;",
+                              "font-family: \\"TELUS-Web\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif;",
+                              "color: #2a2c2e;",
+                              "appearance: none;",
+                              "background: none;",
+                              "box-shadow: none;",
+                              "cursor: pointer;",
+                            ],
+                          },
+                          "displayName": "StandaloneIcon__StandaloneIconClickable",
+                          "foldedComponentIds": Array [],
+                          "render": [Function],
+                          "styledComponentId": "StandaloneIcon__StandaloneIconClickable-ukibfn-0",
+                          "target": "button",
+                          "toString": [Function],
+                          "warnTooManyClasses": [Function],
+                          "withComponent": [Function],
+                        }
+                      }
+                      forwardedRef={null}
                       id="standalone-tooltip-tooltip5_trigger"
                       onClick={[Function]}
                       style={
@@ -1907,100 +1910,116 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 2`] 
                       }
                       type="button"
                     >
-                      <Icon
-                        size={24}
-                        symbol="questionMarkCircle"
+                      <button
+                        aria-controls="standalone-tooltip-tooltip5_tooltip"
+                        aria-expanded="true"
+                        aria-haspopup="true"
+                        className="c6"
+                        id="standalone-tooltip-tooltip5_trigger"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "margin": "-4px",
+                            "padding": "4px",
+                          }
+                        }
+                        type="button"
                       >
-                        <Icon__StyledIcon
-                          iSize={24}
+                        <Icon
+                          size={24}
                           symbol="questionMarkCircle"
                         >
-                          <StyledComponent
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "attrs": Array [],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "Icon__StyledIcon-sc-1g20dn8-0",
-                                  "isStatic": false,
-                                  "lastClassName": "c7",
-                                  "rules": Array [
-                                    [Function],
-                                    [Function],
-                                    [Function],
-                                  ],
-                                },
-                                "displayName": "Icon__StyledIcon",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "Icon__StyledIcon-sc-1g20dn8-0",
-                                "target": "i",
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
-                            }
-                            forwardedRef={null}
+                          <Icon__StyledIcon
                             iSize={24}
                             symbol="questionMarkCircle"
                           >
-                            <i
-                              className="c7"
+                            <StyledComponent
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "Icon__StyledIcon-sc-1g20dn8-0",
+                                    "isStatic": false,
+                                    "lastClassName": "c7",
+                                    "rules": Array [
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                    ],
+                                  },
+                                  "displayName": "Icon__StyledIcon",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "Icon__StyledIcon-sc-1g20dn8-0",
+                                  "target": "i",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              iSize={24}
+                              symbol="questionMarkCircle"
                             >
-                              <A11yContent>
-                                <A11yContent__StyledA11yContent>
-                                  <StyledComponent
-                                    forwardedComponent={
-                                      Object {
-                                        "$$typeof": Symbol(react.forward_ref),
-                                        "attrs": Array [],
-                                        "componentStyle": ComponentStyle {
-                                          "componentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
-                                          "isStatic": true,
-                                          "lastClassName": "c8",
-                                          "rules": Array [
-                                            "position: absolute;",
-                                            "height: 1px;",
-                                            "width: 1px;",
-                                            "overflow: hidden;",
-                                            "clip: rect(1px, 1px, 1px, 1px);",
-                                          ],
-                                        },
-                                        "displayName": "A11yContent__StyledA11yContent",
-                                        "foldedComponentIds": Array [],
-                                        "render": [Function],
-                                        "styledComponentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
-                                        "target": "span",
-                                        "toString": [Function],
-                                        "warnTooManyClasses": [Function],
-                                        "withComponent": [Function],
+                              <i
+                                className="c7"
+                              >
+                                <A11yContent>
+                                  <A11yContent__StyledA11yContent>
+                                    <StyledComponent
+                                      forwardedComponent={
+                                        Object {
+                                          "$$typeof": Symbol(react.forward_ref),
+                                          "attrs": Array [],
+                                          "componentStyle": ComponentStyle {
+                                            "componentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
+                                            "isStatic": true,
+                                            "lastClassName": "c8",
+                                            "rules": Array [
+                                              "position: absolute;",
+                                              "height: 1px;",
+                                              "width: 1px;",
+                                              "overflow: hidden;",
+                                              "clip: rect(1px, 1px, 1px, 1px);",
+                                            ],
+                                          },
+                                          "displayName": "A11yContent__StyledA11yContent",
+                                          "foldedComponentIds": Array [],
+                                          "render": [Function],
+                                          "styledComponentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
+                                          "target": "span",
+                                          "toString": [Function],
+                                          "warnTooManyClasses": [Function],
+                                          "withComponent": [Function],
+                                        }
                                       }
-                                    }
-                                    forwardedRef={null}
-                                  >
-                                    <span
-                                      className="c8"
+                                      forwardedRef={null}
                                     >
-                                      Reveal additional information.
-                                    </span>
-                                  </StyledComponent>
-                                </A11yContent__StyledA11yContent>
-                              </A11yContent>
-                            </i>
-                          </StyledComponent>
-                        </Icon__StyledIcon>
-                      </Icon>
-                    </button>
-                  </StyledComponent>
-                </StandaloneIcon__StandaloneIconClickable>
-              </StandaloneIcon>
-            </div>
-          </StyledComponent>
-        </Tooltip__TooltipContainer>
-      </div>
-    </StyledComponent>
-  </Tooltip__StyledTooltip>
-</Tooltip>
+                                      <span
+                                        className="c8"
+                                      >
+                                        Reveal additional information.
+                                      </span>
+                                    </StyledComponent>
+                                  </A11yContent__StyledA11yContent>
+                                </A11yContent>
+                              </i>
+                            </StyledComponent>
+                          </Icon__StyledIcon>
+                        </Icon>
+                      </button>
+                    </StyledComponent>
+                  </StandaloneIcon__StandaloneIconClickable>
+                </StandaloneIcon>
+              </div>
+            </StyledComponent>
+          </Tooltip__TooltipContainer>
+        </div>
+      </StyledComponent>
+    </Tooltip__StyledTooltip>
+  </Tooltip>
+</WithForwardedRef(Tooltip)>
 `;
 
 exports[`Tooltip interactivity shows and hides the bubble 1`] = `
@@ -2726,105 +2745,90 @@ exports[`Tooltip renders 1`] = `
   }
 }
 
-<Tooltip
+<WithForwardedRef(Tooltip)
   copy="en"
-  direction="auto"
 >
-  <Tooltip__StyledTooltip>
-    <StyledComponent
-      forwardedComponent={
-        Object {
-          "$$typeof": Symbol(react.forward_ref),
-          "attrs": Array [],
-          "componentStyle": ComponentStyle {
-            "componentId": "Tooltip__StyledTooltip-sc-2tc47i-0",
-            "isStatic": true,
-            "lastClassName": "c0",
-            "rules": Array [
-              "line-height: 1;",
-              "position: relative;",
-              "width: 1rem;",
-              "height: 1.3rem;",
-            ],
-          },
-          "displayName": "Tooltip__StyledTooltip",
-          "foldedComponentIds": Array [],
-          "render": [Function],
-          "styledComponentId": "Tooltip__StyledTooltip-sc-2tc47i-0",
-          "target": "div",
-          "toString": [Function],
-          "warnTooManyClasses": [Function],
-          "withComponent": [Function],
+  <Tooltip
+    copy="en"
+    direction="auto"
+    forwardedRef={null}
+  >
+    <Tooltip__StyledTooltip>
+      <StyledComponent
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "Tooltip__StyledTooltip-sc-2tc47i-0",
+              "isStatic": true,
+              "lastClassName": "c0",
+              "rules": Array [
+                "line-height: 1;",
+                "position: relative;",
+                "width: 1rem;",
+                "height: 1.3rem;",
+              ],
+            },
+            "displayName": "Tooltip__StyledTooltip",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "Tooltip__StyledTooltip-sc-2tc47i-0",
+            "target": "div",
+            "toString": [Function],
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
         }
-      }
-      forwardedRef={[Function]}
-    >
-      <div
-        className="c0"
+        forwardedRef={[Function]}
       >
-        <Tooltip__TooltipContainer
-          data-testid="tooltipContainer"
+        <div
+          className="c0"
         >
-          <StyledComponent
+          <Tooltip__TooltipContainer
             data-testid="tooltipContainer"
-            forwardedComponent={
-              Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "attrs": Array [],
-                "componentStyle": ComponentStyle {
-                  "componentId": "Tooltip__TooltipContainer-sc-2tc47i-1",
-                  "isStatic": true,
-                  "lastClassName": "c1",
-                  "rules": Array [
-                    "position: absolute;",
-                  ],
-                },
-                "displayName": "Tooltip__TooltipContainer",
-                "foldedComponentIds": Array [],
-                "render": [Function],
-                "styledComponentId": "Tooltip__TooltipContainer-sc-2tc47i-1",
-                "target": "div",
-                "toString": [Function],
-                "warnTooManyClasses": [Function],
-                "withComponent": [Function],
-              }
-            }
-            forwardedRef={null}
           >
-            <div
-              className="c1"
+            <StyledComponent
               data-testid="tooltipContainer"
-            >
-              <Bubble
-                direction="right"
-                id="standalone-tooltip-tooltip1_tooltip"
-                open={false}
-                width={
-                  Object {
-                    "width": "calc(1008px - 1rem - 0.5rem)",
-                  }
+              forwardedComponent={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "attrs": Array [],
+                  "componentStyle": ComponentStyle {
+                    "componentId": "Tooltip__TooltipContainer-sc-2tc47i-1",
+                    "isStatic": true,
+                    "lastClassName": "c1",
+                    "rules": Array [
+                      "position: absolute;",
+                    ],
+                  },
+                  "displayName": "Tooltip__TooltipContainer",
+                  "foldedComponentIds": Array [],
+                  "render": [Function],
+                  "styledComponentId": "Tooltip__TooltipContainer-sc-2tc47i-1",
+                  "target": "div",
+                  "toString": [Function],
+                  "warnTooManyClasses": [Function],
+                  "withComponent": [Function],
                 }
+              }
+              forwardedRef={null}
+            >
+              <div
+                className="c1"
+                data-testid="tooltipContainer"
               >
-                <Styled(Component)
-                  aria-hidden="true"
-                  aria-live="assertive"
-                  bubbleDimensions={
-                    Object {
-                      "bubbleOffset": "7px",
-                      "bubbleTriangleHeight": "10px",
-                      "bubbleTrianglePosition": "12px",
-                      "bubbleTriangleWidth": "7px",
-                      "bubbleTriggerSize": "24px",
-                    }
-                  }
+                <Bubble
                   direction="right"
-                  horizontal={3}
                   id="standalone-tooltip-tooltip1_tooltip"
                   open={false}
-                  role="tooltip"
-                  vertical={2}
+                  width={
+                    Object {
+                      "width": "calc(1008px - 1rem - 0.5rem)",
+                    }
+                  }
                 >
-                  <StyledComponent
+                  <Styled(Component)
                     aria-hidden="true"
                     aria-live="assertive"
                     bubbleDimensions={
@@ -2837,39 +2841,13 @@ exports[`Tooltip renders 1`] = `
                       }
                     }
                     direction="right"
-                    forwardedComponent={
-                      Object {
-                        "$$typeof": Symbol(react.forward_ref),
-                        "attrs": Array [
-                          [Function],
-                        ],
-                        "componentStyle": ComponentStyle {
-                          "componentId": "sc-bwzfXH",
-                          "isStatic": false,
-                          "lastClassName": "c2",
-                          "rules": Array [
-                            "border-radius: 4px;",
-                            [Function],
-                          ],
-                        },
-                        "displayName": "Styled(Component)",
-                        "foldedComponentIds": Array [],
-                        "render": [Function],
-                        "styledComponentId": "sc-bwzfXH",
-                        "target": [Function],
-                        "toString": [Function],
-                        "warnTooManyClasses": [Function],
-                        "withComponent": [Function],
-                      }
-                    }
-                    forwardedRef={null}
                     horizontal={3}
                     id="standalone-tooltip-tooltip1_tooltip"
                     open={false}
                     role="tooltip"
                     vertical={2}
                   >
-                    <Component
+                    <StyledComponent
                       aria-hidden="true"
                       aria-live="assertive"
                       bubbleDimensions={
@@ -2881,28 +2859,61 @@ exports[`Tooltip renders 1`] = `
                           "bubbleTriggerSize": "24px",
                         }
                       }
-                      className="c2"
-                      data-testid="bubble"
                       direction="right"
+                      forwardedComponent={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "attrs": Array [
+                            [Function],
+                          ],
+                          "componentStyle": ComponentStyle {
+                            "componentId": "sc-bwzfXH",
+                            "isStatic": false,
+                            "lastClassName": "c2",
+                            "rules": Array [
+                              "border-radius: 4px;",
+                              [Function],
+                            ],
+                          },
+                          "displayName": "Styled(Component)",
+                          "foldedComponentIds": Array [],
+                          "render": [Function],
+                          "styledComponentId": "sc-bwzfXH",
+                          "target": [Function],
+                          "toString": [Function],
+                          "warnTooManyClasses": [Function],
+                          "withComponent": [Function],
+                        }
+                      }
+                      forwardedRef={null}
                       horizontal={3}
                       id="standalone-tooltip-tooltip1_tooltip"
                       open={false}
                       role="tooltip"
                       vertical={2}
                     >
-                      <Box
+                      <Component
                         aria-hidden="true"
                         aria-live="assertive"
+                        bubbleDimensions={
+                          Object {
+                            "bubbleOffset": "7px",
+                            "bubbleTriangleHeight": "10px",
+                            "bubbleTrianglePosition": "12px",
+                            "bubbleTriangleWidth": "7px",
+                            "bubbleTriggerSize": "24px",
+                          }
+                        }
                         className="c2"
                         data-testid="bubble"
+                        direction="right"
                         horizontal={3}
                         id="standalone-tooltip-tooltip1_tooltip"
-                        inline={false}
+                        open={false}
                         role="tooltip"
-                        tag="div"
                         vertical={2}
                       >
-                        <styled.div
+                        <Box
                           aria-hidden="true"
                           aria-live="assertive"
                           className="c2"
@@ -2914,41 +2925,11 @@ exports[`Tooltip renders 1`] = `
                           tag="div"
                           vertical={2}
                         >
-                          <StyledComponent
+                          <styled.div
                             aria-hidden="true"
                             aria-live="assertive"
                             className="c2"
                             data-testid="bubble"
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "attrs": Array [
-                                  [Function],
-                                ],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "sc-bdVaJa",
-                                  "isStatic": false,
-                                  "lastClassName": "c3",
-                                  "rules": Array [
-                                    [Function],
-                                    [Function],
-                                    [Function],
-                                    [Function],
-                                    [Function],
-                                    [Function],
-                                  ],
-                                },
-                                "displayName": "styled.div",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "sc-bdVaJa",
-                                "target": "div",
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
-                            }
-                            forwardedRef={null}
                             horizontal={3}
                             id="standalone-tooltip-tooltip1_tooltip"
                             inline={false}
@@ -2956,186 +2937,183 @@ exports[`Tooltip renders 1`] = `
                             tag="div"
                             vertical={2}
                           >
-                            <div
+                            <StyledComponent
                               aria-hidden="true"
                               aria-live="assertive"
-                              className="c2 sc-bwzfXH c2 c3"
+                              className="c2"
                               data-testid="bubble"
-                              id="standalone-tooltip-tooltip1_tooltip"
-                              role="tooltip"
-                            >
-                              <Bubble__InnerBubbleStyle
-                                bubbleWidth={
-                                  Object {
-                                    "width": "calc(1008px - 1rem - 0.5rem)",
-                                  }
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [
+                                    [Function],
+                                  ],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-bdVaJa",
+                                    "isStatic": false,
+                                    "lastClassName": "c3",
+                                    "rules": Array [
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                    ],
+                                  },
+                                  "displayName": "styled.div",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-bdVaJa",
+                                  "target": "div",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
                                 }
+                              }
+                              forwardedRef={null}
+                              horizontal={3}
+                              id="standalone-tooltip-tooltip1_tooltip"
+                              inline={false}
+                              role="tooltip"
+                              tag="div"
+                              vertical={2}
+                            >
+                              <div
+                                aria-hidden="true"
+                                aria-live="assertive"
+                                className="c2 sc-bwzfXH c2 c3"
+                                data-testid="bubble"
+                                id="standalone-tooltip-tooltip1_tooltip"
+                                role="tooltip"
                               >
-                                <StyledComponent
+                                <Bubble__InnerBubbleStyle
                                   bubbleWidth={
                                     Object {
                                       "width": "calc(1008px - 1rem - 0.5rem)",
                                     }
                                   }
-                                  forwardedComponent={
-                                    Object {
-                                      "$$typeof": Symbol(react.forward_ref),
-                                      "attrs": Array [],
-                                      "componentStyle": ComponentStyle {
-                                        "componentId": "Bubble__InnerBubbleStyle-sc-15jatun-0",
-                                        "isStatic": false,
-                                        "lastClassName": "c4",
-                                        "rules": Array [
-                                          [Function],
-                                        ],
-                                      },
-                                      "displayName": "Bubble__InnerBubbleStyle",
-                                      "foldedComponentIds": Array [],
-                                      "render": [Function],
-                                      "styledComponentId": "Bubble__InnerBubbleStyle-sc-15jatun-0",
-                                      "target": "div",
-                                      "toString": [Function],
-                                      "warnTooManyClasses": [Function],
-                                      "withComponent": [Function],
-                                    }
-                                  }
-                                  forwardedRef={null}
                                 >
-                                  <div
-                                    className="c4"
+                                  <StyledComponent
+                                    bubbleWidth={
+                                      Object {
+                                        "width": "calc(1008px - 1rem - 0.5rem)",
+                                      }
+                                    }
+                                    forwardedComponent={
+                                      Object {
+                                        "$$typeof": Symbol(react.forward_ref),
+                                        "attrs": Array [],
+                                        "componentStyle": ComponentStyle {
+                                          "componentId": "Bubble__InnerBubbleStyle-sc-15jatun-0",
+                                          "isStatic": false,
+                                          "lastClassName": "c4",
+                                          "rules": Array [
+                                            [Function],
+                                          ],
+                                        },
+                                        "displayName": "Bubble__InnerBubbleStyle",
+                                        "foldedComponentIds": Array [],
+                                        "render": [Function],
+                                        "styledComponentId": "Bubble__InnerBubbleStyle-sc-15jatun-0",
+                                        "target": "div",
+                                        "toString": [Function],
+                                        "warnTooManyClasses": [Function],
+                                        "withComponent": [Function],
+                                      }
+                                    }
+                                    forwardedRef={null}
                                   >
-                                    <Text
-                                      block={false}
-                                      bold={false}
-                                      invert={false}
-                                      size="small"
+                                    <div
+                                      className="c4"
                                     >
-                                      <Text__StyledText
+                                      <Text
                                         block={false}
                                         bold={false}
                                         invert={false}
                                         size="small"
                                       >
-                                        <StyledComponent
+                                        <Text__StyledText
                                           block={false}
                                           bold={false}
-                                          forwardedComponent={
-                                            Object {
-                                              "$$typeof": Symbol(react.forward_ref),
-                                              "attrs": Array [],
-                                              "componentStyle": ComponentStyle {
-                                                "componentId": "Text__StyledText-sc-1m0rr67-0",
-                                                "isStatic": false,
-                                                "lastClassName": "c5",
-                                                "rules": Array [
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  "sup {",
-                                                  "top: -0.5em;",
-                                                  "font-size: 0.875rem;",
-                                                  "position: relative;",
-                                                  "vertical-align: baseline;",
-                                                  "padding-left: 0.1em;",
-                                                  "}",
-                                                ],
-                                              },
-                                              "displayName": "Text__StyledText",
-                                              "foldedComponentIds": Array [],
-                                              "render": [Function],
-                                              "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
-                                              "target": "span",
-                                              "toString": [Function],
-                                              "warnTooManyClasses": [Function],
-                                              "withComponent": [Function],
-                                            }
-                                          }
-                                          forwardedRef={null}
                                           invert={false}
                                           size="small"
                                         >
-                                          <span
-                                            className="c5"
+                                          <StyledComponent
+                                            block={false}
+                                            bold={false}
+                                            forwardedComponent={
+                                              Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "attrs": Array [],
+                                                "componentStyle": ComponentStyle {
+                                                  "componentId": "Text__StyledText-sc-1m0rr67-0",
+                                                  "isStatic": false,
+                                                  "lastClassName": "c5",
+                                                  "rules": Array [
+                                                    [Function],
+                                                    [Function],
+                                                    [Function],
+                                                    [Function],
+                                                    [Function],
+                                                    "sup {",
+                                                    "top: -0.5em;",
+                                                    "font-size: 0.875rem;",
+                                                    "position: relative;",
+                                                    "vertical-align: baseline;",
+                                                    "padding-left: 0.1em;",
+                                                    "}",
+                                                  ],
+                                                },
+                                                "displayName": "Text__StyledText",
+                                                "foldedComponentIds": Array [],
+                                                "render": [Function],
+                                                "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
+                                                "target": "span",
+                                                "toString": [Function],
+                                                "warnTooManyClasses": [Function],
+                                                "withComponent": [Function],
+                                              }
+                                            }
+                                            forwardedRef={null}
+                                            invert={false}
                                             size="small"
                                           >
-                                            Tooltip text
-                                          </span>
-                                        </StyledComponent>
-                                      </Text__StyledText>
-                                    </Text>
-                                  </div>
-                                </StyledComponent>
-                              </Bubble__InnerBubbleStyle>
-                            </div>
-                          </StyledComponent>
-                        </styled.div>
-                      </Box>
-                    </Component>
-                  </StyledComponent>
-                </Styled(Component)>
-              </Bubble>
-              <StandaloneIcon
-                a11yText="Reveal additional information."
-                aria-controls="standalone-tooltip-tooltip1_tooltip"
-                aria-expanded="false"
-                aria-haspopup="true"
-                id="standalone-tooltip-tooltip1_trigger"
-                onClick={[Function]}
-                size={24}
-                symbol="questionMarkCircle"
-                type="button"
-              >
-                <StandaloneIcon__StandaloneIconClickable
+                                            <span
+                                              className="c5"
+                                              size="small"
+                                            >
+                                              Tooltip text
+                                            </span>
+                                          </StyledComponent>
+                                        </Text__StyledText>
+                                      </Text>
+                                    </div>
+                                  </StyledComponent>
+                                </Bubble__InnerBubbleStyle>
+                              </div>
+                            </StyledComponent>
+                          </styled.div>
+                        </Box>
+                      </Component>
+                    </StyledComponent>
+                  </Styled(Component)>
+                </Bubble>
+                <StandaloneIcon
+                  a11yText="Reveal additional information."
                   aria-controls="standalone-tooltip-tooltip1_tooltip"
                   aria-expanded="false"
                   aria-haspopup="true"
                   id="standalone-tooltip-tooltip1_trigger"
                   onClick={[Function]}
-                  style={
-                    Object {
-                      "margin": "-4px",
-                      "padding": "4px",
-                    }
-                  }
+                  size={24}
+                  symbol="questionMarkCircle"
                   type="button"
                 >
-                  <StyledComponent
+                  <StandaloneIcon__StandaloneIconClickable
                     aria-controls="standalone-tooltip-tooltip1_tooltip"
                     aria-expanded="false"
                     aria-haspopup="true"
-                    forwardedComponent={
-                      Object {
-                        "$$typeof": Symbol(react.forward_ref),
-                        "attrs": Array [],
-                        "componentStyle": ComponentStyle {
-                          "componentId": "StandaloneIcon__StandaloneIconClickable-ukibfn-0",
-                          "isStatic": true,
-                          "lastClassName": "c6",
-                          "rules": Array [
-                            "padding: 0;",
-                            "margin: 0;",
-                            "border-width: 0;",
-                            "font-family: \\"TELUS-Web\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif;",
-                            "color: #2a2c2e;",
-                            "appearance: none;",
-                            "background: none;",
-                            "box-shadow: none;",
-                            "cursor: pointer;",
-                          ],
-                        },
-                        "displayName": "StandaloneIcon__StandaloneIconClickable",
-                        "foldedComponentIds": Array [],
-                        "render": [Function],
-                        "styledComponentId": "StandaloneIcon__StandaloneIconClickable-ukibfn-0",
-                        "target": "button",
-                        "toString": [Function],
-                        "warnTooManyClasses": [Function],
-                        "withComponent": [Function],
-                      }
-                    }
-                    forwardedRef={null}
                     id="standalone-tooltip-tooltip1_trigger"
                     onClick={[Function]}
                     style={
@@ -3146,11 +3124,41 @@ exports[`Tooltip renders 1`] = `
                     }
                     type="button"
                   >
-                    <button
+                    <StyledComponent
                       aria-controls="standalone-tooltip-tooltip1_tooltip"
                       aria-expanded="false"
                       aria-haspopup="true"
-                      className="c6"
+                      forwardedComponent={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "attrs": Array [],
+                          "componentStyle": ComponentStyle {
+                            "componentId": "StandaloneIcon__StandaloneIconClickable-ukibfn-0",
+                            "isStatic": true,
+                            "lastClassName": "c6",
+                            "rules": Array [
+                              "padding: 0;",
+                              "margin: 0;",
+                              "border-width: 0;",
+                              "font-family: \\"TELUS-Web\\", \\"Helvetica Neue\\", Helvetica, Arial, sans-serif;",
+                              "color: #2a2c2e;",
+                              "appearance: none;",
+                              "background: none;",
+                              "box-shadow: none;",
+                              "cursor: pointer;",
+                            ],
+                          },
+                          "displayName": "StandaloneIcon__StandaloneIconClickable",
+                          "foldedComponentIds": Array [],
+                          "render": [Function],
+                          "styledComponentId": "StandaloneIcon__StandaloneIconClickable-ukibfn-0",
+                          "target": "button",
+                          "toString": [Function],
+                          "warnTooManyClasses": [Function],
+                          "withComponent": [Function],
+                        }
+                      }
+                      forwardedRef={null}
                       id="standalone-tooltip-tooltip1_trigger"
                       onClick={[Function]}
                       style={
@@ -3161,98 +3169,114 @@ exports[`Tooltip renders 1`] = `
                       }
                       type="button"
                     >
-                      <Icon
-                        size={24}
-                        symbol="questionMarkCircle"
+                      <button
+                        aria-controls="standalone-tooltip-tooltip1_tooltip"
+                        aria-expanded="false"
+                        aria-haspopup="true"
+                        className="c6"
+                        id="standalone-tooltip-tooltip1_trigger"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "margin": "-4px",
+                            "padding": "4px",
+                          }
+                        }
+                        type="button"
                       >
-                        <Icon__StyledIcon
-                          iSize={24}
+                        <Icon
+                          size={24}
                           symbol="questionMarkCircle"
                         >
-                          <StyledComponent
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "attrs": Array [],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "Icon__StyledIcon-sc-1g20dn8-0",
-                                  "isStatic": false,
-                                  "lastClassName": "c7",
-                                  "rules": Array [
-                                    [Function],
-                                    [Function],
-                                    [Function],
-                                  ],
-                                },
-                                "displayName": "Icon__StyledIcon",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "Icon__StyledIcon-sc-1g20dn8-0",
-                                "target": "i",
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
-                            }
-                            forwardedRef={null}
+                          <Icon__StyledIcon
                             iSize={24}
                             symbol="questionMarkCircle"
                           >
-                            <i
-                              className="c7"
+                            <StyledComponent
+                              forwardedComponent={
+                                Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "Icon__StyledIcon-sc-1g20dn8-0",
+                                    "isStatic": false,
+                                    "lastClassName": "c7",
+                                    "rules": Array [
+                                      [Function],
+                                      [Function],
+                                      [Function],
+                                    ],
+                                  },
+                                  "displayName": "Icon__StyledIcon",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "Icon__StyledIcon-sc-1g20dn8-0",
+                                  "target": "i",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                }
+                              }
+                              forwardedRef={null}
+                              iSize={24}
+                              symbol="questionMarkCircle"
                             >
-                              <A11yContent>
-                                <A11yContent__StyledA11yContent>
-                                  <StyledComponent
-                                    forwardedComponent={
-                                      Object {
-                                        "$$typeof": Symbol(react.forward_ref),
-                                        "attrs": Array [],
-                                        "componentStyle": ComponentStyle {
-                                          "componentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
-                                          "isStatic": true,
-                                          "lastClassName": "c8",
-                                          "rules": Array [
-                                            "position: absolute;",
-                                            "height: 1px;",
-                                            "width: 1px;",
-                                            "overflow: hidden;",
-                                            "clip: rect(1px, 1px, 1px, 1px);",
-                                          ],
-                                        },
-                                        "displayName": "A11yContent__StyledA11yContent",
-                                        "foldedComponentIds": Array [],
-                                        "render": [Function],
-                                        "styledComponentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
-                                        "target": "span",
-                                        "toString": [Function],
-                                        "warnTooManyClasses": [Function],
-                                        "withComponent": [Function],
+                              <i
+                                className="c7"
+                              >
+                                <A11yContent>
+                                  <A11yContent__StyledA11yContent>
+                                    <StyledComponent
+                                      forwardedComponent={
+                                        Object {
+                                          "$$typeof": Symbol(react.forward_ref),
+                                          "attrs": Array [],
+                                          "componentStyle": ComponentStyle {
+                                            "componentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
+                                            "isStatic": true,
+                                            "lastClassName": "c8",
+                                            "rules": Array [
+                                              "position: absolute;",
+                                              "height: 1px;",
+                                              "width: 1px;",
+                                              "overflow: hidden;",
+                                              "clip: rect(1px, 1px, 1px, 1px);",
+                                            ],
+                                          },
+                                          "displayName": "A11yContent__StyledA11yContent",
+                                          "foldedComponentIds": Array [],
+                                          "render": [Function],
+                                          "styledComponentId": "A11yContent__StyledA11yContent-sc-15wexwk-0",
+                                          "target": "span",
+                                          "toString": [Function],
+                                          "warnTooManyClasses": [Function],
+                                          "withComponent": [Function],
+                                        }
                                       }
-                                    }
-                                    forwardedRef={null}
-                                  >
-                                    <span
-                                      className="c8"
+                                      forwardedRef={null}
                                     >
-                                      Reveal additional information.
-                                    </span>
-                                  </StyledComponent>
-                                </A11yContent__StyledA11yContent>
-                              </A11yContent>
-                            </i>
-                          </StyledComponent>
-                        </Icon__StyledIcon>
-                      </Icon>
-                    </button>
-                  </StyledComponent>
-                </StandaloneIcon__StandaloneIconClickable>
-              </StandaloneIcon>
-            </div>
-          </StyledComponent>
-        </Tooltip__TooltipContainer>
-      </div>
-    </StyledComponent>
-  </Tooltip__StyledTooltip>
-</Tooltip>
+                                      <span
+                                        className="c8"
+                                      >
+                                        Reveal additional information.
+                                      </span>
+                                    </StyledComponent>
+                                  </A11yContent__StyledA11yContent>
+                                </A11yContent>
+                              </i>
+                            </StyledComponent>
+                          </Icon__StyledIcon>
+                        </Icon>
+                      </button>
+                    </StyledComponent>
+                  </StandaloneIcon__StandaloneIconClickable>
+                </StandaloneIcon>
+              </div>
+            </StyledComponent>
+          </Tooltip__TooltipContainer>
+        </div>
+      </StyledComponent>
+    </Tooltip__StyledTooltip>
+  </Tooltip>
+</WithForwardedRef(Tooltip)>
 `;

--- a/packages/Tooltip/package.json
+++ b/packages/Tooltip/package.json
@@ -30,6 +30,7 @@
     "@tds/core-responsive": "^1.3.1",
     "@tds/core-standalone-icon": "^2.1.6",
     "@tds/core-text": "^2.0.4",
+    "@tds/shared-hocs": "^1.1.0",
     "@tds/shared-styles": "^1.5.0",
     "@tds/util-helpers": "^1.2.0",
     "prop-types": "^15.5.10"

--- a/packages/hocs/index.js
+++ b/packages/hocs/index.js
@@ -1,2 +1,3 @@
 export { default as withFocusTrap } from './withFocusTrap'
 export { default as withStyledComponent } from './withStyledComponent'
+export { default as withForwardedRef } from './withForwardedRef'

--- a/packages/hocs/withForwardedRef.jsx
+++ b/packages/hocs/withForwardedRef.jsx
@@ -1,0 +1,15 @@
+import React, { forwardRef } from 'react'
+
+const getDisplayName = Component => {
+  return Component.displayName || Component.name || 'Component'
+}
+
+const withForwardedRef = Component => {
+  const WithForwardedRef = forwardRef((props, ref) => <Component {...props} forwardedRef={ref} />)
+
+  WithForwardedRef.displayName = `WithForwardedRef(${getDisplayName(Component)})`
+
+  return WithForwardedRef
+}
+
+export default withForwardedRef


### PR DESCRIPTION
## Description

All focusable elements should utilize React’s `forwardRef` feature. A minor release is made fo these components:

- [x] Breadcrumbs
- [x] ChevronLink
- [x] InteractiveIcon
- [x] Link
- Terms and Conditions:
  - [x] ExpandCollapsible
- [x] Tooltip

## Checklist before submitting pull request

- [ ] New code is unit tested
- Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [ ] For code changes, run `npm run prepr` locally
  - make sure visual and accessibility tests pass
