### PR TITLE
Add htmlElement prop-type for ChevronLink, ButtonLink and Button

### DIFF
--- a/packages/A11yContent/A11yContent.md
+++ b/packages/A11yContent/A11yContent.md
@@ -3,3 +3,13 @@ Allows content to be hidden from sight, but still visible to screen readers. Thi
 ```jsx
     <Text>The screen reader says:</Text><A11yContent>This is accessible content</A11yContent>
 ```
+
+If `A11yContent` has to go between two separate text components, considering wrapping the whole text in a `<span>` to persist leading and trailing space.
+
+```jsx
+<ButtonLink href="#">
+  <span>
+    Shop <A11yContent>iPhone</A11yContent> Now
+  </span>
+</ButtonLink>
+```

--- a/packages/Button/Button.jsx
+++ b/packages/Button/Button.jsx
@@ -2,7 +2,7 @@ import React, { forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-import { componentWithName, or } from '@tds/util-prop-types'
+import { componentWithName, or, htmlElement } from '@tds/util-prop-types'
 import { borders, forms } from '@tds/shared-styles'
 import { medium, boldFont } from '@tds/shared-typography'
 import { colorPrimary, colorSecondary, colorWhite, colorText } from '@tds/core-colours'
@@ -106,9 +106,10 @@ Button.propTypes = {
    */
   variant: PropTypes.oneOf(['primary', 'secondary', 'inverted']),
   /**
-   * The label. It can include the `A11yContent` component or strings.
+   * The label. It can include the `A11yContent` component, strings, or strings wrapped in a `<span>`.
    */
-  children: or([PropTypes.string, componentWithName('A11yContent')]).isRequired,
+  children: or([PropTypes.string, componentWithName('A11yContent'), htmlElement('span')])
+    .isRequired,
 }
 Button.defaultProps = {
   type: 'button',

--- a/packages/ButtonLink/ButtonLink.jsx
+++ b/packages/ButtonLink/ButtonLink.jsx
@@ -2,7 +2,7 @@ import React, { forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-import { componentWithName, or } from '@tds/util-prop-types'
+import { componentWithName, or, htmlElement } from '@tds/util-prop-types'
 import { StyledButton } from '@tds/core-button'
 import { links } from '@tds/shared-styles'
 import {
@@ -88,9 +88,10 @@ ButtonLink.propTypes = {
    */
   href: PropTypes.string,
   /**
-   * The label. It can include the `A11yContent` component or strings.
+   * The label. It can include the `A11yContent` component, strings, or strings wrapped in a `<span>`.
    */
-  children: or([PropTypes.string, componentWithName('A11yContent')]).isRequired,
+  children: or([PropTypes.string, componentWithName('A11yContent'), htmlElement('span')])
+    .isRequired,
 }
 ButtonLink.defaultProps = {
   variant: 'primary',

--- a/packages/ButtonLink/ButtonLink.md
+++ b/packages/ButtonLink/ButtonLink.md
@@ -34,6 +34,8 @@ Use the `A11yContent` component to create invisible text that is read out loud b
 
 ```jsx
 <Button href="#">
-  Shop <A11yContent>iPhone</A11yContent>
+  <span>
+    Shop <A11yContent>iPhone</A11yContent>Now
+  </span>
 </Button>
 ```

--- a/packages/ChevronLink/ChevronLink.jsx
+++ b/packages/ChevronLink/ChevronLink.jsx
@@ -2,7 +2,7 @@ import React, { forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-import { componentWithName, or } from '@tds/util-prop-types'
+import { componentWithName, or, htmlElement } from '@tds/util-prop-types'
 
 import Box from '@tds/core-box'
 import DecorativeIcon from '@tds/core-decorative-icon'
@@ -107,9 +107,10 @@ ChevronLink.propTypes = {
    */
   href: PropTypes.string,
   /**
-   * The label. It can include the `A11yContent` component or strings.
+   * The label. It can include the `A11yContent` component, strings, or strings wrapped in a `<span>`.
    */
-  children: or([PropTypes.string, componentWithName('A11yContent')]).isRequired,
+  children: or([PropTypes.string, componentWithName('A11yContent'), htmlElement('span')])
+    .isRequired,
 }
 ChevronLink.defaultProps = {
   variant: 'primary',

--- a/packages/prop-types/PropTypes.md
+++ b/packages/prop-types/PropTypes.md
@@ -57,6 +57,56 @@ PlanChooser.propTypes = {
 }
 ```
 
+### `htmlElement(element: String)`
+
+Limits the prop to only allow a specific HTML tag.
+
+```jsx noeditor static
+import { htmlElement } from '@tds/util-prop-types'
+
+const Link = () => {
+  return <a>{children}</a>
+}
+
+const App = () => (
+  <CustomLink>
+    <span>Purchase Pixel 3</span>
+  </CustomLink>
+)
+
+CustomLink.propTypes = {
+  children: htmlElement('span').isRequired,
+}
+```
+
+`htmlElement` is especially useful in keeping space between elements. A common use case for this is when you need to insert an `A11yContent` component in between 2 surrounding components. See the example below.
+
+```jsx noeditor static
+import { htmlElement } from '@tds/util-prop-types'
+
+const Link = () => {
+  return <Link>{children}</Link>
+}
+
+const App = () => (
+  <Link>
+    <span>Purchase <A11yContent>Pixel 3</A11yContent> Now</span>
+  </Link>
+)
+
+Link.propTypes = {
+  children: or([PropTypes.string, componentWithName('A11yContent'), htmlElement('span')).isRequired,
+}
+```
+
+```jsx
+<ButtonLink>
+  <span>
+    Purchase <A11yContent>Pixel 3</A11yContent> Now
+  </span>
+</ButtonLink>
+```
+
 ### `or(validators: Array)`
 
 Limits the prop to only allow PropTypes that match those specified.

--- a/packages/prop-types/__tests__/htmlElement.spec.jsx
+++ b/packages/prop-types/__tests__/htmlElement.spec.jsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { htmlElement } from '../prop-types'
+
+describe('htmlElement', () => {
+  it('returns a function', () => {
+    expect(typeof htmlElement('span')).toEqual('function')
+  })
+
+  it('throws an error when not given a string', () => {
+    expect(() => htmlElement()).toThrowError()
+    expect(() => htmlElement({})).toThrowError()
+    expect(() => htmlElement([])).toThrowError()
+    expect(() => htmlElement(123)).toThrowError()
+    expect(() => htmlElement(true)).toThrowError()
+    expect(() => htmlElement(false)).toThrowError()
+    expect(() => htmlElement(undefined)).toThrowError()
+    expect(() => htmlElement(null)).toThrowError()
+  })
+
+  it('returns undefined when given nothing', () => {
+    const validator = htmlElement('span')
+    const status = validator({ children: undefined }, 'children', 'span')
+    expect(status).toBeUndefined()
+  })
+
+  it('throws error when given nothing but is required', () => {
+    const validator = htmlElement('span').isRequired
+    const status = validator({ children: undefined }, 'children', 'span')
+    expect(status).toBeInstanceOf(Error)
+  })
+
+  describe('single child', () => {
+    it('passes validation with a valid html tag', () => {
+      const validator = htmlElement('span')
+      const status = validator({ children: <span>Some content</span> }, 'children', 'span')
+      expect(status).toBeUndefined()
+    })
+  })
+
+  describe('multiple children', () => {
+    it('passes validation with a valid html tag', () => {
+      const validator = htmlElement('span')
+      const status = validator(
+        {
+          children: [<span key={1}>One</span>, <span key={2}>Two</span>],
+        },
+        'children',
+        'span'
+      )
+      expect(status).toBeUndefined()
+    })
+  })
+})

--- a/packages/prop-types/htmlElement.js
+++ b/packages/prop-types/htmlElement.js
@@ -1,0 +1,62 @@
+const htmlElement = element => {
+  if (typeof element !== 'string') {
+    throw new Error('element must be a string')
+  }
+
+  const checkProp = (props, propName, componentName) => {
+    if (typeof props[propName] === 'undefined' || props[propName] === null) {
+      return undefined
+    }
+
+    if (Array.isArray(props[propName])) {
+      // Iterates through every child and try to find the first element that does not match the passed name
+      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+      return props[propName]
+        .map((_, index) => checkProp(props[propName], index, componentName))
+        .find(Boolean)
+    }
+
+    if (typeof props[propName] === 'object' && typeof props[propName].type === 'string') {
+      if (props[propName].type === element) {
+        return undefined
+      }
+
+      return new Error(
+        `${componentName}: Expected \`${propName}\` to be an HTML \`<${element}>\` tag`
+      )
+    }
+    return undefined
+  }
+
+  const checkRequired = (props, propName, componentName) => {
+    if (props[propName] === undefined) {
+      return new Error(
+        `The prop \`${propName}\` is marked as required in \`${componentName}\`, but its value is ${
+          props[propName]
+        }.`
+      )
+    }
+    return undefined
+  }
+
+  const createValidate = isRequired => {
+    if (isRequired) {
+      return (props, propName, componentName) => {
+        const checkForError = checkProp(props, propName, componentName)
+        if (checkForError) {
+          return checkForError
+        }
+
+        return checkRequired(props, propName, componentName)
+      }
+    }
+
+    return checkProp
+  }
+
+  const validate = createValidate()
+  validate.isRequired = createValidate(true)
+  return validate
+}
+
+export default htmlElement

--- a/packages/prop-types/prop-types.js
+++ b/packages/prop-types/prop-types.js
@@ -1,5 +1,6 @@
 import componentWithName from './componentWithName'
 import responsiveProps from './responsiveProps'
 import or from './or'
+import htmlElement from './htmlElement'
 
-export { componentWithName, responsiveProps, or }
+export { componentWithName, responsiveProps, or, htmlElement }


### PR DESCRIPTION
## Description
Added htmlElement prop type to check for html tags as valid children for ChevronLink, ButtonLink and Button components.

## Checklist before submitting pull request
- [x] New code is unit tested
- Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [ ] For code changes, run `npm run prepr` locally
  - make sure visual and accessibility tests pass
