### PR TITLE
Prevent react router invert prop type error

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -519,6 +519,15 @@
       "contributions": [
         "tds"
       ]
+    },
+    {
+      "login": "hamedmam",
+      "name": "Hamed Mamdoohi",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/24867760?v=4",
+      "profile": "https://github.com/hamedmam",
+      "contributions": [
+        "tds"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ The following group are the active maintainers of this project, and have merge r
     <td align="center"><a href="https://github.com/gfroome"><img src="https://avatars1.githubusercontent.com/u/18177753?v=4" width="100px;" alt="gfroome"/><br /><sub><b>gfroome</b></sub></a><br /><a href="#tds-gfroome" title=""></a></td>
     <td align="center"><a href="https://github.com/pkandathil"><img src="https://avatars1.githubusercontent.com/u/1751772?v=4" width="100px;" alt="Prashant Kandathil"/><br /><sub><b>Prashant Kandathil</b></sub></a><br /><a href="#tds-pkandathil" title=""></a></td>
   </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/hamedmam"><img src="https://avatars1.githubusercontent.com/u/24867760?v=4" width="100px;" alt="Hamed Mamdoohi"/><br /><sub><b>Hamed Mamdoohi</b></sub></a><br /><a href="#tds-hamedmam" title=""></a></td>
+  </tr>
 </table>
 
 <!-- markdownlint-enable -->

--- a/packages/Breadcrumbs/__tests__/__snapshots__/Breadcrumbs.spec.jsx.snap
+++ b/packages/Breadcrumbs/__tests__/__snapshots__/Breadcrumbs.spec.jsx.snap
@@ -207,7 +207,6 @@ exports[`Breadcrumbs with children renders 1`] = `
                         <Link
                           forwardedRef={null}
                           href="/"
-                          invert={false}
                           reactRouterLinkComponent={null}
                           to={null}
                         >
@@ -219,7 +218,6 @@ exports[`Breadcrumbs with children renders 1`] = `
                               }
                             }
                             href="/"
-                            invert={false}
                             to={null}
                           >
                             <StyledComponent
@@ -263,7 +261,6 @@ exports[`Breadcrumbs with children renders 1`] = `
                               }
                               forwardedRef={null}
                               href="/"
-                              invert={false}
                               to={null}
                             >
                               <a
@@ -380,7 +377,6 @@ exports[`Breadcrumbs with children renders 1`] = `
                         <Link
                           forwardedRef={null}
                           href="/mobility"
-                          invert={false}
                           reactRouterLinkComponent={null}
                           to={null}
                         >
@@ -392,7 +388,6 @@ exports[`Breadcrumbs with children renders 1`] = `
                               }
                             }
                             href="/mobility"
-                            invert={false}
                             to={null}
                           >
                             <StyledComponent
@@ -436,7 +431,6 @@ exports[`Breadcrumbs with children renders 1`] = `
                               }
                               forwardedRef={null}
                               href="/mobility"
-                              invert={false}
                               to={null}
                             >
                               <a
@@ -885,7 +879,6 @@ exports[`Breadcrumbs with routes renders 1`] = `
                         <Link
                           forwardedRef={null}
                           href="/"
-                          invert={false}
                           reactRouterLinkComponent={null}
                           to={null}
                         >
@@ -897,7 +890,6 @@ exports[`Breadcrumbs with routes renders 1`] = `
                               }
                             }
                             href="/"
-                            invert={false}
                             to={null}
                           >
                             <StyledComponent
@@ -941,7 +933,6 @@ exports[`Breadcrumbs with routes renders 1`] = `
                               }
                               forwardedRef={null}
                               href="/"
-                              invert={false}
                               to={null}
                             >
                               <a
@@ -1058,7 +1049,6 @@ exports[`Breadcrumbs with routes renders 1`] = `
                         <Link
                           forwardedRef={null}
                           href="/mobility"
-                          invert={false}
                           reactRouterLinkComponent={null}
                           to={null}
                         >
@@ -1070,7 +1060,6 @@ exports[`Breadcrumbs with routes renders 1`] = `
                               }
                             }
                             href="/mobility"
-                            invert={false}
                             to={null}
                           >
                             <StyledComponent
@@ -1114,7 +1103,6 @@ exports[`Breadcrumbs with routes renders 1`] = `
                               }
                               forwardedRef={null}
                               href="/mobility"
-                              invert={false}
                               to={null}
                             >
                               <a

--- a/packages/Link/Link.jsx
+++ b/packages/Link/Link.jsx
@@ -86,7 +86,7 @@ Link.defaultProps = {
   reactRouterLinkComponent: null,
   to: null,
   href: null,
-  invert: false,
+  invert: undefined,
   forwardedRef: undefined,
 }
 

--- a/packages/Link/__tests__/__snapshots__/Link.spec.jsx.snap
+++ b/packages/Link/__tests__/__snapshots__/Link.spec.jsx.snap
@@ -45,7 +45,6 @@ Object {
     <Link
       forwardedRef={null}
       href={null}
-      invert={false}
       reactRouterLinkComponent={null}
       to={null}
     >
@@ -57,7 +56,6 @@ Object {
           }
         }
         href={null}
-        invert={false}
         to={null}
       >
         <StyledComponent
@@ -101,7 +99,6 @@ Object {
           }
           forwardedRef={null}
           href={null}
-          invert={false}
           to={null}
         >
           <a
@@ -252,7 +249,6 @@ exports[`Link renders 1`] = `
 <Link
   forwardedRef={null}
   href={null}
-  invert={false}
   reactRouterLinkComponent={null}
   to={null}
 >


### PR DESCRIPTION
See: #1303 

This PR changes the default prop value of `Link`'s `invert` prop to `undefined` from `false`. This prevents a prop type error where a boolean will be passed into a react-router component when used.