### PR TITLE
Adding analytics to video

### DIFF
--- a/packages/Video/Video.jsx
+++ b/packages/Video/Video.jsx
@@ -168,6 +168,17 @@ class Video extends React.Component {
     // **** End Interaction Events ****
 
     // ******** End Video Event Handlers *********
+
+    // **** Video Analytics ****
+    if (
+      (this.props.analyticsTracking !== undefined && this.props.videoTitle === undefined) ||
+      (this.props.analyticsTracking === undefined && this.props.videoTitle !== undefined)
+    ) {
+      warn(
+        'Video',
+        'Both the `analyticsTracking` and `videoTitle` props must be defined in order to return a proper analytics object.'
+      )
+    }
   }
 
   componentWillUnmount() {
@@ -446,9 +457,6 @@ class Video extends React.Component {
       if (this.props.analyticsTracking !== undefined && this.props.videoTitle) {
         const intervalId = setInterval(this.calculatePercentageWatched, 300)
         this.setState({ intervalId })
-      }
-      if (this.props.analyticsTracking !== undefined && this.props.videoTitle === undefined) {
-        warn('Video', 'AnalyticsTracking requires videoTitle to return analytics data object')
       }
     } else {
       this.refVideoPlayer.current.pause()
@@ -897,8 +905,10 @@ Video.propTypes = {
    */
   videoBorder: PropTypes.bool,
   /**
-   * A function that gets called when a customer interacts with Video.
+   * A callback function that fires when a customer interacts with Video.
    * When using `analyticsTracking`, `videoTitle` must also be defined.
+   *
+   * When invoked, your callback function returns an object containing three keys (see below).
    * @since 1.3.0
    *
    * @param {Object} analyticsObject Contains video data based on customer interactions
@@ -908,7 +918,7 @@ Video.propTypes = {
    */
   analyticsTracking: PropTypes.func,
   /**
-   * The title of the video being rendered. This is used for analytics purposes
+   * The title of the video being rendered. This is used for analytics purposes in conjunction with `analyticsTracking`.
    * @since 1.3.0
    */
   videoTitle: PropTypes.string,

--- a/packages/Video/Video.jsx
+++ b/packages/Video/Video.jsx
@@ -102,7 +102,7 @@ class Video extends React.Component {
       captionsMenuOpen: false,
       isMobile: false,
       videoPlayerWidth: 0,
-      percentPlayed: 'watched 0%',
+      elapsedTime: 'watched 0%',
     }
   }
 
@@ -326,30 +326,30 @@ class Video extends React.Component {
   calculatePercentageWatched = () => {
     let percentValue = (this.state.videoCurrentTime / this.state.videoLength) * 100
     percentValue = Math.round(percentValue)
-    const previousValue = this.state.percentPlayed
+    const previousValue = this.state.elapsedTime
     this.percentageBucket(percentValue)
-    if (previousValue !== this.state.percentPlayed) {
+    if (previousValue !== this.state.elapsedTime) {
       const analyticsObject = {}
-      analyticsObject.action = this.state.percentPlayed
+      analyticsObject.action = this.state.elapsedTime
       this.props.analyticsTracking(analyticsObject)
     }
   }
 
   percentageBucket = percentValue => {
     if (percentValue < 25) {
-      return this.setState({ percentPlayed: 'watched 0%' })
+      return this.setState({ elapsedTime: 'watched 0%' })
     }
     if (percentValue < 50) {
-      return this.setState({ percentPlayed: 'watched 25%' })
+      return this.setState({ elapsedTime: 'watched 25%' })
     }
     if (percentValue < 75) {
-      return this.setState({ percentPlayed: 'watched 50%' })
+      return this.setState({ elapsedTime: 'watched 50%' })
     }
     if (percentValue < 100) {
-      return this.setState({ percentPlayed: 'watched 75%' })
+      return this.setState({ elapsedTime: 'watched 75%' })
     }
     if (percentValue === 100) {
-      return this.setState({ percentPlayed: 'watched 100%' })
+      return this.setState({ elapsedTime: 'watched 100%' })
     }
     return false
   }

--- a/packages/Video/Video.md
+++ b/packages/Video/Video.md
@@ -21,6 +21,10 @@ Each video will appear in the "Quality" dialogue from top to bottom sorted by `q
 
 Tracks are supplied to the player through the `tracks` prop, which accepts an array of objects. Each object in the array represents a track file. Typically, these will be different languages or separate files for closed captions, subtitles, or descriptions. If no tracks are provided, the captions button will not be visible in the player.
 
+#### Analytics tracking
+
+You can pass in a callback function to Video, in order to track analytics. The parameter this function takes will give you access to the analytics object which will be updated every time an action is fired (this inclues "play", "pause", percentage watched as an interval of "25%")
+
 ```jsx
 <Video
   sources={[
@@ -55,6 +59,9 @@ Tracks are supplied to the player through the `tracks` prop, which accepts an ar
     },
   ]}
   copy="en"
+  analyticsTracking={object => {
+    console.log('object', object)
+  }}
 />
 ```
 

--- a/packages/Video/Video.md
+++ b/packages/Video/Video.md
@@ -23,7 +23,7 @@ Tracks are supplied to the player through the `tracks` prop, which accepts an ar
 
 #### Analytics tracking
 
-You can pass in a callback function to Video, in order to track analytics. The parameter this function takes will give you access to the analytics object which will be updated every time an action is fired (this inclues "play", "pause", percentage watched as an interval of "25%")
+You can pass in a callback function to Video, in order to track analytics. The parameter this function takes will give you access to the analytics object which will be updated every time an action is fired (this inclues "play", "pause", percentage watched as an interval of "25%"). See analyticsTracking in the props table for more details.
 
 ```jsx
 <Video
@@ -62,6 +62,7 @@ You can pass in a callback function to Video, in order to track analytics. The p
   analyticsTracking={object => {
     console.log('object', object)
   }}
+  videoTitle="Demo video"
 />
 ```
 

--- a/packages/Video/Video.md
+++ b/packages/Video/Video.md
@@ -23,7 +23,7 @@ Tracks are supplied to the player through the `tracks` prop, which accepts an ar
 
 #### Analytics tracking
 
-You can pass in a callback function to Video, in order to track analytics. The parameter this function takes will give you access to the analytics object which will be updated every time an action is fired (this inclues "play", "pause", percentage watched as an interval of "25%"). See analyticsTracking in the props table for more details.
+Pass in a callback function to Video, in order to track analytics. The callback function returns an analytics object which will be updated every time an action is fired (this includes "play", "pause", and percentage watched as an interval of "25%"). See `analyticsTracking` in the props table for more details.
 
 ```jsx
 <Video

--- a/packages/Video/__tests__/Video.spec.jsx
+++ b/packages/Video/__tests__/Video.spec.jsx
@@ -25,6 +25,7 @@ describe('Video', () => {
         copy="en"
         // eslint-disable-next-line
         analyticsTracking={object => {console.log('object', object)}}
+        videoTitle="Demo video"
         {...props}
       />
     )

--- a/packages/Video/__tests__/Video.spec.jsx
+++ b/packages/Video/__tests__/Video.spec.jsx
@@ -23,6 +23,8 @@ describe('Video', () => {
           },
         ]}
         copy="en"
+        // eslint-disable-next-line
+        analyticsTracking={object => {console.log('object', object)}}
         {...props}
       />
     )

--- a/packages/Video/__tests__/__snapshots__/Video.spec.jsx.snap
+++ b/packages/Video/__tests__/__snapshots__/Video.spec.jsx.snap
@@ -591,6 +591,7 @@ input[type=range].c24::-ms-tooltip {
     ]
   }
   videoBorder={false}
+  videoTitle="Demo video"
 >
   <Video__VideoPlayerContainer
     analyticsTracking={[Function]}
@@ -634,6 +635,7 @@ input[type=range].c24::-ms-tooltip {
       ]
     }
     videoBorder={false}
