### PR TITLE
fix(core-interactive-icon): prevent props are undefined navbutton errors

### DIFF
--- a/packages/InteractiveIcon/svgs/NavButton/CartEmptyBold.jsx
+++ b/packages/InteractiveIcon/svgs/NavButton/CartEmptyBold.jsx
@@ -12,6 +12,7 @@ const CartEmptyBold = forwardRef(({ copy, ...props }, ref) => (
     {...props}
     ref={ref}
     a11yText={getCopy(cartEmptyBoldCopyDictionary, copy).a11yText}
+    copy={copy} // Passed in to satisfy styleguidist workaround
   >
     <StyledInteractiveIconSVG width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
       <path

--- a/packages/InteractiveIcon/svgs/NavButton/CartFilledBold.jsx
+++ b/packages/InteractiveIcon/svgs/NavButton/CartFilledBold.jsx
@@ -25,6 +25,7 @@ const CartFilledBold = forwardRef(({ copy, variant, numItems, ...props }, ref) =
       ref={ref}
       a11yText={a11yText.replace('%{numItems}', numItems)}
       variant={variant}
+      copy={copy} // Passed in to satisfy styleguidist workaround
     >
       <StyledInteractiveIconSVG width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
         <g fillRule="evenodd">
@@ -46,8 +47,12 @@ CartFilledBold.propTypes = {
       a11yText: PropTypes.string.isRequired,
     }),
   ]).isRequired,
-  variant: PropTypes.oneOf(['default', 'inverted']).isRequired,
+  variant: PropTypes.oneOf(['default', 'inverted']),
   numItems: PropTypes.number.isRequired,
+}
+
+CartFilledBold.defaultProps = {
+  variant: 'default',
 }
 
 CartFilledBold.displayName = 'CartFilledBold'

--- a/packages/InteractiveIcon/svgs/NavButton/NotifyBold.jsx
+++ b/packages/InteractiveIcon/svgs/NavButton/NotifyBold.jsx
@@ -12,6 +12,7 @@ const NotifyBold = forwardRef(({ copy, ...props }, ref) => (
     {...props}
     ref={ref}
     a11yText={getCopy(notifyBoldCopyDictionary, copy).a11yText}
+    copy={copy} // Passed in to satisfy styleguidist workaround
   >
     <StyledInteractiveIconSVG width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
       <path

--- a/packages/InteractiveIcon/svgs/NavButton/ProfileBold.jsx
+++ b/packages/InteractiveIcon/svgs/NavButton/ProfileBold.jsx
@@ -12,6 +12,7 @@ const ProfileBold = forwardRef(({ copy, ...props }, ref) => (
     {...props}
     ref={ref}
     a11yText={getCopy(profileBoldCopyDictionary, copy).a11yText}
+    copy={copy} // Passed in to satisfy styleguidist workaround
   >
     <StyledInteractiveIconSVG width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
       <path

--- a/packages/InteractiveIcon/svgs/NavButton/SearchBold.jsx
+++ b/packages/InteractiveIcon/svgs/NavButton/SearchBold.jsx
@@ -12,6 +12,7 @@ const SearchBold = forwardRef(({ copy, ...props }, ref) => (
     {...props}
     ref={ref}
     a11yText={getCopy(searchBoldCopyDictionary, copy).a11yText}
+    copy={copy} // Passed in to satisfy styleguidist workaround
   >
     <StyledInteractiveIconSVG width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
       <path d="M10.022 1l.253.003c4.994.13 8.935 4.278 8.806 9.267a8.985 8.985 0 01-1.728 5.087l-.189.249 5.604 5.897c.3.316.306.802.034 1.133l-.074.08-.03.028a.945.945 0 01-1.173.098l-.092-.072-6.081-5.418a9.01 9.01 0 01-5.543 1.719c-4.993-.13-8.935-4.278-8.806-9.267C1.13 4.898 5.144 1.008 10.023 1zm.02 1.81a7.214 7.214 0 100 14.43 7.214 7.214 0 000-14.43z" />

--- a/packages/InteractiveIcon/svgs/NavButton/SettingsBold.jsx
+++ b/packages/InteractiveIcon/svgs/NavButton/SettingsBold.jsx
@@ -12,6 +12,7 @@ const SettingsBold = forwardRef(({ copy, ...props }, ref) => (
     {...props}
     ref={ref}
     a11yText={getCopy(settingsBoldCopyDictionary, copy).a11yText}
+    copy={copy} // Passed in to satisfy styleguidist workaround
   >
     <StyledInteractiveIconSVG width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
       <path

--- a/packages/InteractiveIcon/svgs/NavButton/SupportBold.jsx
+++ b/packages/InteractiveIcon/svgs/NavButton/SupportBold.jsx
@@ -12,6 +12,7 @@ const SupportBold = forwardRef(({ copy, ...props }, ref) => (
     {...props}
     ref={ref}
     a11yText={getCopy(supportBoldCopyDictionary, copy).a11yText}
+    copy={copy} // Passed in to satisfy styleguidist workaround
   >
     <StyledInteractiveIconSVG width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
       <path

--- a/packages/InteractiveIcon/svgs/NavButton/UserAddBold.jsx
+++ b/packages/InteractiveIcon/svgs/NavButton/UserAddBold.jsx
@@ -12,6 +12,7 @@ const UserAddBold = forwardRef(({ copy, ...props }, ref) => (
     {...props}
     ref={ref}
     a11yText={getCopy(userAddBoldCopyDictionary, copy).a11yText}
+    copy={copy} // Passed in to satisfy styleguidist workaround
   >
     <StyledInteractiveIconSVG width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
       <path


### PR DESCRIPTION
Fixes an issue where NavButtons will say that the copy prop was not provided, even though it has. The solution was to pass it to the shared NavButton component, which has the prop set as `required` just so it shows up as such in styleguidist. Additionally, this PR fixes an issue where the `variant` prop was being improperly handled in `CartFilledBold`.