### PR TITLE
chore(core-button-link): dedupe prop-types

### DIFF
--- a/packages/ButtonLink/package.json
+++ b/packages/ButtonLink/package.json
@@ -31,7 +31,7 @@
     "@tds/shared-styles": "^1.5.2",
     "@tds/util-helpers": "^1.4.2",
     "@tds/util-prop-types": "^1.3.2",
-    "prop-types": "^15.7.0"
+    "prop-types": "^15.5.10"
   },
   "devDependencies": {
     "@tds/core-a11y-content": "^2.1.5"


### PR DESCRIPTION
Match `prop-types` dependency of `core-button-link` with all other TDS components.