### PR TITLE
fix: renaming hasIcon to hasLinkIcon to fix a react warning

### DIFF
--- a/packages/Breadcrumbs/__tests__/__snapshots__/Breadcrumbs.spec.jsx.snap
+++ b/packages/Breadcrumbs/__tests__/__snapshots__/Breadcrumbs.spec.jsx.snap
@@ -253,7 +253,7 @@ exports[`Breadcrumbs with children renders 1`] = `
                                 "inheritColor": true,
                               }
                             }
-                            hasIcon={false}
+                            hasInlineIcon={false}
                             href="/"
                             to={null}
                           >
@@ -310,7 +310,7 @@ exports[`Breadcrumbs with children renders 1`] = `
                                 }
                               }
                               forwardedRef={null}
-                              hasIcon={false}
+                              hasInlineIcon={false}
                               href="/"
                               to={null}
                             >
@@ -439,7 +439,7 @@ exports[`Breadcrumbs with children renders 1`] = `
                                 "inheritColor": true,
                               }
                             }
-                            hasIcon={false}
+                            hasInlineIcon={false}
                             href="/mobility"
                             to={null}
                           >
@@ -496,7 +496,7 @@ exports[`Breadcrumbs with children renders 1`] = `
                                 }
                               }
                               forwardedRef={null}
-                              hasIcon={false}
+                              hasInlineIcon={false}
                               href="/mobility"
                               to={null}
                             >
@@ -980,7 +980,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent 1`] = `
                                 "inheritColor": true,
                               }
                             }
-                            hasIcon={false}
+                            hasInlineIcon={false}
                             href={null}
                             to="/"
                           >
@@ -1037,7 +1037,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent 1`] = `
                                 }
                               }
                               forwardedRef={null}
-                              hasIcon={false}
+                              hasInlineIcon={false}
                               href={null}
                               to="/"
                             >
@@ -1048,7 +1048,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent 1`] = `
                                     "inheritColor": true,
                                   }
                                 }
-                                hasIcon={false}
+                                hasInlineIcon={false}
                                 href={null}
                                 to="/"
                               >
@@ -1178,7 +1178,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent 1`] = `
                                 "inheritColor": true,
                               }
                             }
-                            hasIcon={false}
+                            hasInlineIcon={false}
                             href={null}
                             to="/mobility"
                           >
@@ -1235,7 +1235,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent 1`] = `
                                 }
                               }
                               forwardedRef={null}
-                              hasIcon={false}
+                              hasInlineIcon={false}
                               href={null}
                               to="/mobility"
                             >
@@ -1246,7 +1246,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent 1`] = `
                                     "inheritColor": true,
                                   }
                                 }
-                                hasIcon={false}
+                                hasInlineIcon={false}
                                 href={null}
                                 to="/mobility"
                               >
@@ -1727,7 +1727,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent in Item
                                 "inheritColor": true,
                               }
                             }
-                            hasIcon={false}
+                            hasInlineIcon={false}
                             href="/"
                             to={null}
                           >
@@ -1784,7 +1784,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent in Item
                                 }
                               }
                               forwardedRef={null}
-                              hasIcon={false}
+                              hasInlineIcon={false}
                               href="/"
                               to={null}
                             >
@@ -1915,7 +1915,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent in Item
                                 "inheritColor": true,
                               }
                             }
-                            hasIcon={false}
+                            hasInlineIcon={false}
                             href={null}
                             to="/mobility"
                           >
@@ -1972,7 +1972,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent in Item
                                 }
                               }
                               forwardedRef={null}
-                              hasIcon={false}
+                              hasInlineIcon={false}
                               href={null}
                               to="/mobility"
                             >
@@ -1983,7 +1983,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent in Item
                                     "inheritColor": true,
                                   }
                                 }
-                                hasIcon={false}
+                                hasInlineIcon={false}
                                 href={null}
                                 to="/mobility"
                               >
