### PR TITLE
Upgrade TDS to Node 12

### DIFF
--- a/.github/workflows/tds-workflow.yml
+++ b/.github/workflows/tds-workflow.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v1
-      - name: Setup Node 8
+      - name: Setup Node 12
         uses: actions/setup-node@v1
         with:
           node-version: 12
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v1
-      - name: Setup Node 8
+      - name: Setup Node 12
         uses: actions/setup-node@v1
         with:
           node-version: 12

--- a/.github/workflows/tds-workflow.yml
+++ b/.github/workflows/tds-workflow.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Node 8
         uses: actions/setup-node@v1
         with:
-          node-version: 8
+          node-version: 12
       - name: Bootstrap
         run: npm ci && npx lerna bootstrap --hoist && npm run build -- --all
       - name: Run Unit Tests
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node 8
         uses: actions/setup-node@v1
         with:
-          node-version: 8
+          node-version: 12
       - name: Bootstrap
         run: npm ci && npx lerna bootstrap --hoist && npm run build -- --all
       - name: Build Cartesian Components

--- a/circle.yml
+++ b/circle.yml
@@ -7,11 +7,11 @@ executors:
 
   browsers:
     docker:
-      - image: circleci/node:8-browsers
+      - image: circleci/node:12-browsers
 
   prepr:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:12
 
 commands:
   persist:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4263,11 +4263,6 @@
       "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
       "dev": true
     },
-    "array-find-es6": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/array-find-es6/-/array-find-es6-2.0.3.tgz",
-      "integrity": "sha512-35QZe7bM24H1Q+tAhFRVp6mUsCD+M1zREs45fjeiVqF2OAgzly76tcCjBISvu4AlR6slKv1oDaYr4KlPmzBKZA=="
-    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -8123,14 +8118,6 @@
         "esutils": "^2.0.2"
       }
     },
-    "dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-      "requires": {
-        "@babel/runtime": "^7.1.2"
-      }
-    },
     "dom-iterator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dom-iterator/-/dom-iterator-1.0.0.tgz",
@@ -9469,7 +9456,8 @@
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -9804,14 +9792,6 @@
       "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
       "dev": true
     },
-    "flexboxgrid2": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/flexboxgrid2/-/flexboxgrid2-7.2.1.tgz",
-      "integrity": "sha512-O2bO5ZcBXnFy7cYmyt/CKb6CuwzNuUPxWJt8WOiaot8SetE9zyUahXGTSpKDm3+CTYQ5YeEMPeunMdjcxKJz4w==",
-      "requires": {
-        "normalize.css": "^7.0.0"
-      }
-    },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -9944,11 +9924,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fscreen": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fscreen/-/fscreen-1.0.2.tgz",
-      "integrity": "sha1-xMUdltgZ11oZ1yjg30Rfm+m7mE8="
     },
     "fsevents": {
       "version": "1.2.9",
@@ -15304,6 +15279,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -17011,14 +16987,6 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
-    "json2mq": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
-      "integrity": "sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=",
-      "requires": {
-        "string-convert": "^0.2.0"
-      }
-    },
     "json3": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
@@ -17625,11 +17593,6 @@
         "npm-prefix": "^1.2.0",
         "resolve-from": "^5.0.0"
       }
-    },
-    "load-script": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
     },
     "loader-runner": {
       "version": "2.4.0",
@@ -19127,11 +19090,6 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
       "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
       "dev": true
-    },
-    "normalize.css": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-7.0.0.tgz",
-      "integrity": "sha1-q/sd2CRwZ04DIrU86xqvQSk45L8="
     },
     "npm": {
       "version": "6.13.6",
@@ -27127,15 +27085,6 @@
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==",
       "dev": true
     },
-    "react-flexbox-grid": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/react-flexbox-grid/-/react-flexbox-grid-2.1.2.tgz",
-      "integrity": "sha512-lj1oVnIJ7TY3W6tPjFUxlUYd1DLFxEg8RiX3HAYVvreE3O9HU9n2390CFoPQ+qk1E+5MXa2t/mLMafFLAa8+7Q==",
-      "requires": {
-        "flexboxgrid2": "^7.2.0",
-        "prop-types": "^15.5.8"
-      }
-    },
     "react-group": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/react-group/-/react-group-1.0.6.tgz",
