### PR TITLE
Fix parseArgs to enable E2E

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -537,6 +537,15 @@
       "contributions": [
         "tds"
       ]
+    },
+    {
+      "login": "iamstuartwilson",
+      "name": "Stuart Wilson",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/3594817?v=4",
+      "profile": "https://iamstuartwilson.com",
+      "contributions": [
+        "tds"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The following group are the active maintainers of this project, and have merge r
   <tr>
     <td align="center"><a href="https://github.com/hamedmam"><img src="https://avatars1.githubusercontent.com/u/24867760?v=4" width="100px;" alt="Hamed Mamdoohi"/><br /><sub><b>Hamed Mamdoohi</b></sub></a><br /><a href="#tds-hamedmam" title=""></a></td>
     <td align="center"><a href="https://github.com/DougTelus"><img src="https://avatars3.githubusercontent.com/u/32107656?v=4" width="100px;" alt="DougL"/><br /><sub><b>DougL</b></sub></a><br /><a href="#tds-DougTelus" title=""></a></td>
+    <td align="center"><a href="https://iamstuartwilson.com"><img src="https://avatars1.githubusercontent.com/u/3594817?v=4" width="100px;" alt="Stuart Wilson"/><br /><sub><b>Stuart Wilson</b></sub></a><br /><a href="#tds-iamstuartwilson" title=""></a></td>
   </tr>
 </table>
 

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -11,7 +11,9 @@ module.exports = {
     path.resolve('docs/components'),
     path.resolve('shared'),
     path.resolve('e2e/visual'),
+    path.resolve('scripts'),
   ],
+  testPathIgnorePatterns: [path.resolve('scripts/scaffolding')],
   moduleNameMapper: {
     '^.+\\.css$': path.resolve('config/jest/__mocks__/styleMock.js'),
   },

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -17,7 +17,7 @@ const { spawnSync } = require('child_process')
 const getPackageNames = require('./utils/getPackageNames')
 const arrayToGlob = require('./utils/arrayToGlob')
 
-getPackageNames(packageNames => {
+getPackageNames(process.argv, packageNames => {
   const scopeGlob = arrayToGlob(packageNames)
 
   spawnSync(

--- a/scripts/e2e.js
+++ b/scripts/e2e.js
@@ -16,11 +16,12 @@ Usage: npm run test:e2e [component name...] [options] [lerna options]
 */
 
 const { spawnSync } = require('child_process')
-const { tdsOptions } = require('./utils/parseArgs')
+const parseArgs = require('./utils/parseArgs')
 
 const getPackageNames = require('./utils/getPackageNames')
 
-getPackageNames(packageNames => {
+getPackageNames(process.argv, packageNames => {
+  const { tdsOptions } = parseArgs(process.argv)
   if (!tdsOptions.name) {
     // eslint-disable-next-line no-console
     console.error(

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -17,28 +17,34 @@ const { spawnSync } = require('child_process')
 const readline = require('readline')
 
 const getPackageNames = require('./utils/getPackageNames')
-const { lernaOptions } = require('./utils/parseArgs')
+const parseArgs = require('./utils/parseArgs')
 
 const read = readline.createInterface({
   input: process.stdin,
   output: process.stdout,
 })
 
-getPackageNames(packageNames => {
-  console.warn(`You are about to publish the following packages: ${packageNames}`)
+getPackageNames(
+  process.argv,
+  packageNames => {
+    const { lernaOptions } = parseArgs(process.argv)
 
-  read.question(
-    'Are these the exact packages you wish to publish? (You will be prompted after this for versioning confirmation) (y/n) ',
-    answer => {
-      if (answer === 'Y' || answer === 'y') {
-        spawnSync('npx', ['lerna', 'publish', '--conventional-commits'].concat(lernaOptions), {
-          stdio: 'inherit',
-        })
-      } else {
-        console.log('Publishing aborted!')
+    console.warn(`You are about to publish the following packages: ${packageNames}`)
+
+    read.question(
+      'Are these the exact packages you wish to publish? (You will be prompted after this for versioning confirmation) (y/n) ',
+      answer => {
+        if (answer === 'Y' || answer === 'y') {
+          spawnSync('npx', ['lerna', 'publish', '--conventional-commits'].concat(lernaOptions), {
+            stdio: 'inherit',
+          })
+        } else {
+          console.log('Publishing aborted!')
+        }
+
+        read.close()
       }
-
-      read.close()
-    }
-  )
-}, true)
+    )
+  },
+  true
+)

--- a/scripts/utils/__tests__/getPackageNames.spec.js
+++ b/scripts/utils/__tests__/getPackageNames.spec.js
@@ -1,0 +1,39 @@
+import { exec } from 'child_process'
+
+import getPackageNames from '../getPackageNames'
+
+describe('getPackageNames', () => {
+  it('handles a single package name', done => {
+    const argv = ['bin/node', 'tds-core/scripts/e2e.js', '@tds/core-button', '-n', 'branch-name']
+    getPackageNames(argv, packageNames => {
+      expect(packageNames).toEqual(['@tds/core-button'])
+      done()
+    })
+  })
+
+  it('handles multiple package names', done => {
+    const argv = [
+      'bin/node',
+      'tds-core/scripts/e2e.js',
+      '@tds/core-button',
+      '@tds/core-button-link',
+      '-n',
+      'branch-name',
+    ]
+    getPackageNames(argv, packageNames => {
+      expect(packageNames).toEqual(['@tds/core-button', '@tds/core-button-link'])
+      done()
+    })
+  })
+
+  it('handles --all', done => {
+    const argv = ['bin/node', 'tds-core/scripts/e2e.js', '--all', '-n', 'branch-name']
+    getPackageNames(argv, packageNames => {
+      exec('npx lerna ls', (error, stdout) => {
+        const lernaLS = stdout.trim().split('\n')
+        expect(packageNames).toEqual(lernaLS)
+        done()
+      })
+    })
+  })
+})

--- a/scripts/utils/__tests__/parseArgs.spec.js
+++ b/scripts/utils/__tests__/parseArgs.spec.js
@@ -1,0 +1,39 @@
+import parseArgs from '../parseArgs'
+
+describe('parseArgs', () => {
+  it('test:e2e', () => {
+    const argv = ['bin/node', 'tds-core/scripts/e2e.js', '@tds/core-button', '-n', 'branch-name']
+    const { userPackageNames, tdsOptions, lernaOptions } = parseArgs(argv)
+
+    expect(tdsOptions).toEqual({
+      n: 'branch-name',
+      name: 'branch-name',
+    })
+    expect(userPackageNames).toEqual(['@tds/core-button'])
+    expect(lernaOptions).toEqual([])
+  })
+
+  it('publish.js', () => {
+    const argv = ['bin/node', 'node scripts/publish.js', '--conventional-commits', '--yes']
+
+    const { userPackageNames, tdsOptions, lernaOptions } = parseArgs(argv)
+
+    expect(tdsOptions).toEqual({})
+    expect(userPackageNames).toEqual([])
+    expect(lernaOptions).toEqual(['--conventional-commits', '--yes'])
+  })
+
+  it('e2e test --all', () => {
+    const argv = ['bin/node', 'tds-core/scripts/e2e.js', '--all', '-n', 'branch-name']
+    const { userPackageNames, tdsOptions, lernaOptions } = parseArgs(argv)
+
+    expect(tdsOptions).toEqual({
+      n: 'branch-name',
+      name: 'branch-name',
+      a: true,
+      all: true,
+    })
+    expect(userPackageNames).toEqual([])
+    expect(lernaOptions).toEqual([])
+  })
+})

--- a/scripts/utils/getPackageNames.js
+++ b/scripts/utils/getPackageNames.js
@@ -1,10 +1,12 @@
 /* eslint-disable no-console */
 
 const { exec } = require('child_process')
-const { userPackageNames, tdsOptions, lernaOptions } = require('./parseArgs')
+const parseArgs = require('./parseArgs')
 const { ignoredPackages } = require('../../config/constants')
 
-const getPackageNames = (callback, forceUpdatedPackages) => {
+const getPackageNames = (args, callback, forceUpdatedPackages) => {
+  const { userPackageNames, tdsOptions, lernaOptions } = parseArgs(args)
+
   if (!forceUpdatedPackages && userPackageNames.length > 0) {
     callback(userPackageNames)
     return

--- a/scripts/utils/parseArgs.js
+++ b/scripts/utils/parseArgs.js
@@ -1,35 +1,42 @@
-const parseArgs = require('minimist')
+const { execSync } = require('child_process')
+const minimist = require('minimist')
 
-const TDS_OPTIONS = [
-  '-a',
-  '--all',
-  '-u',
-  '--update-screenshots',
-  '-n',
-  '--name',
-  '-e',
-  '--environment',
-]
+const TDS_OPTIONS = { a: 'all', u: 'update-screenshots', n: 'name', e: 'environment' }
 
-let originalArgs = process.argv.slice(2).filter(arg => arg !== '')
+const parseArgs = args => {
+  let originalArgs = args.slice(2).filter(arg => arg !== '')
 
-if (originalArgs.length === 1) {
-  originalArgs = originalArgs[0].split(' ')
+  if (originalArgs.length === 1) {
+    originalArgs = originalArgs[0].split(' ')
+  }
+
+  const lernaOptions = []
+  const lernaLS = execSync('npx lerna ls')
+    .toString('utf8')
+    .trim()
+    .split('\n')
+
+  const parsedArgs = minimist(originalArgs, {
+    alias: TDS_OPTIONS,
+    unknown: arg => {
+      if (lernaLS.includes(arg)) {
+        return true
+      }
+      lernaOptions.push(arg)
+      return false
+    },
+  })
+
+  const userPackageNames = parsedArgs._
+
+  const tdsOptions = { ...parsedArgs }
+  delete tdsOptions._
+
+  return {
+    userPackageNames,
+    tdsOptions,
+    lernaOptions,
+  }
 }
 
-const parsedArgs = parseArgs(originalArgs, {
-  alias: { a: 'all', u: 'update-screenshots', n: 'name', e: 'environment' },
-})
-
-const lernaOptions = originalArgs
-  .filter(arg => !parsedArgs._.includes(arg))
-  .filter(arg => !TDS_OPTIONS.includes(arg))
-
-const tdsOptions = Object.assign({}, parsedArgs)
-delete tdsOptions._
-
-module.exports = {
-  userPackageNames: parsedArgs._,
-  tdsOptions,
-  lernaOptions,
-}
+module.exports = parseArgs

--- a/scripts/utils/parseArgs.js
+++ b/scripts/utils/parseArgs.js
@@ -11,7 +11,7 @@ const parseArgs = args => {
   }
 
   const lernaOptions = []
-  const lernaLS = execSync('npx lerna ls')
+  const lernaLS = execSync('npx lerna ls', { stdio: ['pipe'] })
     .toString('utf8')
     .trim()
     .split('\n')


### PR DESCRIPTION
## Description

- Update `parseArgs` logic
- Add unit tests for `parseArgs.js` and `generatePackageNames.js`

## Checklist before submitting pull request

- [x] New code is unit tested
- Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [ ] For code changes, run `npm run prepr` locally
  - make sure visual and accessibility tests pass