@@ -2478,7 +2478,7 @@ exports[`Breadcrumbs with routes renders 1`] = `
                                 "inheritColor": true,
                               }
                             }
-                            hasIcon={false}
+                            hasInlineIcon={false}
                             href="/"
                             to={null}
                           >
@@ -2535,7 +2535,7 @@ exports[`Breadcrumbs with routes renders 1`] = `
                                 }
                               }
                               forwardedRef={null}
-                              hasIcon={false}
+                              hasInlineIcon={false}
                               href="/"
                               to={null}
                             >
@@ -2664,7 +2664,7 @@ exports[`Breadcrumbs with routes renders 1`] = `
                                 "inheritColor": true,
                               }
                             }
-                            hasIcon={false}
+                            hasInlineIcon={false}
                             href="/mobility"
                             to={null}
                           >
@@ -2721,7 +2721,7 @@ exports[`Breadcrumbs with routes renders 1`] = `
                                 }
                               }
                               forwardedRef={null}
-                              hasIcon={false}
+                              hasInlineIcon={false}
                               href="/mobility"
                               to={null}
                             >

--- a/packages/Breadcrumbs/__tests__/__snapshots__/Breadcrumbs.spec.jsx.snap
+++ b/packages/Breadcrumbs/__tests__/__snapshots__/Breadcrumbs.spec.jsx.snap
@@ -253,7 +253,7 @@ exports[`Breadcrumbs with children renders 1`] = `
                                 "inheritColor": true,
                               }
                             }
-                            hasInlineIcon={false}
+                            hasLinkIcon={false}
                             href="/"
                             to={null}
                           >
@@ -310,7 +310,7 @@ exports[`Breadcrumbs with children renders 1`] = `
                                 }
                               }
                               forwardedRef={null}
-                              hasInlineIcon={false}
+                              hasLinkIcon={false}
                               href="/"
                               to={null}
                             >
@@ -439,7 +439,7 @@ exports[`Breadcrumbs with children renders 1`] = `
                                 "inheritColor": true,
                               }
                             }
-                            hasInlineIcon={false}
+                            hasLinkIcon={false}
                             href="/mobility"
                             to={null}
                           >
@@ -496,7 +496,7 @@ exports[`Breadcrumbs with children renders 1`] = `
                                 }
                               }
                               forwardedRef={null}
-                              hasInlineIcon={false}
+                              hasLinkIcon={false}
                               href="/mobility"
                               to={null}
                             >
@@ -980,7 +980,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent 1`] = `
                                 "inheritColor": true,
                               }
                             }
-                            hasInlineIcon={false}
+                            hasLinkIcon={false}
                             href={null}
                             to="/"
                           >
@@ -1037,7 +1037,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent 1`] = `
                                 }
                               }
                               forwardedRef={null}
-                              hasInlineIcon={false}
+                              hasLinkIcon={false}
                               href={null}
                               to="/"
                             >
@@ -1048,7 +1048,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent 1`] = `
                                     "inheritColor": true,
                                   }
                                 }
-                                hasInlineIcon={false}
+                                hasLinkIcon={false}
                                 href={null}
                                 to="/"
                               >
@@ -1178,7 +1178,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent 1`] = `
                                 "inheritColor": true,
                               }
                             }
-                            hasInlineIcon={false}
+                            hasLinkIcon={false}
                             href={null}
                             to="/mobility"
                           >
@@ -1235,7 +1235,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent 1`] = `
                                 }
                               }
                               forwardedRef={null}
-                              hasInlineIcon={false}
+                              hasLinkIcon={false}
                               href={null}
                               to="/mobility"
                             >
@@ -1246,7 +1246,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent 1`] = `
                                     "inheritColor": true,
                                   }
                                 }
-                                hasInlineIcon={false}
+                                hasLinkIcon={false}
                                 href={null}
                                 to="/mobility"
                               >
@@ -1727,7 +1727,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent in Item
                                 "inheritColor": true,
                               }
                             }
-                            hasInlineIcon={false}
+                            hasLinkIcon={false}
                             href="/"
                             to={null}
                           >
