### PR TITLE
feat(core-expand-collapse): render id attribute on panels

### DIFF
--- a/packages/ExpandCollapse/Accordion/__tests__/__snapshots__/Accordion.spec.jsx.snap
+++ b/packages/ExpandCollapse/Accordion/__tests__/__snapshots__/Accordion.spec.jsx.snap
@@ -296,6 +296,7 @@ exports[`Accordion renders a closed accordion 1`] = `
           >
             <div
               data-testid="panel-1"
+              id="panel-1"
             >
               <div>
                 <PanelWrapper__HeaderButtonClickable
@@ -1474,6 +1475,7 @@ exports[`Accordion renders an open accordion 1`] = `
           >
             <div
               data-testid="panel-1"
+              id="panel-1"
             >
               <div>
                 <PanelWrapper__HeaderButtonClickable

--- a/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
+++ b/packages/ExpandCollapse/PanelWrapper/PanelWrapper.jsx
@@ -230,7 +230,11 @@ class PanelWrapper extends React.Component {
   render() {
     const { panelId } = this.props
 
-    return <div data-testid={panelId}>{this.renderPanelWrapper()}</div>
+    return (
+      <div id={panelId} data-testid={panelId}>
+        {this.renderPanelWrapper()}
+      </div>
+    )
   }
 }
 

--- a/packages/ExpandCollapse/__tests__/__snapshots__/ExpandCollapse.spec.jsx.snap
+++ b/packages/ExpandCollapse/__tests__/__snapshots__/ExpandCollapse.spec.jsx.snap
@@ -1626,6 +1626,7 @@ exports[`ExpandCollapse renders a closed panel 1`] = `
           >
             <div
               data-testid="panel-1"
+              id="panel-1"
             >
               <div>
                 <PanelWrapper__HeaderButtonClickable
@@ -2824,6 +2825,7 @@ exports[`ExpandCollapse renders an open panel 1`] = `
           >
             <div
               data-testid="panel-1"
+              id="panel-1"
             >
               <div>
                 <PanelWrapper__HeaderButtonClickable


### PR DESCRIPTION
## Related issues

See #1415

## Description

Renders the existing `id` Panel prop as an HTML `id` attribute.

## Checklist before submitting pull request

- [x] New code is unit tested
- [x] Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [x] For code changes, run `npm run prepr` locally
- [x] make sure visual and accessibility tests pass