@@ -27180,7 +27129,8 @@
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "dev": true
     },
     "react-live": {
       "version": "1.12.0",
@@ -27195,17 +27145,6 @@
         "prismjs": "1.6",
         "prop-types": "^15.5.8",
         "unescape": "^0.2.0"
-      }
-    },
-    "react-media": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/react-media/-/react-media-1.10.0.tgz",
-      "integrity": "sha512-FjgYmFoaPTImST06jqotuu0Mk8LOXiGYS/fIyiXuLnf20l3DPniBwtrxi604/HxxjqvmHS3oz5rAwnqdvosV4A==",
-      "requires": {
-        "@babel/runtime": "^7.2.0",
-        "invariant": "^2.2.2",
-        "json2mq": "^0.2.0",
-        "prop-types": "^15.5.10"
       }
     },
     "react-router": {
@@ -27504,27 +27443,6 @@
         "prop-types": "^15.6.2",
         "react-is": "^16.8.6",
         "scheduler": "^0.13.6"
-      }
-    },
-    "react-transition-group": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
-      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
-      "requires": {
-        "dom-helpers": "^3.4.0",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
-    "react-youtube": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/react-youtube/-/react-youtube-7.9.0.tgz",
-      "integrity": "sha512-2+nBF4qP8nStYEILIO1/SylKOCnnJUxuZm+qCeWA0eeZxnWZIIixfAeAqbzblwx5L1n/26ACocy3epm9Glox8w==",
-      "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "prop-types": "^15.5.3",
-        "youtube-player": "^5.5.1"
       }
     },
     "read": {
@@ -29164,11 +29082,6 @@
         "walker": "~1.0.5"
       }
     },
-    "sass-mq": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/sass-mq/-/sass-mq-5.0.1.tgz",
-      "integrity": "sha512-ugSVZO5fzasSFrGfKCtY02spnkOOfo9U9sXuzCuSXoCl1CgcoqdJRdNmigZkhvRVph1GKM6o0pgI00Jjc445CA=="
-    },
     "sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
@@ -29766,11 +29679,6 @@
         }
       }
     },
-    "sister": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/sister/-/sister-3.0.2.tgz",
-      "integrity": "sha512-p19rtTs+NksBRKW9qn0UhZ8/TUI9BPw9lmtHny+Y3TinWlOa9jWh9xB0AtPSdmOy49NJJJSSe0Ey4C7h0TrcYA=="
-    },
     "sisteransi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
@@ -30357,11 +30265,6 @@
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
       "integrity": "sha1-2sMECGkMIfPDYwo/86BYd73L1zY=",
       "dev": true
-    },
-    "string-convert": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
-      "integrity": "sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c="
     },
     "string-hash": {
       "version": "1.1.3",
@@ -33672,31 +33575,6 @@
       "dev": true,
       "requires": {
         "camelcase": "^4.1.0"
-      }
-    },
-    "youtube-player": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/youtube-player/-/youtube-player-5.5.2.tgz",
-      "integrity": "sha512-ZGtsemSpXnDky2AUYWgxjaopgB+shFHgXVpiJFeNB5nWEugpW1KWYDaHKuLqh2b67r24GtP6HoSW5swvf0fFIQ==",
-      "requires": {
-        "debug": "^2.6.6",
-        "load-script": "^1.0.0",
-        "sister": "^3.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
       }
     },
     "yup": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@telus/tds-core",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4263,6 +4263,11 @@
       "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
       "dev": true
     },
+    "array-find-es6": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/array-find-es6/-/array-find-es6-2.0.3.tgz",
+      "integrity": "sha512-35QZe7bM24H1Q+tAhFRVp6mUsCD+M1zREs45fjeiVqF2OAgzly76tcCjBISvu4AlR6slKv1oDaYr4KlPmzBKZA=="
+    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -8118,6 +8123,14 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "dom-iterator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dom-iterator/-/dom-iterator-1.0.0.tgz",
@@ -9456,8 +9469,7 @@
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -9792,6 +9804,14 @@
       "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
       "dev": true
     },
+    "flexboxgrid2": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/flexboxgrid2/-/flexboxgrid2-7.2.1.tgz",
+      "integrity": "sha512-O2bO5ZcBXnFy7cYmyt/CKb6CuwzNuUPxWJt8WOiaot8SetE9zyUahXGTSpKDm3+CTYQ5YeEMPeunMdjcxKJz4w==",
+      "requires": {
+        "normalize.css": "^7.0.0"
+      }
+    },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -9924,6 +9944,11 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fscreen": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fscreen/-/fscreen-1.0.2.tgz",
+      "integrity": "sha1-xMUdltgZ11oZ1yjg30Rfm+m7mE8="
     },
     "fsevents": {
       "version": "1.2.9",
@@ -15279,7 +15304,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -16987,6 +17011,14 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
+    "json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=",
+      "requires": {
+        "string-convert": "^0.2.0"
+      }
+    },
     "json3": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
@@ -17593,6 +17625,11 @@
         "npm-prefix": "^1.2.0",
         "resolve-from": "^5.0.0"
       }
