### PR TITLE
Add querystring hash to fonts

### DIFF
--- a/packages/css-reset/fonts.js
+++ b/packages/css-reset/fonts.js
@@ -2,28 +2,28 @@ const fontBase = 'https://cdn.telus.digital/thorium/core/fonts/'
 const iconFontBase = 'https://cdn.telus.digital/thorium/core/v0.4.0/'
 
 const fonts = [
-  `${fontBase}aff68211-86bb-476d-882e-f7a3face144c.woff2`,
-  `${fontBase}50d35bbc-dfd4-48f1-af16-cf058f69421d.woff`,
+  `${fontBase}aff68211-86bb-476d-882e-f7a3face144c.woff2?v=20200302`,
+  `${fontBase}50d35bbc-dfd4-48f1-af16-cf058f69421d.woff?v=20200302`,
   `${fontBase}278bef59-6be1-4800-b5ac-1f769ab47430.ttf`,
   `${fontBase}56be84de-9d60-4089-8df0-0ea6ec786b84.eot?#iefix`,
 
-  `${fontBase}etext/b8765d4b-d9a3-48b9-ac65-560e7517cf0e.woff2`,
-  `${fontBase}etext/d7d2e6c6-fc3a-41a5-9b52-648e12e215b2.woff`,
+  `${fontBase}etext/b8765d4b-d9a3-48b9-ac65-560e7517cf0e.woff2?v=20200302`,
+  `${fontBase}etext/d7d2e6c6-fc3a-41a5-9b52-648e12e215b2.woff?v=20200302`,
   `${fontBase}etext/cb64744b-d0f7-4ef8-a790-b60d6e3e4f21.ttf`,
   `${fontBase}etext/e0781a75-0ecb-464e-b6e9-85780ddc0921.eot?#iefix`,
 
-  `${fontBase}etext/dc50c02f-3f77-4e75-b89c-e3f9bb4752e6.woff2`,
-  `${fontBase}etext/ce6f5b38-1cb5-4a27-8182-583aa68b2436.woff`,
+  `${fontBase}etext/dc50c02f-3f77-4e75-b89c-e3f9bb4752e6.woff2?v=20200302`,
+  `${fontBase}etext/ce6f5b38-1cb5-4a27-8182-583aa68b2436.woff?v=20200302`,
   `${fontBase}etext/ff06cde7-e06a-4cf0-af4d-5b2f737bf544.ttf`,
   `${fontBase}etext/706ec8e5-fe4a-4518-91a6-7aba4d3d333f.eot?#iefix`,
 
-  `${fontBase}etext/3e8a8b56-3cb0-4347-b670-eaaf06b76e9b.woff2`,
-  `${fontBase}etext/07173950-fa69-4b65-9c71-0cf2ec00b51d.woff`,
+  `${fontBase}etext/3e8a8b56-3cb0-4347-b670-eaaf06b76e9b.woff2?v=20200302`,
+  `${fontBase}etext/07173950-fa69-4b65-9c71-0cf2ec00b51d.woff?v=20200302`,
   `${fontBase}etext/aac5a4b8-ffd3-4529-a098-21b91bc86f9a.ttf`,
   `${fontBase}etext/a747e1ea-ecdf-4f3d-ad47-3df9cfbee3cc.eot?#iefix`,
 
-  `${iconFontBase}core-icons.woff2`,
-  `${iconFontBase}core-icons.woff`,
+  `${iconFontBase}core-icons.woff2?v=20200302`,
+  `${iconFontBase}core-icons.woff?v=20200302`,
   `${iconFontBase}core-icons.ttf`,
   `${iconFontBase}core-icons.eot?#iefix`,
 ]


### PR DESCRIPTION
## Description

- Add querystring hash to fonts to cache-bust fonts

## Checklist before submitting pull request

- [ ] New code is unit tested
- Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [ ] For code changes, run `npm run prepr` locally
  - make sure visual and accessibility tests pass
