### PR TITLE
chore(other): re-generate contributor table

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,6 +1,6 @@
 {
   "projectName": "tds-core",
-  "projectOwner": "telusdigital",
+  "projectOwner": "telus",
   "repoType": "github",
   "repoHost": "https://github.com",
   "types": {
@@ -13,7 +13,8 @@
     "README.md"
   ],
   "imageSize": 100,
-  "commit": true,
+  "commit": false,
+  "commitConvention": "none",
   "contributors": [
     {
       "login": "lzcabrera",
@@ -25,10 +26,19 @@
       ]
     },
     {
-      "login": "ryanoglesby08",
-      "name": "Ryan Oglesby",
-      "avatar_url": "https://avatars0.githubusercontent.com/u/1375942?v=4",
-      "profile": "http://ryanogles.by",
+      "login": "marcod1419",
+      "name": "Marco Donnici",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/10531523?v=4",
+      "profile": "http://marcodonnici.com/",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
+      "login": "jraff",
+      "name": "Jordan Raffoul",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/1036187?v=4",
+      "profile": "https://github.com/jraff",
       "contributions": [
         "tds"
       ]
@@ -43,6 +53,15 @@
       ]
     },
     {
+      "login": "ryanoglesby08",
+      "name": "Ryan Oglesby",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/1375942?v=4",
+      "profile": "http://ryanogles.by",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
       "login": "tomharrison",
       "name": "Tom Harrison",
       "avatar_url": "https://avatars0.githubusercontent.com/u/613921?v=4",
@@ -52,19 +71,10 @@
       ]
     },
     {
-      "login": "lucylist",
-      "name": "Lucy",
-      "avatar_url": "https://avatars1.githubusercontent.com/u/17018330?v=4",
-      "profile": "http://www.telus.com",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "marcod1419",
-      "name": "Marco Donnici",
-      "avatar_url": "https://avatars0.githubusercontent.com/u/10531523?v=4",
-      "profile": "https://github.com/marcod1419",
+      "login": "simpleimpulse",
+      "name": "Ani",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/2739819?v=4",
+      "profile": "https://github.com/simpleimpulse",
       "contributions": [
         "tds"
       ]
@@ -73,7 +83,16 @@
       "login": "xingbo828",
       "name": "Bo Xing",
       "avatar_url": "https://avatars3.githubusercontent.com/u/3753196?v=4",
-      "profile": "http://www.lavamelon.com",
+      "profile": "https://github.com/xingbo828",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
+      "login": "nicmak",
+      "name": "Nicholas Mak",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/22725151?v=4",
+      "profile": "https://github.com/nicmak",
       "contributions": [
         "tds"
       ]
@@ -88,10 +107,55 @@
       ]
     },
     {
+      "login": "Andrew-K-Lam",
+      "name": "Andrew Lam",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/931411?v=4",
+      "profile": "https://github.com/Andrew-K-Lam",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
+      "login": "cuginoAle",
+      "name": "Alessio Carnevale",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/1298616?v=4",
+      "profile": "https://github.com/cuginoAle",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
+      "login": "ah-arch",
+      "name": "Ally Hui",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/4450690?v=4",
+      "profile": "https://github.com/ah-arch",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
+      "login": "varunj90",
+      "name": "Varun Jain",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/3495961?v=4",
+      "profile": "https://github.com/varunj90",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
+      "login": "elliottjro",
+      "name": "Elliott Ro",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/1139851?v=4",
+      "profile": "http://fournine.digital",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
       "login": "claflamme",
       "name": "claflamme",
       "avatar_url": "https://avatars1.githubusercontent.com/u/5008307?v=4",
-      "profile": "https://github.com/claflamme",
+      "profile": "https://corylaflamme.com",
       "contributions": [
         "tds"
       ]
@@ -142,6 +206,15 @@
       ]
     },
     {
+      "login": "Christina-Lo",
+      "name": "Christina L.",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/42220619?v=4",
+      "profile": "https://github.com/Christina-Lo",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
       "login": "guilhermeblanco",
       "name": "Guilherme Blanco",
       "avatar_url": "https://avatars1.githubusercontent.com/u/208883?v=4",
@@ -155,6 +228,42 @@
       "name": "Phil Dufault",
       "avatar_url": "https://avatars3.githubusercontent.com/u/145619?v=4",
       "profile": "https://github.com/pdufault",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
+      "login": "rbrander",
+      "name": "Rob Brander",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/968192?v=4",
+      "profile": "http://rbrander.ca",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
+      "login": "saydex",
+      "name": "Sayde Deng",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/49663423?v=4",
+      "profile": "https://github.com/saydex",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
+      "login": "alfredctchoi",
+      "name": "Alfred Choi",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/5086190?v=4",
+      "profile": "https://github.com/alfredctchoi",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
+      "login": "brendanpowershifter",
+      "name": "Brendan Betts",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/25777936?v=4",
+      "profile": "https://github.com/brendanpowershifter",
       "contributions": [
         "tds"
       ]
@@ -178,10 +287,28 @@
       ]
     },
     {
+      "login": "jonathanpalma",
+      "name": "Jonathan Palma",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/12414771?v=4",
+      "profile": "http://jonathanpalma.me",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
+      "login": "githubjosh",
+      "name": "Josh Arndt",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/224624?v=4",
+      "profile": "https://github.com/githubjosh",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
       "login": "kkwoker",
       "name": "Kinnan Kwok",
       "avatar_url": "https://avatars1.githubusercontent.com/u/5900772?v=4",
-      "profile": "https://github.com/kkwoker",
+      "profile": "http://kkwoker.io",
       "contributions": [
         "tds"
       ]
@@ -205,10 +332,37 @@
       ]
     },
     {
+      "login": "smm-telus",
+      "name": "Sean McCullough",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/31409656?v=4",
+      "profile": "http://architech.ca",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
+      "login": "affansajid",
+      "name": "Affan Sajid",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/3418750?v=4",
+      "profile": "https://github.com/affansajid",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
       "login": "ahmadnassri",
       "name": "Ahmad Nassri",
       "avatar_url": "https://avatars2.githubusercontent.com/u/183195?v=4",
       "profile": "https://www.ahmadnassri.com",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
+      "login": "brastrullo",
+      "name": "Bradley Rastrullo",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/11504992?v=4",
+      "profile": "https://github.com/brastrullo",
       "contributions": [
         "tds"
       ]
@@ -223,10 +377,37 @@
       ]
     },
     {
+      "login": "coltonpowershifter",
+      "name": "Colton Buchanan",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/33848122?v=4",
+      "profile": "https://github.com/coltonpowershifter",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
       "login": "DJDA",
       "name": "David DeAngelis",
       "avatar_url": "https://avatars2.githubusercontent.com/u/2502296?v=4",
       "profile": "https://github.com/DJDA",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
+      "login": "derekkramer",
+      "name": "Derek Kramer",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/25651179?v=4",
+      "profile": "http://derekkramer.co",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
+      "login": "donnavitan",
+      "name": "Donna Vitan",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/21316148?v=4",
+      "profile": "http://donnavitan.com",
       "contributions": [
         "tds"
       ]
@@ -250,10 +431,19 @@
       ]
     },
     {
-      "login": "mattseburn",
-      "name": "mattseburn",
-      "avatar_url": "https://avatars3.githubusercontent.com/u/5891333?v=4",
-      "profile": "https://github.com/mattseburn",
+      "login": "Jeffrey-Chang",
+      "name": "Jeffrey Chang",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/30445300?v=4",
+      "profile": "https://github.com/Jeffrey-Chang",
+      "contributions": [
+        "tds"
+      ]
+    },
+    {
+      "login": "kspaans",
+      "name": "Kyle Spaans",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/14052?v=4",
+      "profile": "http://spaans.ca",
       "contributions": [
         "tds"
       ]
@@ -280,7 +470,7 @@
       "login": "mrkrumhausen",
       "name": "Sebastian Krumhausen",
       "avatar_url": "https://avatars3.githubusercontent.com/u/2011006?v=4",
-      "profile": "http://krumhausen.com",
+      "profile": "https://krumhausen.com",
       "contributions": [
         "tds"
       ]
@@ -322,168 +512,6 @@
       ]
     },
     {
-      "login": "githubjosh",
-      "name": "Josh Arndt",
-      "avatar_url": "https://avatars3.githubusercontent.com/u/224624?v=4",
-      "profile": "https://github.com/githubjosh",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "simpleimpulse",
-      "name": "Ani",
-      "avatar_url": "https://avatars2.githubusercontent.com/u/2739819?v=4",
-      "profile": "https://github.com/simpleimpulse",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "varunj90",
-      "name": "Varun Jain",
-      "avatar_url": "https://avatars1.githubusercontent.com/u/3495961?v=4",
-      "profile": "https://github.com/varunj90",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "ah-arch",
-      "name": "Ally Hui",
-      "avatar_url": "https://avatars2.githubusercontent.com/u/4450690?v=4",
-      "profile": "https://github.com/ah-arch",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "jraff",
-      "name": "Jordan Raffoul",
-      "avatar_url": "https://avatars0.githubusercontent.com/u/1036187?v=4",
-      "profile": "http://jordanraffoul.com",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "derekkramer",
-      "name": "Derek Kramer",
-      "avatar_url": "https://avatars2.githubusercontent.com/u/25651179?v=4",
-      "profile": "http://derekkramer.co",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "brastrullo",
-      "name": "Bradley Rastrullo",
-      "avatar_url": "https://avatars2.githubusercontent.com/u/11504992?v=4",
-      "profile": "https://github.com/brastrullo",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "Andrew-K-Lam",
-      "name": "Andrew Lam",
-      "avatar_url": "https://avatars0.githubusercontent.com/u/931411?v=4",
-      "profile": "https://github.com/Andrew-K-Lam",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "rbrander",
-      "name": "Rob Brander",
-      "avatar_url": "https://avatars2.githubusercontent.com/u/968192?v=4",
-      "profile": "http://rbrander.ca",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "jonathanpalma",
-      "name": "Jonathan Palma",
-      "avatar_url": "https://avatars3.githubusercontent.com/u/12414771?v=4",
-      "profile": "https://github.com/jonathanpalma",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "nicmak",
-      "name": "Nicholas Mak",
-      "avatar_url": "https://avatars2.githubusercontent.com/u/22725151?v=4",
-      "profile": "https://github.com/nicmak",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "Christina-Lo",
-      "name": "Christina L.",
-      "avatar_url": "https://avatars3.githubusercontent.com/u/42220619?v=4",
-      "profile": "https://github.com/Christina-Lo",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "kspaans",
-      "name": "Kyle Spaans",
-      "avatar_url": "https://avatars0.githubusercontent.com/u/14052?v=4",
-      "profile": "http://spaans.ca",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "affansajid",
-      "name": "Affan Sajid",
-      "avatar_url": "https://avatars3.githubusercontent.com/u/3418750?v=4",
-      "profile": "https://github.com/affansajid",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "coltonpowershifter",
-      "name": "Colton Buchanan",
-      "avatar_url": "https://avatars3.githubusercontent.com/u/33848122?v=4",
-      "profile": "https://github.com/coltonpowershifter",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "ElliottJRo",
-      "name": "Elliott Ro",
-      "avatar_url": "https://avatars3.githubusercontent.com/u/1139851?v=4",
-      "profile": "http://www.techsamurais.com",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "smm-telus",
-      "name": "Sean McCullough",
-      "avatar_url": "https://avatars0.githubusercontent.com/u/31409656?v=4",
-      "profile": "http://architech.ca",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "alfredctchoi",
-      "name": "Alfred Choi",
-      "avatar_url": "https://avatars2.githubusercontent.com/u/5086190?v=4",
-      "profile": "https://github.com/alfredctchoi",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
       "login": "pkandathil",
       "name": "Prashant Kandathil",
       "avatar_url": "https://avatars1.githubusercontent.com/u/1751772?v=4",
@@ -491,70 +519,7 @@
       "contributions": [
         "tds"
       ]
-    },
-    {
-      "login": "saydex",
-      "name": "Sayde Deng",
-      "avatar_url": "https://avatars0.githubusercontent.com/u/49663423?v=4",
-      "profile": "https://github.com/saydex",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "agorovyi",
-      "name": "Anatolii Gorovyi",
-      "avatar_url": "https://avatars3.githubusercontent.com/u/26413531?v=4",
-      "profile": "https://github.com/agorovyi",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "brendanpowershifter",
-      "name": "Brendan Betts",
-      "avatar_url": "https://avatars1.githubusercontent.com/u/25777936?v=4",
-      "profile": "https://github.com/brendanpowershifter",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "cuginoAle",
-      "name": "Alessio Carnevale",
-      "avatar_url": "https://avatars3.githubusercontent.com/u/1298616?v=4",
-      "profile": "https://github.com/cuginoAle",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "Jeffrey-Chang",
-      "name": "Jeffrey Chang",
-      "avatar_url": "https://avatars3.githubusercontent.com/u/30445300?v=4",
-      "profile": "https://github.com/Jeffrey-Chang",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "AriqAhmad",
-      "name": "Ariq Ahmad",
-      "avatar_url": "https://avatars0.githubusercontent.com/u/23136810?v=4",
-      "profile": "https://github.com/AriqAhmad",
-      "contributions": [
-        "tds"
-      ]
-    },
-    {
-      "login": "donnavitan",
-      "name": "Donna Vitan",
-      "avatar_url": "https://avatars3.githubusercontent.com/u/21316148?v=4",
-      "profile": "http://donnavitan.com",
-      "contributions": [
-        "tds"
-      ]
     }
   ],
