### PR TITLE
fix(core-expand-collapse): prevent tertiary text overflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@telus/tds-core",
-  "version": "4.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
+++ b/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
@@ -62,11 +62,13 @@ const ShowFromMd = styled.div({
   display: 'none',
   ...media.from('md').css({
     display: 'inline-block',
+    whiteSpace: 'nowrap',
   }),
 })
 
 const ShowUntilMd = styled.div({
   display: 'inline-block',
+  whiteSpace: 'nowrap',
   ...media.from('md').css({
     display: 'none',
   }),


### PR DESCRIPTION
See #1372 

This prevents an issue where tertiary text will overflow onto a second line if it's too long.