@@ -1784,7 +1784,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent in Item
                                 }
                               }
                               forwardedRef={null}
-                              hasInlineIcon={false}
+                              hasLinkIcon={false}
                               href="/"
                               to={null}
                             >
@@ -1915,7 +1915,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent in Item
                                 "inheritColor": true,
                               }
                             }
-                            hasInlineIcon={false}
+                            hasLinkIcon={false}
                             href={null}
                             to="/mobility"
                           >
@@ -1972,7 +1972,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent in Item
                                 }
                               }
                               forwardedRef={null}
-                              hasInlineIcon={false}
+                              hasLinkIcon={false}
                               href={null}
                               to="/mobility"
                             >
@@ -1983,7 +1983,7 @@ exports[`Breadcrumbs with children renders with ReactRouterLinkComponent in Item
                                     "inheritColor": true,
                                   }
                                 }
-                                hasInlineIcon={false}
+                                hasLinkIcon={false}
                                 href={null}
                                 to="/mobility"
                               >
@@ -2478,7 +2478,7 @@ exports[`Breadcrumbs with routes renders 1`] = `
                                 "inheritColor": true,
                               }
                             }
-                            hasInlineIcon={false}
+                            hasLinkIcon={false}
                             href="/"
                             to={null}
                           >
@@ -2535,7 +2535,7 @@ exports[`Breadcrumbs with routes renders 1`] = `
                                 }
                               }
                               forwardedRef={null}
-                              hasInlineIcon={false}
+                              hasLinkIcon={false}
                               href="/"
                               to={null}
                             >
@@ -2664,7 +2664,7 @@ exports[`Breadcrumbs with routes renders 1`] = `
                                 "inheritColor": true,
                               }
                             }
-                            hasInlineIcon={false}
+                            hasLinkIcon={false}
                             href="/mobility"
                             to={null}
                           >
@@ -2721,7 +2721,7 @@ exports[`Breadcrumbs with routes renders 1`] = `
                                 }
                               }
                               forwardedRef={null}
-                              hasInlineIcon={false}
+                              hasLinkIcon={false}
                               href="/mobility"
                               to={null}
                             >

--- a/packages/InteractiveIcon/__tests__/__snapshots__/InteractiveIcon.spec.jsx.snap
+++ b/packages/InteractiveIcon/__tests__/__snapshots__/InteractiveIcon.spec.jsx.snap
@@ -434,7 +434,7 @@ exports[`InteractiveIcon renders Dependent icon with Link 1`] = `
           "inheritColor": undefined,
         }
       }
-      hasIcon={true}
+      hasInlineIcon={true}
       href="#"
       to={null}
     >
@@ -491,7 +491,7 @@ exports[`InteractiveIcon renders Dependent icon with Link 1`] = `
           }
         }
         forwardedRef={null}
-        hasIcon={true}
+        hasInlineIcon={true}
         href="#"
         to={null}
       >

--- a/packages/InteractiveIcon/__tests__/__snapshots__/InteractiveIcon.spec.jsx.snap
+++ b/packages/InteractiveIcon/__tests__/__snapshots__/InteractiveIcon.spec.jsx.snap
@@ -434,7 +434,7 @@ exports[`InteractiveIcon renders Dependent icon with Link 1`] = `
           "inheritColor": undefined,
         }
       }
-      hasInlineIcon={true}
+      hasLinkIcon={true}
       href="#"
       to={null}
     >