+    },
+    "load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
     },
     "loader-runner": {
       "version": "2.4.0",
@@ -19090,6 +19127,11 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
       "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
       "dev": true
+    },
+    "normalize.css": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-7.0.0.tgz",
+      "integrity": "sha1-q/sd2CRwZ04DIrU86xqvQSk45L8="
     },
     "npm": {
       "version": "6.13.6",
@@ -27085,6 +27127,15 @@
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==",
       "dev": true
     },
+    "react-flexbox-grid": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-flexbox-grid/-/react-flexbox-grid-2.1.2.tgz",
+      "integrity": "sha512-lj1oVnIJ7TY3W6tPjFUxlUYd1DLFxEg8RiX3HAYVvreE3O9HU9n2390CFoPQ+qk1E+5MXa2t/mLMafFLAa8+7Q==",
+      "requires": {
+        "flexboxgrid2": "^7.2.0",
+        "prop-types": "^15.5.8"
+      }
+    },
     "react-group": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/react-group/-/react-group-1.0.6.tgz",
@@ -27129,8 +27180,7 @@
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-live": {
       "version": "1.12.0",
@@ -27145,6 +27195,17 @@
         "prismjs": "1.6",
         "prop-types": "^15.5.8",
         "unescape": "^0.2.0"
+      }
+    },
+    "react-media": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/react-media/-/react-media-1.10.0.tgz",
+      "integrity": "sha512-FjgYmFoaPTImST06jqotuu0Mk8LOXiGYS/fIyiXuLnf20l3DPniBwtrxi604/HxxjqvmHS3oz5rAwnqdvosV4A==",
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "invariant": "^2.2.2",
+        "json2mq": "^0.2.0",
+        "prop-types": "^15.5.10"
       }
     },
     "react-router": {
@@ -27443,6 +27504,27 @@
         "prop-types": "^15.6.2",
         "react-is": "^16.8.6",
         "scheduler": "^0.13.6"
+      }
+    },
+    "react-transition-group": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+      "requires": {
+        "dom-helpers": "^3.4.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
+      }
+    },
+    "react-youtube": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/react-youtube/-/react-youtube-7.9.0.tgz",
+      "integrity": "sha512-2+nBF4qP8nStYEILIO1/SylKOCnnJUxuZm+qCeWA0eeZxnWZIIixfAeAqbzblwx5L1n/26ACocy3epm9Glox8w==",
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "prop-types": "^15.5.3",
+        "youtube-player": "^5.5.1"
       }
     },
     "read": {
@@ -29082,6 +29164,11 @@
         "walker": "~1.0.5"
       }
     },
+    "sass-mq": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/sass-mq/-/sass-mq-5.0.1.tgz",
+      "integrity": "sha512-ugSVZO5fzasSFrGfKCtY02spnkOOfo9U9sXuzCuSXoCl1CgcoqdJRdNmigZkhvRVph1GKM6o0pgI00Jjc445CA=="
+    },
     "sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
@@ -29679,6 +29766,11 @@
         }
       }
     },
+    "sister": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sister/-/sister-3.0.2.tgz",
+      "integrity": "sha512-p19rtTs+NksBRKW9qn0UhZ8/TUI9BPw9lmtHny+Y3TinWlOa9jWh9xB0AtPSdmOy49NJJJSSe0Ey4C7h0TrcYA=="
+    },
     "sisteransi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
@@ -30265,6 +30357,11 @@
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
       "integrity": "sha1-2sMECGkMIfPDYwo/86BYd73L1zY=",
       "dev": true
+    },
+    "string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c="
     },
     "string-hash": {
       "version": "1.1.3",
@@ -33575,6 +33672,31 @@
       "dev": true,
       "requires": {
         "camelcase": "^4.1.0"
+      }
+    },
+    "youtube-player": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/youtube-player/-/youtube-player-5.5.2.tgz",
+      "integrity": "sha512-ZGtsemSpXnDky2AUYWgxjaopgB+shFHgXVpiJFeNB5nWEugpW1KWYDaHKuLqh2b67r24GtP6HoSW5swvf0fFIQ==",
+      "requires": {
+        "debug": "^2.6.6",
+        "load-script": "^1.0.0",
+        "sister": "^3.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "yup": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0",
+  "version": "4.0.0",
   "name": "@telus/tds-core",
   "description": "TELUS Design System core components",
   "homepage": "https://github.com/telus/tds-core",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "telus"
   ],
   "engines": {
-    "node": ">=8"
+    "node": ">=12"
   },
   "bugs": {
     "url": "https://github.com/telus/tds-core/issues"


### PR DESCRIPTION
This PR changes the minimum supported version of Node on all components and the repo itself to 12. Additionally, it updates the CI actions to use Node 12.

This bumps the repo to V4.