### PR TITLE
fix(core-terms-and-conditions): prevent chevron icon from shifting

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -519,6 +519,15 @@
       "contributions": [
         "tds"
       ]
+    },
+    {
+      "login": "hamedmam",
+      "name": "Hamed Mamdoohi",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/24867760?v=4",
+      "profile": "https://github.com/hamedmam",
+      "contributions": [
+        "tds"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ The following group are the active maintainers of this project, and have merge r
     <td align="center"><a href="https://github.com/gfroome"><img src="https://avatars1.githubusercontent.com/u/18177753?v=4" width="100px;" alt="gfroome"/><br /><sub><b>gfroome</b></sub></a><br /><a href="#tds-gfroome" title=""></a></td>
     <td align="center"><a href="https://github.com/pkandathil"><img src="https://avatars1.githubusercontent.com/u/1751772?v=4" width="100px;" alt="Prashant Kandathil"/><br /><sub><b>Prashant Kandathil</b></sub></a><br /><a href="#tds-pkandathil" title=""></a></td>
   </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/hamedmam"><img src="https://avatars1.githubusercontent.com/u/24867760?v=4" width="100px;" alt="Hamed Mamdoohi"/><br /><sub><b>Hamed Mamdoohi</b></sub></a><br /><a href="#tds-hamedmam" title=""></a></td>
+  </tr>
 </table>
 
 <!-- markdownlint-enable -->

--- a/packages/TermsAndConditions/TermsAndConditions.jsx
+++ b/packages/TermsAndConditions/TermsAndConditions.jsx
@@ -28,6 +28,7 @@ const StyledClickableHeading = styled(StyledClickable)({
 
 const StyledExpandCollapseHeading = styled(Box)({
   alignItems: 'center',
+  minWidth: '245px',
 })
 
 const StyledChevronContainer = styled.span({

--- a/packages/TermsAndConditions/__tests__/__snapshots__/TermsAndConditions.spec.jsx.snap
+++ b/packages/TermsAndConditions/__tests__/__snapshots__/TermsAndConditions.spec.jsx.snap
@@ -199,6 +199,7 @@ div.c14 {
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  min-width: 245px;
 }
 
 .c8 {
@@ -767,6 +768,7 @@ div.c14 {
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  min-width: 245px;
 }
 
 .c8 {
@@ -1361,6 +1363,7 @@ div.c14 {
                                                         "lastClassName": "c6",
                                                         "rules": Array [
                                                           "align-items: center;",
+                                                          "min-width: 245px;",
                                                         ],
                                                       },
                                                       "displayName": "Styled(Box)",
@@ -2975,6 +2978,7 @@ div.c14 {
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  min-width: 245px;
 }
 
 .c8 {
@@ -3584,6 +3588,7 @@ div.c14 {
                                                         "lastClassName": "c6",
                                                         "rules": Array [
                                                           "align-items: center;",
+                                                          "min-width: 245px;",
                                                         ],
                                                       },
                                                       "displayName": "Styled(Box)",
@@ -5877,6 +5882,7 @@ div.c14 {
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  min-width: 245px;
 }
 
 .c8 {
@@ -6470,6 +6476,7 @@ div.c14 {
                                                         "lastClassName": "c6",
                                                         "rules": Array [
                                                           "align-items: center;",
+                                                          "min-width: 245px;",
                                                         ],
                                                       },
                                                       "displayName": "Styled(Box)",


### PR DESCRIPTION
Quick PR to fix an issue I noticed in Terms And Conditions. In desktop, the chevron expand/collapse icon will shift slightly when opened and closed. This addresses that.