+    videoTitle="Demo video"
   >
     <StyledComponent
       analyticsTracking={[Function]}
@@ -1577,6 +1579,7 @@ input[type=range].c24::-ms-tooltip {
         ]
       }
       videoBorder={false}
+      videoTitle="Demo video"
     >
       <div
         aria-label="Video selected. Press Q to listen to controls."

--- a/packages/Video/__tests__/__snapshots__/Video.spec.jsx.snap
+++ b/packages/Video/__tests__/__snapshots__/Video.spec.jsx.snap
@@ -556,6 +556,7 @@ input[type=range].c24::-ms-tooltip {
 }
 
 <Video
+  analyticsTracking={[Function]}
   beginMuted={false}
   copy="en"
   defaultDesktopQuality={1}
@@ -592,6 +593,7 @@ input[type=range].c24::-ms-tooltip {
   videoBorder={false}
 >
   <Video__VideoPlayerContainer
+    analyticsTracking={[Function]}
     aria-label="Video selected. Press Q to listen to controls."
     beginMuted={false}
     copy="en"
@@ -634,6 +636,7 @@ input[type=range].c24::-ms-tooltip {
     videoBorder={false}
   >
     <StyledComponent
+      analyticsTracking={[Function]}
       aria-label="Video selected. Press Q to listen to controls."
       beginMuted={false}
       copy="en"


### PR DESCRIPTION
## Related issues

https://telusdigital.atlassian.net/browse/RL-3649 
#1441 

## Description

Adds tracking for analytics - You can pass in a callback function to Video, in order to track analytics. The parameter this function takes will give you access to the analytics object which will be updated every time an action is fired (this inclues "play", "pause", percentage watched as an interval of "25%")

## Checklist before submitting pull request

- [x] New code is unit tested
- [x] Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [ ] For code changes, run `npm run prepr` locally
  - make sure visual and accessibility tests pass
