### PR TITLE
fix(core-expand-collapse,core-terms-and-conditions): add button type for clickables

### DIFF
--- a/packages/ExpandCollapse/Accordion/__tests__/__snapshots__/Accordion.spec.jsx.snap
+++ b/packages/ExpandCollapse/Accordion/__tests__/__snapshots__/Accordion.spec.jsx.snap
@@ -305,6 +305,7 @@ exports[`Accordion renders a closed accordion 1`] = `
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   panelDisabled={false}
+                  type="button"
                 >
                   <StyledComponent
                     aria-expanded={false}
@@ -345,6 +346,7 @@ exports[`Accordion renders a closed accordion 1`] = `
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     panelDisabled={false}
+                    type="button"
                   >
                     <button
                       aria-expanded={false}
@@ -353,6 +355,7 @@ exports[`Accordion renders a closed accordion 1`] = `
                       onClick={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      type="button"
                     >
                       <Box
                         inline={false}
@@ -1480,6 +1483,7 @@ exports[`Accordion renders an open accordion 1`] = `
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   panelDisabled={false}
+                  type="button"
                 >
                   <StyledComponent
                     aria-expanded={true}
@@ -1520,6 +1524,7 @@ exports[`Accordion renders an open accordion 1`] = `
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     panelDisabled={false}
+                    type="button"
                   >
                     <button
                       aria-expanded={true}
@@ -1528,6 +1533,7 @@ exports[`Accordion renders an open accordion 1`] = `
                       onClick={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      type="button"
                     >
                       <Box
                         inline={false}

--- a/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
+++ b/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
@@ -182,6 +182,7 @@ class PanelWrapper extends React.Component {
 
     const headerButton = (
       <HeaderButtonClickable
+        type="button"
         panelDisabled={panelDisabled}
         onClick={this.handleClick}
         onMouseEnter={this.mouseEnter}

--- a/packages/ExpandCollapse/__tests__/__snapshots__/ExpandCollapse.spec.jsx.snap
+++ b/packages/ExpandCollapse/__tests__/__snapshots__/ExpandCollapse.spec.jsx.snap
@@ -137,6 +137,7 @@ exports[`ExpandCollapse accessibility wraps a heading tag around a panel label 1
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
   panelDisabled={false}
+  type="button"
 >
   <StyledComponent
     aria-expanded={false}
@@ -177,6 +178,7 @@ exports[`ExpandCollapse accessibility wraps a heading tag around a panel label 1
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
     panelDisabled={false}
+    type="button"
   >
     <button
       aria-expanded={false}
@@ -185,6 +187,7 @@ exports[`ExpandCollapse accessibility wraps a heading tag around a panel label 1
       onClick={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
+      type="button"
     >
       <Box
         inline={false}
@@ -825,6 +828,7 @@ exports[`ExpandCollapse disabled panels are rendered in a disabled treatment 1`]
   onClick={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
+  type="button"
 >
   <Box
     inline={false}
@@ -1631,6 +1635,7 @@ exports[`ExpandCollapse renders a closed panel 1`] = `
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   panelDisabled={false}
+                  type="button"
                 >
                   <StyledComponent
                     aria-expanded={false}
@@ -1671,6 +1676,7 @@ exports[`ExpandCollapse renders a closed panel 1`] = `
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     panelDisabled={false}
+                    type="button"
                   >
                     <button
                       aria-expanded={false}
@@ -1679,6 +1685,7 @@ exports[`ExpandCollapse renders a closed panel 1`] = `
                       onClick={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      type="button"
                     >
                       <Box
                         inline={false}
@@ -2826,6 +2833,7 @@ exports[`ExpandCollapse renders an open panel 1`] = `
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                   panelDisabled={false}
+                  type="button"
                 >
                   <StyledComponent
                     aria-expanded={true}
@@ -2866,6 +2874,7 @@ exports[`ExpandCollapse renders an open panel 1`] = `
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                     panelDisabled={false}
+                    type="button"
                   >
                     <button
                       aria-expanded={true}
@@ -2874,6 +2883,7 @@ exports[`ExpandCollapse renders an open panel 1`] = `
                       onClick={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
+                      type="button"
                     >
                       <Box
                         inline={false}

--- a/packages/TermsAndConditions/Footnote/Footnote.jsx
+++ b/packages/TermsAndConditions/Footnote/Footnote.jsx
@@ -278,6 +278,7 @@ const Footnote = props => {
                         {getCopy(copyDictionary, copy).heading}
                       </Heading>
                       <StyledClickable
+                        type="button"
                         onClick={e => {
                           closeFootnote(e, { returnFocus: true })
                         }}

--- a/packages/TermsAndConditions/Footnote/__tests__/__snapshots__/Footnote.spec.jsx.snap
+++ b/packages/TermsAndConditions/Footnote/__tests__/__snapshots__/Footnote.spec.jsx.snap
@@ -412,6 +412,7 @@ div.c5 {
                         <button
                           aria-label="close"
                           class="c11"
+                          type="button"
                         >
                           <svg
                             class="c12"
@@ -881,6 +882,7 @@ div.c5 {
                         <button
                           aria-label="close"
                           class="c11"
+                          type="button"
                         >
                           <svg
                             class="c12"

--- a/packages/TermsAndConditions/FootnoteLink/FootnoteLink.jsx
+++ b/packages/TermsAndConditions/FootnoteLink/FootnoteLink.jsx
@@ -34,6 +34,7 @@ const FootnoteLink = ({ number, onClick, copy }) => {
       {numbers.map((n, i) => (
         <sup key={n}>
           <StyledFootnoteLink
+            type="button"
             key={numbers[i]}
             ref={refs[i]}
             onClick={e => {

--- a/packages/TermsAndConditions/TermsAndConditions.jsx
+++ b/packages/TermsAndConditions/TermsAndConditions.jsx
@@ -77,6 +77,7 @@ const TermsAndConditions = forwardRef(
           <FlexGrid.Row>
             <FlexGrid.Col>
               <StyledClickableHeading
+                type="button"
                 aria-expanded={isOpen}
                 ref={ref}
                 onClick={() => setOpen(!isOpen)}

--- a/packages/TermsAndConditions/__tests__/__snapshots__/TermsAndConditions.spec.jsx.snap
+++ b/packages/TermsAndConditions/__tests__/__snapshots__/TermsAndConditions.spec.jsx.snap
@@ -460,6 +460,7 @@ div.c14 {
         <button
           aria-expanded="false"
           class="c4 c5"
+          type="button"
         >
           <div
             class="c6 sc-bZQynM c6 c7"
@@ -1317,6 +1318,7 @@ div.c14 {
                                         <Styled(StyledClickable)
                                           aria-expanded={true}
                                           onClick={[Function]}
+                                          type="button"
                                         >
                                           <StyledComponent
                                             aria-expanded={true}
@@ -1358,11 +1360,13 @@ div.c14 {
                                             }
                                             forwardedRef={null}
                                             onClick={[Function]}
+                                            type="button"
                                           >
                                             <button
                                               aria-expanded={true}
                                               className="c4 c5"
                                               onClick={[Function]}
+                                              type="button"
                                             >
                                               <Styled(Box)
                                                 between={3}
@@ -3548,6 +3552,7 @@ div.c14 {
                                         <Styled(StyledClickable)
                                           aria-expanded={true}
                                           onClick={[Function]}
+                                          type="button"
                                         >
                                           <StyledComponent
                                             aria-expanded={true}
@@ -3589,11 +3594,13 @@ div.c14 {
                                             }
                                             forwardedRef={null}
                                             onClick={[Function]}
+                                            type="button"
                                           >
                                             <button
                                               aria-expanded={true}
                                               className="c4 c5"
                                               onClick={[Function]}
+                                              type="button"
                                             >
                                               <Styled(Box)
                                                 between={3}
@@ -6440,6 +6447,7 @@ div.c14 {
                                         <Styled(StyledClickable)
                                           aria-expanded={true}
                                           onClick={[Function]}
+                                          type="button"
                                         >
                                           <StyledComponent
                                             aria-expanded={true}
@@ -6481,11 +6489,13 @@ div.c14 {
                                             }
                                             forwardedRef={null}
                                             onClick={[Function]}
+                                            type="button"
                                           >
                                             <button
                                               aria-expanded={true}
                                               className="c4 c5"
                                               onClick={[Function]}
+                                              type="button"
                                             >
                                               <Styled(Box)
                                                 between={3}


### PR DESCRIPTION
## Related issues

See #1394 

## Description

- Added `type="button"` on `HeaderButtonClickable`, `StyledClickableHeading`, `StyledClickable`

## Checklist before submitting pull request

- [X] New code is unit tested
- Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [ ] For code changes, run `npm run prepr` locally
  - make sure visual and accessibility tests pass
