### PR TITLE
fix(core-video): add focus border to middle play/pause button

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -545,6 +545,15 @@
       "contributions": [
         "tds"
       ]
+    },
+    {
+      "login": "donnavitan",
+      "name": "Donna Vitan",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/21316148?v=4",
+      "profile": "http://donnavitan.com",
+      "contributions": [
+        "tds"
+      ]
     }
   ],
   "commitConvention": "none"

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The following group are the active maintainers of this project, and have merge r
     <td align="center"><a href="https://github.com/cuginoAle"><img src="https://avatars3.githubusercontent.com/u/1298616?v=4" width="100px;" alt="Alessio Carnevale"/><br /><sub><b>Alessio Carnevale</b></sub></a><br /><a href="#tds-cuginoAle" title=""></a></td>
     <td align="center"><a href="https://github.com/Jeffrey-Chang"><img src="https://avatars3.githubusercontent.com/u/30445300?v=4" width="100px;" alt="Jeffrey Chang"/><br /><sub><b>Jeffrey Chang</b></sub></a><br /><a href="#tds-Jeffrey-Chang" title=""></a></td>
     <td align="center"><a href="https://github.com/AriqAhmad"><img src="https://avatars0.githubusercontent.com/u/23136810?v=4" width="100px;" alt="Ariq Ahmad"/><br /><sub><b>Ariq Ahmad</b></sub></a><br /><a href="#tds-AriqAhmad" title=""></a></td>
+    <td align="center"><a href="http://donnavitan.com"><img src="https://avatars3.githubusercontent.com/u/21316148?v=4" width="100px;" alt="Donna Vitan"/><br /><sub><b>Donna Vitan</b></sub></a><br /><a href="#tds-donnavitan" title=""></a></td>
   </tr>
 </table>
 

--- a/packages/Video/MiddleControlButton/MiddleControlButton.jsx
+++ b/packages/Video/MiddleControlButton/MiddleControlButton.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 
 import { colorGreyShark } from '@tds/core-colours'
 
-const StyledMiddleControlButton = styled.div(({ isHidden, iconLeftOffsetPx }) => ({
+const StyledMiddleControlButton = styled.button(({ isHidden, iconLeftOffsetPx }) => ({
   width: 64,
   height: 64,
   borderRadius: '50%',

--- a/packages/Video/Video.jsx
+++ b/packages/Video/Video.jsx
@@ -664,6 +664,7 @@ class Video extends React.Component {
                   iconLeftOffsetPx={this.state.videoIsPlaying ? 0 : 2}
                   isHidden={this.state.mouseInactive}
                   onClick={this.togglePlayPause}
+                  onFocus={this.resetInactivityTimer}
                 />
               )}
             {/* ========================================== */}


### PR DESCRIPTION
This addresses an accessibility issue where the middle play/pause button would not show a focus border when selected.