### PR TITLE
fix(core-colours): fix path to deprecate.js for windows

### DIFF
--- a/packages/colours/package.json
+++ b/packages/colours/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/telusdigital/tds.git"
   },
   "scripts": {
-    "postinstall": "node ./deprecate.js; exit 0;"
+    "postinstall": "node deprecate.js"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Related issues

Fixes #1278 

## Description

There were some issues when trying to run `@tds/core-colours` postinstall script using MINGW64 on Windows.

Before:
![image](https://user-images.githubusercontent.com/12414771/66431281-f1c5f180-e9d8-11e9-9d40-27cc23ccfd68.png)

After:
![image](https://user-images.githubusercontent.com/12414771/66431288-f68aa580-e9d8-11e9-9b7c-c7a7643de854.png)


## Checklist before submitting pull request

- [x] New code is unit tested
- Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [ ] For code changes, run `npm run prepr` locally
  - make sure visual and accessibility tests pass