@@ -491,7 +491,7 @@ exports[`InteractiveIcon renders Dependent icon with Link 1`] = `
           }
         }
         forwardedRef={null}
-        hasInlineIcon={true}
+        hasLinkIcon={true}
         href="#"
         to={null}
       >

--- a/packages/Link/Link.jsx
+++ b/packages/Link/Link.jsx
@@ -73,8 +73,8 @@ const StyledLink = styled.a(
     return {}
   },
   states,
-  ({ hasInlineIcon }) => {
-    if (hasInlineIcon) {
+  ({ hasLinkIcon }) => {
+    if (hasLinkIcon) {
       return {
         display: 'inline-block',
         '& > svg': {
@@ -121,7 +121,7 @@ const Link = (
       invert={invert}
       context={context}
       ref={forwardedRef}
-      hasInlineIcon={!!Icon}
+      hasLinkIcon={!!Icon}
     >
       {renderChildren()}
     </StyledLink>

--- a/packages/Link/Link.jsx
+++ b/packages/Link/Link.jsx
@@ -73,8 +73,8 @@ const StyledLink = styled.a(
     return {}
   },
   states,
-  ({ hasIcon }) => {
-    if (hasIcon) {
+  ({ hasInlineIcon }) => {
+    if (hasInlineIcon) {
       return {
         display: 'inline-block',
         '& > svg': {
@@ -121,7 +121,7 @@ const Link = (
       invert={invert}
       context={context}
       ref={forwardedRef}
-      hasIcon={!!Icon}
+      hasInlineIcon={!!Icon}
     >
       {renderChildren()}
     </StyledLink>

--- a/packages/Link/__tests__/__snapshots__/Link.spec.jsx.snap
+++ b/packages/Link/__tests__/__snapshots__/Link.spec.jsx.snap
@@ -126,7 +126,7 @@ Object {
             "inheritColor": undefined,
           }
         }
-        hasInlineIcon={false}
+        hasLinkIcon={false}
         href={null}
         to={null}
       >
@@ -183,7 +183,7 @@ Object {
             }
           }
           forwardedRef={null}
-          hasInlineIcon={false}
+          hasLinkIcon={false}
           href={null}
           to={null}
         >
@@ -342,7 +342,7 @@ Object {
             "inheritColor": undefined,
           }
         }
-        hasInlineIcon={false}
+        hasLinkIcon={false}
         href={null}
         invert={true}
         to={null}
@@ -400,7 +400,7 @@ Object {
             }
           }
           forwardedRef={null}
-          hasInlineIcon={false}
+          hasLinkIcon={false}
           href={null}
           invert={true}
           to={null}

--- a/packages/Link/__tests__/__snapshots__/Link.spec.jsx.snap
+++ b/packages/Link/__tests__/__snapshots__/Link.spec.jsx.snap
@@ -126,7 +126,7 @@ Object {
             "inheritColor": undefined,
           }
         }
-        hasIcon={false}
+        hasInlineIcon={false}
         href={null}
         to={null}
       >
@@ -183,7 +183,7 @@ Object {
             }
           }
           forwardedRef={null}
-          hasIcon={false}
+          hasInlineIcon={false}
           href={null}
           to={null}
         >
@@ -342,7 +342,7 @@ Object {
             "inheritColor": undefined,
           }
         }
-        hasIcon={false}
+        hasInlineIcon={false}
         href={null}
         invert={true}
         to={null}
@@ -400,7 +400,7 @@ Object {
             }
           }
           forwardedRef={null}
-          hasIcon={false}
+          hasInlineIcon={false}
           href={null}
           invert={true}
           to={null}


### PR DESCRIPTION
Related issues

See https://github.com/telus/tds-core/issues/1464

## EDIT - working on a solution

The hasIcon complain seems to be about react detecting it being passed as an HTML attribute but we're only passing a prop into styled-components. Investigating on how to actually fix this...

## Description

This PR is to rename the custom react prop from `hasIcon` to `hasLinkIcon` to avoid the react warning:

```
Warning: React does not recognize the `hasIcon` prop on a DOM element.
If you intentionally want it to appear in the DOM as a custom attribute, 
spell it as lowercase `hasicon` instead. If you accidentally passed it from 
a parent component, remove it from the DOM element.     
in a (created by LinkAnchor)     in LinkAnchor (created by Context.Consumer)     
in Link (created by Context.Consumer)
```

Due to the fact `<Link />` component is a dependency of other components, it affects
- Link
- Breadcrumbs
- Terms and Conditions as well

## Checklist before submitting pull request

- [x] New code is unit tested
- [x] Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [x] For code changes, run `npm run prepr` locally
- [x] make sure visual and accessibility tests pass