-  "commitConvention": "none"
+  "contributorsPerLine": 7
 }

--- a/.remarkignore
+++ b/.remarkignore
@@ -1,4 +1,3 @@
-README.md
 **/CHANGELOG.md
 guide/announcements.md
 /**/_book/**

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ The following group are the active maintainers of this project, and have merge r
 | Christina Lo     | Design Lead   | @Christina L.   | @Christina-Lo |
 | Donna Vitan      | Design        | @donnavitan     | @donnavitan   |
 
-
 ## Contributors
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
@@ -39,16 +38,25 @@ The following group are the active maintainers of this project, and have merge r
 <table>
   <tr>
     <td align="center"><a href="https://github.com/lzcabrera"><img src="https://avatars3.githubusercontent.com/u/677496?v=4" width="100px;" alt="Laura Cabrera"/><br /><sub><b>Laura Cabrera</b></sub></a><br /><a href="#tds-lzcabrera" title=""></a></td>
-    <td align="center"><a href="http://ryanogles.by"><img src="https://avatars0.githubusercontent.com/u/1375942?v=4" width="100px;" alt="Ryan Oglesby"/><br /><sub><b>Ryan Oglesby</b></sub></a><br /><a href="#tds-ryanoglesby08" title=""></a></td>
+    <td align="center"><a href="http://marcodonnici.com/"><img src="https://avatars0.githubusercontent.com/u/10531523?v=4" width="100px;" alt="Marco Donnici"/><br /><sub><b>Marco Donnici</b></sub></a><br /><a href="#tds-marcod1419" title=""></a></td>
+    <td align="center"><a href="https://github.com/jraff"><img src="https://avatars0.githubusercontent.com/u/1036187?v=4" width="100px;" alt="Jordan Raffoul"/><br /><sub><b>Jordan Raffoul</b></sub></a><br /><a href="#tds-jraff" title=""></a></td>
     <td align="center"><a href="http://theetrain.ca"><img src="https://avatars0.githubusercontent.com/u/12798751?v=4" width="100px;" alt="Enrico Sacchetti"/><br /><sub><b>Enrico Sacchetti</b></sub></a><br /><a href="#tds-theetrain" title=""></a></td>
+    <td align="center"><a href="http://ryanogles.by"><img src="https://avatars0.githubusercontent.com/u/1375942?v=4" width="100px;" alt="Ryan Oglesby"/><br /><sub><b>Ryan Oglesby</b></sub></a><br /><a href="#tds-ryanoglesby08" title=""></a></td>
     <td align="center"><a href="http://www.thetomharrison.com/"><img src="https://avatars0.githubusercontent.com/u/613921?v=4" width="100px;" alt="Tom Harrison"/><br /><sub><b>Tom Harrison</b></sub></a><br /><a href="#tds-tomharrison" title=""></a></td>
-    <td align="center"><a href="http://www.telus.com"><img src="https://avatars1.githubusercontent.com/u/17018330?v=4" width="100px;" alt="Lucy"/><br /><sub><b>Lucy</b></sub></a><br /><a href="#tds-lucylist" title=""></a></td>
-    <td align="center"><a href="https://github.com/marcod1419"><img src="https://avatars0.githubusercontent.com/u/10531523?v=4" width="100px;" alt="Marco Donnici"/><br /><sub><b>Marco Donnici</b></sub></a><br /><a href="#tds-marcod1419" title=""></a></td>
-    <td align="center"><a href="http://www.lavamelon.com"><img src="https://avatars3.githubusercontent.com/u/3753196?v=4" width="100px;" alt="Bo Xing"/><br /><sub><b>Bo Xing</b></sub></a><br /><a href="#tds-xingbo828" title=""></a></td>
+    <td align="center"><a href="https://github.com/simpleimpulse"><img src="https://avatars2.githubusercontent.com/u/2739819?v=4" width="100px;" alt="Ani"/><br /><sub><b>Ani</b></sub></a><br /><a href="#tds-simpleimpulse" title=""></a></td>
   </tr>
   <tr>
+    <td align="center"><a href="https://github.com/xingbo828"><img src="https://avatars3.githubusercontent.com/u/3753196?v=4" width="100px;" alt="Bo Xing"/><br /><sub><b>Bo Xing</b></sub></a><br /><a href="#tds-xingbo828" title=""></a></td>
+    <td align="center"><a href="https://github.com/nicmak"><img src="https://avatars2.githubusercontent.com/u/22725151?v=4" width="100px;" alt="Nicholas Mak"/><br /><sub><b>Nicholas Mak</b></sub></a><br /><a href="#tds-nicmak" title=""></a></td>
     <td align="center"><a href="https://github.com/codedavinci"><img src="https://avatars2.githubusercontent.com/u/17863803?v=4" width="100px;" alt="Edivan Silva"/><br /><sub><b>Edivan Silva</b></sub></a><br /><a href="#tds-codedavinci" title=""></a></td>
-    <td align="center"><a href="https://github.com/claflamme"><img src="https://avatars1.githubusercontent.com/u/5008307?v=4" width="100px;" alt="claflamme"/><br /><sub><b>claflamme</b></sub></a><br /><a href="#tds-claflamme" title=""></a></td>
+    <td align="center"><a href="https://github.com/Andrew-K-Lam"><img src="https://avatars0.githubusercontent.com/u/931411?v=4" width="100px;" alt="Andrew Lam"/><br /><sub><b>Andrew Lam</b></sub></a><br /><a href="#tds-Andrew-K-Lam" title=""></a></td>
+    <td align="center"><a href="https://github.com/cuginoAle"><img src="https://avatars3.githubusercontent.com/u/1298616?v=4" width="100px;" alt="Alessio Carnevale"/><br /><sub><b>Alessio Carnevale</b></sub></a><br /><a href="#tds-cuginoAle" title=""></a></td>
+    <td align="center"><a href="https://github.com/ah-arch"><img src="https://avatars2.githubusercontent.com/u/4450690?v=4" width="100px;" alt="Ally Hui"/><br /><sub><b>Ally Hui</b></sub></a><br /><a href="#tds-ah-arch" title=""></a></td>
+    <td align="center"><a href="https://github.com/varunj90"><img src="https://avatars1.githubusercontent.com/u/3495961?v=4" width="100px;" alt="Varun Jain"/><br /><sub><b>Varun Jain</b></sub></a><br /><a href="#tds-varunj90" title=""></a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="http://fournine.digital"><img src="https://avatars3.githubusercontent.com/u/1139851?v=4" width="100px;" alt="Elliott Ro"/><br /><sub><b>Elliott Ro</b></sub></a><br /><a href="#tds-elliottjro" title=""></a></td>
+    <td align="center"><a href="https://corylaflamme.com"><img src="https://avatars1.githubusercontent.com/u/5008307?v=4" width="100px;" alt="claflamme"/><br /><sub><b>claflamme</b></sub></a><br /><a href="#tds-claflamme" title=""></a></td>
     <td align="center"><a href="https://github.com/malikalim1"><img src="https://avatars1.githubusercontent.com/u/27707082?v=4" width="100px;" alt="Malika Mariah Lim"/><br /><sub><b>Malika Mariah Lim</b></sub></a><br /><a href="#tds-malikalim1" title=""></a></td>
     <td align="center"><a href="https://github.com/saulfougnier"><img src="https://avatars2.githubusercontent.com/u/22059850?v=4" width="100px;" alt="saulfougnier"/><br /><sub><b>saulfougnier</b></sub></a><br /><a href="#tds-saulfougnier" title=""></a></td>
     <td align="center"><a href="https://github.com/jackreeves"><img src="https://avatars1.githubusercontent.com/u/9420407?v=4" width="100px;" alt="Jack Reeves"/><br /><sub><b>Jack Reeves</b></sub></a><br /><a href="#tds-jackreeves" title=""></a></td>
@@ -56,64 +64,49 @@ The following group are the active maintainers of this project, and have merge r
     <td align="center"><a href="https://github.com/ParkDan"><img src="https://avatars2.githubusercontent.com/u/4040680?v=4" width="100px;" alt="Dan Park"/><br /><sub><b>Dan Park</b></sub></a><br /><a href="#tds-ParkDan" title=""></a></td>
   </tr>
   <tr>
+    <td align="center"><a href="https://github.com/Christina-Lo"><img src="https://avatars3.githubusercontent.com/u/42220619?v=4" width="100px;" alt="Christina L."/><br /><sub><b>Christina L.</b></sub></a><br /><a href="#tds-Christina-Lo" title=""></a></td>
     <td align="center"><a href="http://www.doctrine-project.org"><img src="https://avatars1.githubusercontent.com/u/208883?v=4" width="100px;" alt="Guilherme Blanco"/><br /><sub><b>Guilherme Blanco</b></sub></a><br /><a href="#tds-guilhermeblanco" title=""></a></td>
     <td align="center"><a href="https://github.com/pdufault"><img src="https://avatars3.githubusercontent.com/u/145619?v=4" width="100px;" alt="Phil Dufault"/><br /><sub><b>Phil Dufault</b></sub></a><br /><a href="#tds-pdufault" title=""></a></td>
+    <td align="center"><a href="http://rbrander.ca"><img src="https://avatars2.githubusercontent.com/u/968192?v=4" width="100px;" alt="Rob Brander"/><br /><sub><b>Rob Brander</b></sub></a><br /><a href="#tds-rbrander" title=""></a></td>
+    <td align="center"><a href="https://github.com/saydex"><img src="https://avatars0.githubusercontent.com/u/49663423?v=4" width="100px;" alt="Sayde Deng"/><br /><sub><b>Sayde Deng</b></sub></a><br /><a href="#tds-saydex" title=""></a></td>
+    <td align="center"><a href="https://github.com/alfredctchoi"><img src="https://avatars2.githubusercontent.com/u/5086190?v=4" width="100px;" alt="Alfred Choi"/><br /><sub><b>Alfred Choi</b></sub></a><br /><a href="#tds-alfredctchoi" title=""></a></td>
+    <td align="center"><a href="https://github.com/brendanpowershifter"><img src="https://avatars1.githubusercontent.com/u/25777936?v=4" width="100px;" alt="Brendan Betts"/><br /><sub><b>Brendan Betts</b></sub></a><br /><a href="#tds-brendanpowershifter" title=""></a></td>
+  </tr>
+  <tr>
     <td align="center"><a href="https://github.com/ianMcHuge"><img src="https://avatars3.githubusercontent.com/u/21041962?v=4" width="100px;" alt="Ian McGonigle"/><br /><sub><b>Ian McGonigle</b></sub></a><br /><a href="#tds-ianMcHuge" title=""></a></td>
     <td align="center"><a href="https://github.com/Jebbie87"><img src="https://avatars0.githubusercontent.com/u/17952850?v=4" width="100px;" alt="Jeffrey Chang"/><br /><sub><b>Jeffrey Chang</b></sub></a><br /><a href="#tds-Jebbie87" title=""></a></td>
-    <td align="center"><a href="https://github.com/kkwoker"><img src="https://avatars1.githubusercontent.com/u/5900772?v=4" width="100px;" alt="Kinnan Kwok"/><br /><sub><b>Kinnan Kwok</b></sub></a><br /><a href="#tds-kkwoker" title=""></a></td>
+    <td align="center"><a href="http://jonathanpalma.me"><img src="https://avatars3.githubusercontent.com/u/12414771?v=4" width="100px;" alt="Jonathan Palma"/><br /><sub><b>Jonathan Palma</b></sub></a><br /><a href="#tds-jonathanpalma" title=""></a></td>
+    <td align="center"><a href="https://github.com/githubjosh"><img src="https://avatars3.githubusercontent.com/u/224624?v=4" width="100px;" alt="Josh Arndt"/><br /><sub><b>Josh Arndt</b></sub></a><br /><a href="#tds-githubjosh" title=""></a></td>
+    <td align="center"><a href="http://kkwoker.io"><img src="https://avatars1.githubusercontent.com/u/5900772?v=4" width="100px;" alt="Kinnan Kwok"/><br /><sub><b>Kinnan Kwok</b></sub></a><br /><a href="#tds-kkwoker" title=""></a></td>
     <td align="center"><a href="http://jackmakesthings.com"><img src="https://avatars1.githubusercontent.com/u/3606708?v=4" width="100px;" alt="jack"/><br /><sub><b>jack</b></sub></a><br /><a href="#tds-jackmakesthings" title=""></a></td>
     <td align="center"><a href="https://github.com/nealmcgann"><img src="https://avatars0.githubusercontent.com/u/22376665?v=4" width="100px;" alt="nealmcgann"/><br /><sub><b>nealmcgann</b></sub></a><br /><a href="#tds-nealmcgann" title=""></a></td>
   </tr>
   <tr>
+    <td align="center"><a href="http://architech.ca"><img src="https://avatars0.githubusercontent.com/u/31409656?v=4" width="100px;" alt="Sean McCullough"/><br /><sub><b>Sean McCullough</b></sub></a><br /><a href="#tds-smm-telus" title=""></a></td>
+    <td align="center"><a href="https://github.com/affansajid"><img src="https://avatars3.githubusercontent.com/u/3418750?v=4" width="100px;" alt="Affan Sajid"/><br /><sub><b>Affan Sajid</b></sub></a><br /><a href="#tds-affansajid" title=""></a></td>
     <td align="center"><a href="https://www.ahmadnassri.com"><img src="https://avatars2.githubusercontent.com/u/183195?v=4" width="100px;" alt="Ahmad Nassri"/><br /><sub><b>Ahmad Nassri</b></sub></a><br /><a href="#tds-ahmadnassri" title=""></a></td>
+    <td align="center"><a href="https://github.com/brastrullo"><img src="https://avatars2.githubusercontent.com/u/11504992?v=4" width="100px;" alt="Bradley Rastrullo"/><br /><sub><b>Bradley Rastrullo</b></sub></a><br /><a href="#tds-brastrullo" title=""></a></td>
     <td align="center"><a href="https://github.com/ctafts"><img src="https://avatars0.githubusercontent.com/u/782892?v=4" width="100px;" alt="Chris Tafts"/><br /><sub><b>Chris Tafts</b></sub></a><br /><a href="#tds-ctafts" title=""></a></td>
+    <td align="center"><a href="https://github.com/coltonpowershifter"><img src="https://avatars3.githubusercontent.com/u/33848122?v=4" width="100px;" alt="Colton Buchanan"/><br /><sub><b>Colton Buchanan</b></sub></a><br /><a href="#tds-coltonpowershifter" title=""></a></td>
     <td align="center"><a href="https://github.com/DJDA"><img src="https://avatars2.githubusercontent.com/u/2502296?v=4" width="100px;" alt="David DeAngelis"/><br /><sub><b>David DeAngelis</b></sub></a><br /><a href="#tds-DJDA" title=""></a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="http://derekkramer.co"><img src="https://avatars2.githubusercontent.com/u/25651179?v=4" width="100px;" alt="Derek Kramer"/><br /><sub><b>Derek Kramer</b></sub></a><br /><a href="#tds-derekkramer" title=""></a></td>
+    <td align="center"><a href="http://donnavitan.com"><img src="https://avatars3.githubusercontent.com/u/21316148?v=4" width="100px;" alt="Donna Vitan"/><br /><sub><b>Donna Vitan</b></sub></a><br /><a href="#tds-donnavitan" title=""></a></td>
     <td align="center"><a href="http://www.drewminns.com"><img src="https://avatars0.githubusercontent.com/u/448452?v=4" width="100px;" alt="Drew Minns"/><br /><sub><b>Drew Minns</b></sub></a><br /><a href="#tds-drewminns" title=""></a></td>
     <td align="center"><a href="https://github.com/ethome"><img src="https://avatars2.githubusercontent.com/u/5311720?v=4" width="100px;" alt="Ed Thome"/><br /><sub><b>Ed Thome</b></sub></a><br /><a href="#tds-ethome" title=""></a></td>
-    <td align="center"><a href="https://github.com/mattseburn"><img src="https://avatars3.githubusercontent.com/u/5891333?v=4" width="100px;" alt="mattseburn"/><br /><sub><b>mattseburn</b></sub></a><br /><a href="#tds-mattseburn" title=""></a></td>
+    <td align="center"><a href="https://github.com/Jeffrey-Chang"><img src="https://avatars3.githubusercontent.com/u/30445300?v=4" width="100px;" alt="Jeffrey Chang"/><br /><sub><b>Jeffrey Chang</b></sub></a><br /><a href="#tds-Jeffrey-Chang" title=""></a></td>
+    <td align="center"><a href="http://spaans.ca"><img src="https://avatars0.githubusercontent.com/u/14052?v=4" width="100px;" alt="Kyle Spaans"/><br /><sub><b>Kyle Spaans</b></sub></a><br /><a href="#tds-kspaans" title=""></a></td>
     <td align="center"><a href="https://linkedin.com/in/wintorez"><img src="https://avatars0.githubusercontent.com/u/1269616?v=4" width="100px;" alt="Reza Sadr"/><br /><sub><b>Reza Sadr</b></sub></a><br /><a href="#tds-wintorez" title=""></a></td>
   </tr>
   <tr>
     <td align="center"><a href="http://rodrigomaia.me"><img src="https://avatars0.githubusercontent.com/u/2081077?v=4" width="100px;" alt="Rodrigo Maia"/><br /><sub><b>Rodrigo Maia</b></sub></a><br /><a href="#tds-rodrigomaia17" title=""></a></td>
-    <td align="center"><a href="http://krumhausen.com"><img src="https://avatars3.githubusercontent.com/u/2011006?v=4" width="100px;" alt="Sebastian Krumhausen"/><br /><sub><b>Sebastian Krumhausen</b></sub></a><br /><a href="#tds-mrkrumhausen" title=""></a></td>
+    <td align="center"><a href="https://krumhausen.com"><img src="https://avatars3.githubusercontent.com/u/2011006?v=4" width="100px;" alt="Sebastian Krumhausen"/><br /><sub><b>Sebastian Krumhausen</b></sub></a><br /><a href="#tds-mrkrumhausen" title=""></a></td>
     <td align="center"><a href="https://github.com/sy-lee"><img src="https://avatars0.githubusercontent.com/u/2330366?v=4" width="100px;" alt="Suet Yi Lee"/><br /><sub><b>Suet Yi Lee</b></sub></a><br /><a href="#tds-sy-lee" title=""></a></td>
     <td align="center"><a href="https://github.com/travis-eh"><img src="https://avatars2.githubusercontent.com/u/1456613?v=4" width="100px;" alt="Travis Allan"/><br /><sub><b>Travis Allan</b></sub></a><br /><a href="#tds-travis-eh" title=""></a></td>
     <td align="center"><a href="https://github.com/aquirkles"><img src="https://avatars3.githubusercontent.com/u/32460479?v=4" width="100px;" alt="aquirkles"/><br /><sub><b>aquirkles</b></sub></a><br /><a href="#tds-aquirkles" title=""></a></td>
     <td align="center"><a href="https://github.com/gfroome"><img src="https://avatars1.githubusercontent.com/u/18177753?v=4" width="100px;" alt="gfroome"/><br /><sub><b>gfroome</b></sub></a><br /><a href="#tds-gfroome" title=""></a></td>
-    <td align="center"><a href="https://github.com/githubjosh"><img src="https://avatars3.githubusercontent.com/u/224624?v=4" width="100px;" alt="Josh Arndt"/><br /><sub><b>Josh Arndt</b></sub></a><br /><a href="#tds-githubjosh" title=""></a></td>
-  </tr>
-  <tr>
-    <td align="center"><a href="https://github.com/simpleimpulse"><img src="https://avatars2.githubusercontent.com/u/2739819?v=4" width="100px;" alt="Ani"/><br /><sub><b>Ani</b></sub></a><br /><a href="#tds-simpleimpulse" title=""></a></td>
-    <td align="center"><a href="https://github.com/varunj90"><img src="https://avatars1.githubusercontent.com/u/3495961?v=4" width="100px;" alt="Varun Jain"/><br /><sub><b>Varun Jain</b></sub></a><br /><a href="#tds-varunj90" title=""></a></td>
-    <td align="center"><a href="https://github.com/ah-arch"><img src="https://avatars2.githubusercontent.com/u/4450690?v=4" width="100px;" alt="Ally Hui"/><br /><sub><b>Ally Hui</b></sub></a><br /><a href="#tds-ah-arch" title=""></a></td>
-    <td align="center"><a href="http://jordanraffoul.com"><img src="https://avatars0.githubusercontent.com/u/1036187?v=4" width="100px;" alt="Jordan Raffoul"/><br /><sub><b>Jordan Raffoul</b></sub></a><br /><a href="#tds-jraff" title=""></a></td>
-    <td align="center"><a href="http://derekkramer.co"><img src="https://avatars2.githubusercontent.com/u/25651179?v=4" width="100px;" alt="Derek Kramer"/><br /><sub><b>Derek Kramer</b></sub></a><br /><a href="#tds-derekkramer" title=""></a></td>
-    <td align="center"><a href="https://github.com/brastrullo"><img src="https://avatars2.githubusercontent.com/u/11504992?v=4" width="100px;" alt="Bradley Rastrullo"/><br /><sub><b>Bradley Rastrullo</b></sub></a><br /><a href="#tds-brastrullo" title=""></a></td>
-    <td align="center"><a href="https://github.com/Andrew-K-Lam"><img src="https://avatars0.githubusercontent.com/u/931411?v=4" width="100px;" alt="Andrew Lam"/><br /><sub><b>Andrew Lam</b></sub></a><br /><a href="#tds-Andrew-K-Lam" title=""></a></td>
-  </tr>
-  <tr>
-    <td align="center"><a href="http://rbrander.ca"><img src="https://avatars2.githubusercontent.com/u/968192?v=4" width="100px;" alt="Rob Brander"/><br /><sub><b>Rob Brander</b></sub></a><br /><a href="#tds-rbrander" title=""></a></td>
-    <td align="center"><a href="https://github.com/jonathanpalma"><img src="https://avatars3.githubusercontent.com/u/12414771?v=4" width="100px;" alt="Jonathan Palma"/><br /><sub><b>Jonathan Palma</b></sub></a><br /><a href="#tds-jonathanpalma" title=""></a></td>
-    <td align="center"><a href="https://github.com/nicmak"><img src="https://avatars2.githubusercontent.com/u/22725151?v=4" width="100px;" alt="Nicholas Mak"/><br /><sub><b>Nicholas Mak</b></sub></a><br /><a href="#tds-nicmak" title=""></a></td>
-    <td align="center"><a href="https://github.com/Christina-Lo"><img src="https://avatars3.githubusercontent.com/u/42220619?v=4" width="100px;" alt="Christina L."/><br /><sub><b>Christina L.</b></sub></a><br /><a href="#tds-Christina-Lo" title=""></a></td>
-    <td align="center"><a href="http://spaans.ca"><img src="https://avatars0.githubusercontent.com/u/14052?v=4" width="100px;" alt="Kyle Spaans"/><br /><sub><b>Kyle Spaans</b></sub></a><br /><a href="#tds-kspaans" title=""></a></td>
-    <td align="center"><a href="https://github.com/affansajid"><img src="https://avatars3.githubusercontent.com/u/3418750?v=4" width="100px;" alt="Affan Sajid"/><br /><sub><b>Affan Sajid</b></sub></a><br /><a href="#tds-affansajid" title=""></a></td>
-    <td align="center"><a href="https://github.com/coltonpowershifter"><img src="https://avatars3.githubusercontent.com/u/33848122?v=4" width="100px;" alt="Colton Buchanan"/><br /><sub><b>Colton Buchanan</b></sub></a><br /><a href="#tds-coltonpowershifter" title=""></a></td>
-  </tr>
-  <tr>
-    <td align="center"><a href="http://www.techsamurais.com"><img src="https://avatars3.githubusercontent.com/u/1139851?v=4" width="100px;" alt="Elliott Ro"/><br /><sub><b>Elliott Ro</b></sub></a><br /><a href="#tds-ElliottJRo" title=""></a></td>
-    <td align="center"><a href="http://architech.ca"><img src="https://avatars0.githubusercontent.com/u/31409656?v=4" width="100px;" alt="Sean McCullough"/><br /><sub><b>Sean McCullough</b></sub></a><br /><a href="#tds-smm-telus" title=""></a></td>
-    <td align="center"><a href="https://github.com/alfredctchoi"><img src="https://avatars2.githubusercontent.com/u/5086190?v=4" width="100px;" alt="Alfred Choi"/><br /><sub><b>Alfred Choi</b></sub></a><br /><a href="#tds-alfredctchoi" title=""></a></td>
     <td align="center"><a href="https://github.com/pkandathil"><img src="https://avatars1.githubusercontent.com/u/1751772?v=4" width="100px;" alt="Prashant Kandathil"/><br /><sub><b>Prashant Kandathil</b></sub></a><br /><a href="#tds-pkandathil" title=""></a></td>
-    <td align="center"><a href="https://github.com/saydex"><img src="https://avatars0.githubusercontent.com/u/49663423?v=4" width="100px;" alt="Sayde Deng"/><br /><sub><b>Sayde Deng</b></sub></a><br /><a href="#tds-saydex" title=""></a></td>
-    <td align="center"><a href="https://github.com/agorovyi"><img src="https://avatars3.githubusercontent.com/u/26413531?v=4" width="100px;" alt="Anatolii Gorovyi"/><br /><sub><b>Anatolii Gorovyi</b></sub></a><br /><a href="#tds-agorovyi" title=""></a></td>
-    <td align="center"><a href="https://github.com/brendanpowershifter"><img src="https://avatars1.githubusercontent.com/u/25777936?v=4" width="100px;" alt="Brendan Betts"/><br /><sub><b>Brendan Betts</b></sub></a><br /><a href="#tds-brendanpowershifter" title=""></a></td>
-  </tr>
-  <tr>
-    <td align="center"><a href="https://github.com/cuginoAle"><img src="https://avatars3.githubusercontent.com/u/1298616?v=4" width="100px;" alt="Alessio Carnevale"/><br /><sub><b>Alessio Carnevale</b></sub></a><br /><a href="#tds-cuginoAle" title=""></a></td>
-    <td align="center"><a href="https://github.com/Jeffrey-Chang"><img src="https://avatars3.githubusercontent.com/u/30445300?v=4" width="100px;" alt="Jeffrey Chang"/><br /><sub><b>Jeffrey Chang</b></sub></a><br /><a href="#tds-Jeffrey-Chang" title=""></a></td>
-    <td align="center"><a href="https://github.com/AriqAhmad"><img src="https://avatars0.githubusercontent.com/u/23136810?v=4" width="100px;" alt="Ariq Ahmad"/><br /><sub><b>Ariq Ahmad</b></sub></a><br /><a href="#tds-AriqAhmad" title=""></a></td>
-    <td align="center"><a href="http://donnavitan.com"><img src="https://avatars3.githubusercontent.com/u/21316148?v=4" width="100px;" alt="Donna Vitan"/><br /><sub><b>Donna Vitan</b></sub></a><br /><a href="#tds-donnavitan" title=""></a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
The new version of `all-contributors-cli` required that we regenerate our config and `README.md`. Additionally, `README.md` was removed from the `.remarkignore` config, as it was causing errors.