### PR TITLE
fix(core-terms-and-conditions): add aria-expanded to TermsAndConditons

### DIFF
--- a/packages/TermsAndConditions/TermsAndConditions.jsx
+++ b/packages/TermsAndConditions/TermsAndConditions.jsx
@@ -76,7 +76,11 @@ const TermsAndConditions = forwardRef(
         <FlexGrid gutter={false} limitWidth={false}>
           <FlexGrid.Row>
             <FlexGrid.Col>
-              <StyledClickableHeading ref={ref} onClick={() => setOpen(!isOpen)}>
+              <StyledClickableHeading
+                aria-expanded={isOpen}
+                ref={ref}
+                onClick={() => setOpen(!isOpen)}
+              >
                 <StyledExpandCollapseHeading inline vertical={3} between={3}>
                   <StyledChevronContainer>
                     <Circle />

--- a/packages/TermsAndConditions/__tests__/TermsAndConditions.spec.jsx
+++ b/packages/TermsAndConditions/__tests__/TermsAndConditions.spec.jsx
@@ -77,4 +77,10 @@ describe('TermsAndConditions', () => {
 
     expect(target).toEqual(ref.current)
   })
+
+  it('can announce the expansion with screen reader', () => {
+    const termsAndConditions = mount(<TermsAndConditions {...defaultProps} />)
+    termsAndConditions.find('button').simulate('click')
+    expect(termsAndConditions.find('button').prop('aria-expanded')).toEqual(true)
+  })
 })

--- a/packages/TermsAndConditions/__tests__/__snapshots__/TermsAndConditions.spec.jsx.snap
+++ b/packages/TermsAndConditions/__tests__/__snapshots__/TermsAndConditions.spec.jsx.snap
@@ -448,6 +448,7 @@ div.c14 {
         class="col-xs c3"
       >
         <button
+          aria-expanded="false"
           class="c4 c5"
         >
           <div
@@ -1294,9 +1295,11 @@ div.c14 {
                                         className="col-xs c3"
                                       >
                                         <Styled(StyledClickable)
+                                          aria-expanded={true}
                                           onClick={[Function]}
                                         >
                                           <StyledComponent
+                                            aria-expanded={true}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -1337,6 +1340,7 @@ div.c14 {
                                             onClick={[Function]}
                                           >
                                             <button
+                                              aria-expanded={true}
                                               className="c4 c5"
                                               onClick={[Function]}
                                             >
@@ -3514,9 +3518,11 @@ div.c14 {
                                         className="col-xs c3"
                                       >
                                         <Styled(StyledClickable)
+                                          aria-expanded={true}
                                           onClick={[Function]}
                                         >
                                           <StyledComponent
+                                            aria-expanded={true}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -3557,6 +3563,7 @@ div.c14 {
                                             onClick={[Function]}
                                           >
                                             <button
+                                              aria-expanded={true}
                                               className="c4 c5"
                                               onClick={[Function]}
                                             >
@@ -6397,9 +6404,11 @@ div.c14 {
                                         className="col-xs c3"
                                       >
                                         <Styled(StyledClickable)
+                                          aria-expanded={true}
                                           onClick={[Function]}
                                         >
                                           <StyledComponent
+                                            aria-expanded={true}
                                             forwardedComponent={
                                               Object {
                                                 "$$typeof": Symbol(react.forward_ref),
@@ -6440,6 +6449,7 @@ div.c14 {
                                             onClick={[Function]}
                                           >
                                             <button
+                                              aria-expanded={true}
                                               className="c4 c5"
                                               onClick={[Function]}
                                             >


### PR DESCRIPTION
## Related issues
https://github.com/telus/tds-core/issues/1320

## Description
Adds aria-expanded attribute to the button on Terms and Condition to enable screen reader announce the expanse-collapse states

## Checklist before submitting pull request

- [x] New code is unit tested
