### PR TITLE
Address Video Focus A11y Issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -196,7 +196,8 @@
     "@babel/helper-plugin-utils": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
+      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+      "dev": true
     },
     "@babel/helper-regex": {
       "version": "7.4.4",
@@ -689,6 +690,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.7.4.tgz",
       "integrity": "sha512-O8kSkS5fP74Ad/8pfsCMGa8sBRdLxYoSReaARRNSz3FbFQj3z/QUvoUmJ28gn9BO93YfnXc3j+Xyaqe8cKDNBQ==",
+      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.7.4",
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -700,6 +702,7 @@
           "version": "7.7.4",
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz",
           "integrity": "sha512-dGcrX6K9l8258WFjyDLJwuVKxR4XZfU0/vTUgOQYWEnRD8mgr+p4d6fCUMq/ys0h4CCt/S5JhbvtyErjWouAUQ==",
+          "dev": true,
           "requires": {
             "@babel/types": "^7.7.4"
           }
@@ -708,6 +711,7 @@
           "version": "7.7.4",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
           "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "lodash": "^4.17.13",
@@ -3472,6 +3476,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@vxna/mini-html-webpack-template/-/mini-html-webpack-template-1.0.0.tgz",
       "integrity": "sha512-cwlmP9CoWyZYtI33DUKOjS6Hyn3yNrXZQtP+QxPjaRpYNYcbrg+u7EZQZmvB/Mi7qwiDbeTU7UtMT0C5ouRTNA==",
+      "dev": true,
       "requires": {
         "common-tags": "^1.8.0"
       }
@@ -6304,7 +6309,8 @@
     "common-tags": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw=="
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -9224,7 +9230,8 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
     },
     "etag": {
       "version": "1.8.1",
@@ -25618,7 +25625,8 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "1.7.0",
@@ -29232,6 +29240,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
       "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -29935,7 +29944,8 @@
     "semver": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -31860,7 +31870,8 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",

--- a/packages/Video/ControlBar/ControlBar.jsx
+++ b/packages/Video/ControlBar/ControlBar.jsx
@@ -59,6 +59,7 @@ const ControlBar = ({
   sources,
   tracks,
   videoPlaying,
+  videoUnplayed,
   videoBufferEnd,
   isHidden,
   videoLength,
@@ -134,11 +135,13 @@ const ControlBar = ({
           copy={copy}
           compactModeThreshold={compactModeThreshold}
           videoPlayerWidth={videoPlayerWidth}
+          disableFocus={videoUnplayed}
         />
 
         <Box between={3} inline>
           {tracksAvailable && (
             <VideoButton
+              disableFocus={videoUnplayed}
               label={videoText[copy].captionsToggle}
               icon={<ClosedCaptions />}
               onClick={event => {
@@ -163,6 +166,7 @@ const ControlBar = ({
             </MenuContainer>
           )}
           <VideoButton
+            disableFocus={videoUnplayed}
             label={videoText[copy].qualityToggle}
             icon={<Gear />}
             onClick={event => {
@@ -186,6 +190,7 @@ const ControlBar = ({
             </MenuContainer>
           )}
           <VideoButton
+            disableFocus={videoUnplayed}
             label={videoText[copy].fullScreenToggle}
             icon={videoIsFullscreen ? <FsMinimize /> : <FsExpand />}
             onClick={toggleFullscreen}
@@ -204,6 +209,7 @@ ControlBar.propTypes = {
   sources: PropTypes.array.isRequired,
   tracks: PropTypes.array,
   videoPlaying: PropTypes.bool.isRequired,
+  videoUnplayed: PropTypes.bool.isRequired,
   videoBufferEnd: PropTypes.number.isRequired,
   isHidden: PropTypes.bool,
   videoLength: PropTypes.number.isRequired,

--- a/packages/Video/ControlBar/Controls/VideoButton/VideoButton.jsx
+++ b/packages/Video/ControlBar/Controls/VideoButton/VideoButton.jsx
@@ -12,7 +12,7 @@ const StyledButton = styled.button({
   display: 'inline-flex',
   alignItems: 'center',
 })
-const VideoButton = ({ icon, label, children, ...rest }) => {
+const VideoButton = ({ icon, label, disableFocus, children, ...rest }) => {
   const handleOnKeyDown = event => {
     const key = event.key || event.keyCode
 
@@ -23,7 +23,12 @@ const VideoButton = ({ icon, label, children, ...rest }) => {
   }
 
   return (
-    <StyledButton aria-label={label} onKeyDown={handleOnKeyDown} {...rest}>
+    <StyledButton
+      aria-label={label}
+      onKeyDown={handleOnKeyDown}
+      tabIndex={disableFocus && '-1'}
+      {...rest}
+    >
       {icon}
       {children}
     </StyledButton>
@@ -32,6 +37,7 @@ const VideoButton = ({ icon, label, children, ...rest }) => {
 VideoButton.propTypes = {
   icon: PropTypes.node.isRequired,
   label: PropTypes.string.isRequired,
+  disableFocus: PropTypes.bool.isRequired,
   children: PropTypes.node,
 }
 

--- a/packages/Video/ControlBar/Controls/VolumeSlider/VolumeSlider.jsx
+++ b/packages/Video/ControlBar/Controls/VolumeSlider/VolumeSlider.jsx
@@ -139,6 +139,7 @@ class VolumeSlider extends React.PureComponent {
               ? videoText[this.props.copy].unmute
               : videoText[this.props.copy].mute
           }
+          disableFocus={this.props.disableFocus}
           onClick={this.props.toggleMute}
           onFocus={this.props.resetInactivityTimer}
         />
@@ -170,6 +171,7 @@ VolumeSlider.propTypes = {
   copy: PropTypes.oneOf(['en', 'fr']).isRequired,
   compactModeThreshold: PropTypes.number.isRequired,
   videoPlayerWidth: PropTypes.number.isRequired,
+  disableFocus: PropTypes.bool.isRequired,
 }
 
 VolumeSlider.defaultProps = {}

--- a/packages/Video/Video.jsx
+++ b/packages/Video/Video.jsx
@@ -706,6 +706,7 @@ class Video extends React.Component {
             videoPlaying={
               this.refVideoPlayer.current !== null ? !this.refVideoPlayer.current.paused : false
             }
+            videoUnplayed={this.state.videoUnplayed}
             videoDefaultVolume={this.props.defaultVolume / 100}
             videoCurrentVolume={this.state.videoCurrentVolume}
             videoIsMuted={this.state.videoIsMuted}

--- a/packages/Video/__tests__/__snapshots__/Video.spec.jsx.snap
+++ b/packages/Video/__tests__/__snapshots__/Video.spec.jsx.snap
@@ -142,7 +142,6 @@ exports[`Video renders 1`] = `
   font: inherit;
   cursor: pointer;
   vertical-align: middle;
-  outline: none;
 }
 
 .c6 svg>path {
@@ -807,7 +806,6 @@ input[type=range].c24::-ms-tooltip {
   font: inherit;
   cursor: pointer;
   vertical-align: middle;
-  outline: none;
 }
 
 .c6 svg>path {
@@ -1364,6 +1362,7 @@ input[type=range].c24::-ms-tooltip {
                   <button
                     aria-label="Mute"
                     class="c23"
+                    tabindex="-1"
                   >
                     <svg
                       height="17px"
@@ -1427,6 +1426,7 @@ input[type=range].c24::-ms-tooltip {
                   <button
                     aria-label="Select captions"
                     class="c23"
+                    tabindex="-1"
                   >
                     <svg
                       height="12px"
@@ -1459,6 +1459,7 @@ input[type=range].c24::-ms-tooltip {
                   <button
                     aria-label="Change video quality"
                     class="c23"
+                    tabindex="-1"
                   >
                     <svg
                       height="14px"
@@ -1496,6 +1497,7 @@ input[type=range].c24::-ms-tooltip {
                   <button
                     aria-label="Toggle fullscreen"
                     class="c23"
+                    tabindex="-1"
                   >
                     <svg
                       height="14px"
@@ -1780,7 +1782,6 @@ input[type=range].c24::-ms-tooltip {
                                                 "font: inherit;",
                                                 "cursor: pointer;",
                                                 "vertical-align: middle;",
-                                                "outline: none;",
                                                 "@media (min-width: 768px) {",
                                                 "width: 200px;",
                                                 "height: 200px;",
@@ -2507,6 +2508,7 @@ input[type=range].c24::-ms-tooltip {
                       <button
                         aria-label="Mute"
                         class="c23"
+                        tabindex="-1"
                       >
                         <svg
                           height="17px"
@@ -2570,6 +2572,7 @@ input[type=range].c24::-ms-tooltip {
                       <button
                         aria-label="Select captions"
                         class="c23"
+                        tabindex="-1"
                       >
                         <svg
                           height="12px"
@@ -2602,6 +2605,7 @@ input[type=range].c24::-ms-tooltip {
                       <button
                         aria-label="Change video quality"
                         class="c23"
+                        tabindex="-1"
                       >
                         <svg
                           height="14px"
@@ -2639,6 +2643,7 @@ input[type=range].c24::-ms-tooltip {
                       <button
                         aria-label="Toggle fullscreen"
                         class="c23"
+                        tabindex="-1"
                       >
                         <svg
                           height="14px"
@@ -2685,6 +2690,7 @@ input[type=range].c24::-ms-tooltip {
           videoPlayerWidth={0}
           videoPlaying={false}
           videoQuality={1}
+          videoUnplayed={true}
         >
           <ControlBar__ControlBarContainer
             isHidden={true}
@@ -3000,6 +3006,7 @@ input[type=range].c24::-ms-tooltip {
                       <VolumeSlider
                         compactModeThreshold={700}
                         copy="en"
+                        disableFocus={true}
                         resetInactivityTimer={[Function]}
                         setVolume={[Function]}
                         toggleMute={[Function]}
@@ -3062,6 +3069,7 @@ input[type=range].c24::-ms-tooltip {
                               className="c22"
                             >
                               <VideoButton
+                                disableFocus={true}
                                 icon={<Unmuted />}
                                 label="Mute"
                                 onClick={[Function]}
@@ -3072,6 +3080,7 @@ input[type=range].c24::-ms-tooltip {
                                   onClick={[Function]}
                                   onFocus={[Function]}
                                   onKeyDown={[Function]}
+                                  tabIndex="-1"
                                 >
                                   <StyledComponent
                                     aria-label="Mute"
@@ -3108,6 +3117,7 @@ input[type=range].c24::-ms-tooltip {
                                     onClick={[Function]}
                                     onFocus={[Function]}
                                     onKeyDown={[Function]}
+                                    tabIndex="-1"
                                   >
                                     <button
                                       aria-label="Mute"
@@ -3115,6 +3125,7 @@ input[type=range].c24::-ms-tooltip {
                                       onClick={[Function]}
                                       onFocus={[Function]}
                                       onKeyDown={[Function]}
+                                      tabIndex="-1"
                                     >
                                       <Unmuted>
                                         <svg
@@ -3293,6 +3304,7 @@ input[type=range].c24::-ms-tooltip {
                               className="c25"
                             >
                               <VideoButton
+                                disableFocus={true}
                                 icon={<ClosedCaptions />}
                                 label="Select captions"
                                 onBlur={[Function]}
@@ -3305,6 +3317,7 @@ input[type=range].c24::-ms-tooltip {
                                   onClick={[Function]}
                                   onFocus={[Function]}
                                   onKeyDown={[Function]}
+                                  tabIndex="-1"
                                 >
                                   <StyledComponent
                                     aria-label="Select captions"
@@ -3342,6 +3355,7 @@ input[type=range].c24::-ms-tooltip {
                                     onClick={[Function]}
                                     onFocus={[Function]}
                                     onKeyDown={[Function]}
+                                    tabIndex="-1"
                                   >
                                     <button
                                       aria-label="Select captions"
@@ -3350,6 +3364,7 @@ input[type=range].c24::-ms-tooltip {
                                       onClick={[Function]}
                                       onFocus={[Function]}
                                       onKeyDown={[Function]}
+                                      tabIndex="-1"
                                     >
                                       <ClosedCaptions>
                                         <svg
@@ -3385,6 +3400,7 @@ input[type=range].c24::-ms-tooltip {
                                 </VideoButton__StyledButton>
                               </VideoButton>
                               <VideoButton
+                                disableFocus={true}
                                 icon={<FsExpand />}
                                 label="Change video quality"
                                 onBlur={[Function]}
@@ -3397,6 +3413,7 @@ input[type=range].c24::-ms-tooltip {
                                   onClick={[Function]}
                                   onFocus={[Function]}
                                   onKeyDown={[Function]}
+                                  tabIndex="-1"
                                 >
                                   <StyledComponent
                                     aria-label="Change video quality"
@@ -3434,6 +3451,7 @@ input[type=range].c24::-ms-tooltip {
                                     onClick={[Function]}
                                     onFocus={[Function]}
                                     onKeyDown={[Function]}
+                                    tabIndex="-1"
                                   >
                                     <button
                                       aria-label="Change video quality"
@@ -3442,6 +3460,7 @@ input[type=range].c24::-ms-tooltip {
                                       onClick={[Function]}
                                       onFocus={[Function]}
                                       onKeyDown={[Function]}
+                                      tabIndex="-1"
                                     >
                                       <FsExpand>
                                         <svg
@@ -3482,6 +3501,7 @@ input[type=range].c24::-ms-tooltip {
                                 </VideoButton__StyledButton>
                               </VideoButton>
                               <VideoButton
+                                disableFocus={true}
                                 icon={<FsExpand />}
                                 label="Toggle fullscreen"
                                 onBlur={[Function]}
@@ -3494,6 +3514,7 @@ input[type=range].c24::-ms-tooltip {
                                   onClick={[Function]}
                                   onFocus={[Function]}
                                   onKeyDown={[Function]}
+                                  tabIndex="-1"
                                 >
                                   <StyledComponent
                                     aria-label="Toggle fullscreen"
@@ -3531,6 +3552,7 @@ input[type=range].c24::-ms-tooltip {
                                     onClick={[Function]}
                                     onFocus={[Function]}
                                     onKeyDown={[Function]}
+                                    tabIndex="-1"
                                   >
                                     <button
                                       aria-label="Toggle fullscreen"
@@ -3539,6 +3561,7 @@ input[type=range].c24::-ms-tooltip {
                                       onClick={[Function]}
                                       onFocus={[Function]}
                                       onKeyDown={[Function]}
+                                      tabIndex="-1"
                                     >
                                       <FsExpand>
                                         <svg

--- a/packages/WebVideo/__tests__/__snapshots__/WebVideo.spec.jsx.snap
+++ b/packages/WebVideo/__tests__/__snapshots__/WebVideo.spec.jsx.snap
@@ -182,7 +182,6 @@ exports[`WebVideo renders 1`] = `
   font: inherit;
   cursor: pointer;
   vertical-align: middle;
-  outline: none;
 }
 
 .c5 svg>path {
@@ -453,7 +452,6 @@ exports[`WebVideo renders 1`] = `
                                           "font: inherit;",
                                           "cursor: pointer;",
                                           "vertical-align: middle;",
-                                          "outline: none;",
                                           "@media (min-width: 768px) {",
                                           "width: 200px;",
                                           "height: 200px;",

--- a/shared/components/VideoSplash/BigVideoButton/BigVideoButton.jsx
+++ b/shared/components/VideoSplash/BigVideoButton/BigVideoButton.jsx
@@ -58,7 +58,6 @@ const BigPlayButton = styled.button({
   font: 'inherit',
   cursor: 'pointer',
   verticalAlign: 'middle',
-  outline: 'none',
 
   ...media.from('md').css({
     width: 200,


### PR DESCRIPTION
This PR adjusts the following:

- Adds a default focus border to the splash screen play button when focused
- Fixes a bug in `Video` where the buttons in the control bar would be focusable while the splash screen was visible