### PR TITLE
Fix/decorative icon sizing

### DIFF
--- a/packages/Benefit/BenefitNoHeading/__tests__/__snapshots__/BenefitNoHeading.spec.jsx.snap
+++ b/packages/Benefit/BenefitNoHeading/__tests__/__snapshots__/BenefitNoHeading.spec.jsx.snap
@@ -13,8 +13,8 @@ exports[`BenefitNoHeading renders with icons set in each item 1`] = `
 }
 
 .c2 > svg {
-  width: 24px;
-  height: 24px;
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 .c0 {
@@ -135,8 +135,8 @@ exports[`BenefitNoHeading renders with one icon set in the parent 1`] = `
 }
 
 .c2 > svg {
-  width: 24px;
-  height: 24px;
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 .c0 {

--- a/packages/Benefit/BenefitWithHeading/__tests__/__snapshots__/BenefitWithHeading.spec.jsx.snap
+++ b/packages/Benefit/BenefitWithHeading/__tests__/__snapshots__/BenefitWithHeading.spec.jsx.snap
@@ -13,8 +13,8 @@ exports[`BenefitWithHeading renders with icons set in each item 1`] = `
 }
 
 .c3 > svg {
-  width: 24px;
-  height: 24px;
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 .c4 {
@@ -196,8 +196,8 @@ exports[`BenefitWithHeading renders with one icon set in the parent 1`] = `
 }
 
 .c3 > svg {
-  width: 24px;
-  height: 24px;
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 .c4 {

--- a/packages/DecorativeIcon/SVGIcon.jsx
+++ b/packages/DecorativeIcon/SVGIcon.jsx
@@ -20,7 +20,9 @@ const getColour = variant => {
 }
 
 const svgVariant = ({ variant }) => ({ '& > svg': { fill: getColour(variant) } })
-const svgSize = ({ size }) => ({ '& > svg': { width: size, height: size } })
+const svgSize = ({ size }) => ({
+  '& > svg': { width: `${size / 16}rem`, height: `${size / 16}rem` },
+})
 
 const StyledSVGIcon = styled.i(
   {

--- a/packages/DecorativeIcon/SVGIcon.md
+++ b/packages/DecorativeIcon/SVGIcon.md
@@ -1,4 +1,4 @@
-`### Naming Convention
+### Naming Convention
 
 The convention for icon names is to capitalize the beginning of each word or abbreviation.
 For example the icon for Remote control is `RemoteControl`, the icon for USB cable is `UsbCable` and the icon for TV is `Tv`

--- a/packages/DecorativeIcon/__tests__/__snapshots__/SVGIcon.spec.jsx.snap
+++ b/packages/DecorativeIcon/__tests__/__snapshots__/SVGIcon.spec.jsx.snap
@@ -13,8 +13,8 @@ exports[`SVGIcon consumer renders 1`] = `
 }
 
 .c0 > svg {
-  width: 24px;
-  height: 24px;
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 <i
@@ -49,8 +49,8 @@ exports[`SVGIcon has size set to 24 1`] = `
 }
 
 .c0 > svg {
-  width: 24px;
-  height: 24px;
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 <i
@@ -75,8 +75,8 @@ exports[`SVGIcon renders 1`] = `
 }
 
 .c0 > svg {
-  width: 24px;
-  height: 24px;
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 <i

--- a/packages/WebVideo/__tests__/__snapshots__/WebVideo.spec.jsx.snap
+++ b/packages/WebVideo/__tests__/__snapshots__/WebVideo.spec.jsx.snap
@@ -36,8 +36,8 @@ exports[`WebVideo renders 1`] = `
 }
 
 .c13 > svg {
-  width: 16px;
-  height: 16px;
+  width: 1rem;
+  height: 1rem;
 }
 
 .c8 {


### PR DESCRIPTION
See #1284 

This addresses an issue where icons will not be sized properly on SSR. It also improves accessibility by using rem units to make the icons scale with the browser font size.