### PR TITLE
feat(core-web-video): add onstart callback

### DIFF
--- a/packages/WebVideo/WebVideo.jsx
+++ b/packages/WebVideo/WebVideo.jsx
@@ -46,11 +46,13 @@ const WebVideo = ({
   beginMuted,
   videoLength,
   copy,
+  onStart,
   ...rest
 }) => {
   const [started, setStarted] = useState(false)
 
   const initializeYoutubePlayer = event => {
+    onStart()
     if (beginMuted) {
       event.target.mute()
     }
@@ -124,6 +126,10 @@ WebVideo.propTypes = {
    * The splash screen UI's language as an ISO language code. It currently supports English and French.
    */
   copy: PropTypes.oneOf(['en', 'fr']).isRequired,
+  /**
+   * A function to be run when the play button is pressed on the video splash screen and the video is ready to play.
+   */
+  onStart: PropTypes.func,
 }
 
 WebVideo.defaultProps = {
@@ -131,6 +137,7 @@ WebVideo.defaultProps = {
   posterSrc: undefined,
   defaultVolume: 1,
   beginMuted: false,
+  onStart: () => {},
 }
 
 export default WebVideo

--- a/packages/WebVideo/__tests__/__snapshots__/WebVideo.spec.jsx.snap
+++ b/packages/WebVideo/__tests__/__snapshots__/WebVideo.spec.jsx.snap
@@ -248,6 +248,7 @@ exports[`WebVideo renders 1`] = `
   beginMuted={false}
   copy="en"
   defaultVolume={1}
+  onStart={[Function]}
   videoId="ppF-fn37SDs"
   videoLength={30}
 >


### PR DESCRIPTION
See #1287 

This adds an `onStart` callback to `WebVideo`. It's called `onStart` instead of `onReady` because the function gets called when play is pressed on the video splash screen, rather than when the component is loaded.