### PR TITLE
 fix(core-flex-grid): prevent invisible hairline divider w/ mdOffset+

### DIFF
--- a/packages/FlexGrid/Col/Col.jsx
+++ b/packages/FlexGrid/Col/Col.jsx
@@ -17,6 +17,7 @@ const StyledCol = styled(({ hiddenLevel, gutter, horizontalAlignLevel, ...rest }
   'div&': {
     paddingLeft: gutter ? '1rem' : 0,
     paddingRight: gutter ? '1rem' : 0,
+    flexGrow: 1,
   },
   ...media.until('sm').css({
     display: hiddenLevel[0] === 0 ? 'none' : 'block',

--- a/packages/FlexGrid/Col/__tests__/__snapshots__/Col.spec.jsx.snap
+++ b/packages/FlexGrid/Col/__tests__/__snapshots__/Col.spec.jsx.snap
@@ -4,6 +4,10 @@ exports[`Col can align column content horizontally using a responsive prop objec
 div.c0 {
   padding-left: 1rem;
   padding-right: 1rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 @media (max-width:575px) {
@@ -57,6 +61,10 @@ exports[`Col can align column content horizontally using a string 1`] = `
 div.c0 {
   padding-left: 1rem;
   padding-right: 1rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 @media (max-width:575px) {
@@ -110,6 +118,10 @@ exports[`Col can hide columns 1`] = `
 div.c0 {
   padding-left: 1rem;
   padding-right: 1rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 @media (max-width:575px) {
@@ -166,6 +178,10 @@ exports[`Col renders 1`] = `
 div.c0 {
   padding-left: 1rem;
   padding-right: 1rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 @media (max-width:575px) {
@@ -219,6 +235,10 @@ exports[`Col supports responsive hidden columns 1`] = `
 div.c0 {
   padding-left: 1rem;
   padding-right: 1rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 @media (max-width:575px) {

--- a/packages/FlexGrid/__tests__/__snapshots__/FlexGrid.spec.jsx.snap
+++ b/packages/FlexGrid/__tests__/__snapshots__/FlexGrid.spec.jsx.snap
@@ -4,6 +4,10 @@ exports[`FlexGrid allows the limitWidth prop to be unset 1`] = `
 div.c2 {
   padding-left: 1rem;
   padding-right: 1rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 .c1 {
@@ -464,6 +468,10 @@ exports[`FlexGrid can have limited width at various viewport sizes 1`] = `
 div.c2 {
   padding-left: 1rem;
   padding-right: 1rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 .c1 {
@@ -928,6 +936,10 @@ exports[`FlexGrid renders 1`] = `
 div.c2 {
   padding-left: 1rem;
   padding-right: 1rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 .c1 {
@@ -1100,6 +1112,10 @@ exports[`FlexGrid supports responsive reversal 1`] = `
 div.c2 {
   padding-left: 1rem;
   padding-right: 1rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 .c1 {

--- a/packages/Notification/__tests__/__snapshots__/Notification.spec.jsx.snap
+++ b/packages/Notification/__tests__/__snapshots__/Notification.spec.jsx.snap
@@ -4,11 +4,19 @@ exports[`<Notification /> can have a variant 1`] = `
 div.c4 {
   padding-left: 1rem;
   padding-right: 1rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 div.c5 {
   padding-left: 0;
   padding-right: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 .c3 {
@@ -1043,11 +1051,19 @@ exports[`<Notification /> can have a variant 2`] = `
 div.c4 {
   padding-left: 1rem;
   padding-right: 1rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 div.c5 {
   padding-left: 0;
   padding-right: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 .c3 {
@@ -2222,11 +2238,19 @@ exports[`<Notification /> renders 1`] = `
 div.c4 {
   padding-left: 1rem;
   padding-right: 1rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 div.c5 {
   padding-left: 0;
   padding-right: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 .c3 {

--- a/packages/StepTracker/__tests__/__snapshots__/StepTracker.spec.jsx.snap
+++ b/packages/StepTracker/__tests__/__snapshots__/StepTracker.spec.jsx.snap
@@ -57,11 +57,19 @@ exports[`<StepTracker /> renders 1`] = `
 div.c3 {
   padding-left: 1rem;
   padding-right: 1rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 div.c12 {
   padding-left: 1rem;
   padding-right: 1rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 .c2 {

--- a/packages/TermsAndConditions/Footnote/__tests__/__snapshots__/Footnote.spec.jsx.snap
+++ b/packages/TermsAndConditions/Footnote/__tests__/__snapshots__/Footnote.spec.jsx.snap
@@ -52,6 +52,10 @@ exports[`Footnote renders closed 1`] = `
 div.c7 {
   padding-left: 1rem;
   padding-right: 1rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 .c6 {
@@ -518,6 +522,10 @@ exports[`Footnote renders opened 1`] = `
 div.c7 {
   padding-left: 1rem;
   padding-right: 1rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 .c6 {

--- a/packages/TermsAndConditions/__tests__/__snapshots__/TermsAndConditions.spec.jsx.snap
+++ b/packages/TermsAndConditions/__tests__/__snapshots__/TermsAndConditions.spec.jsx.snap
@@ -27,11 +27,19 @@ exports[`TermsAndConditions renders 1`] = `
 div.c3 {
   padding-left: 0;
   padding-right: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 div.c15 {
   padding-left: 1rem;
   padding-right: 1rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 .c2 {
@@ -599,11 +607,19 @@ exports[`TermsAndConditions renders expanded 1`] = `
 div.c3 {
   padding-left: 0;
   padding-right: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 div.c15 {
   padding-left: 1rem;
   padding-right: 1rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 .c2 {
@@ -2788,11 +2804,19 @@ exports[`TermsAndConditions renders expanded with indexedContent and nonIndexedC
 div.c3 {
   padding-left: 0;
   padding-right: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 div.c15 {
   padding-left: 1rem;
   padding-right: 1rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 .c2 {
@@ -5709,11 +5733,19 @@ exports[`TermsAndConditions renders expanded with just nonIndexedContent 1`] = `
 div.c3 {
   padding-left: 0;
   padding-right: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 div.c15 {
   padding-left: 1rem;
   padding-right: 1rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
 }
 
 .c2 {


### PR DESCRIPTION
See #1373 

This prevents an issue where `HairlineDivider` will become invisible if `mdOffset` or higher is set. I've chosen to apply `flex: 1 0 auto` to all `col`s indiscriminately to reduce complexity and ensure consistency. (For example, avoiding another case of a passed down `flex` property, while also treating all `col`s the same way) This should not break any usage of `FlexGrid`, but it should be tested thoroughly in QA to be sure.