### PR TITLE
feat(packages): box - make below prop public

### DIFF
--- a/docs/components/overrides/StyleGuide/GlobalStyleGuide.js
+++ b/docs/components/overrides/StyleGuide/GlobalStyleGuide.js
@@ -64,6 +64,12 @@ const GlobalStyleGuide = createGlobalStyle({
     marginRight: '-50vw'
   },
 
+  '.docs_full-width-footer': {
+    'a': {
+      textDecoration: 'none !important',
+    }
+  },
+
   '.docs_full-height-box': {
     height: '100%'
   },

--- a/packages/Box/Box.jsx
+++ b/packages/Box/Box.jsx
@@ -152,12 +152,7 @@ Box.propTypes = {
    */
   inset: responsiveProps(PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7, 8])),
   /**
-   * @ignore
-   *
-   * We are keeping this hidden for now as we are not sold on the necessity. We use it internally still to apply
-   * spacing to Markdown components, but would like to use between instead if the library allows it.
-   *
-   * Sets a `margin-bottom`.
+   * Indent content from the container's bottom edge by applying margin-bottom.
    *
    * One of: `0,1,2,3,4,5,6,7,8` as a [**responsive prop**](#responsiveProps)
    */

--- a/packages/Box/Box.md
+++ b/packages/Box/Box.md
@@ -170,3 +170,84 @@ This prop implements `justify-content: space-between;` in CSS. With `space-betwe
 ```
 
 Use `space-between` to space elements inside of `Box` evenly, dynamically fitted to the `Box`'s size.
+
+### Below
+
+```jsx { "props": { "className": "docs_full-width-playground docs_full-width-footer" } }
+<div>
+  <Box below={8}>
+    <FlexGrid>
+      <FlexGrid.Row>
+        <FlexGrid.Col>
+          <Box inset={4} between={3}>
+            <Heading level="h2">Mobile internet plans</Heading>
+            <Paragraph>
+              Take your business out of the office. All across Canada businesses use TELUS mobile
+              phones to go where their customers are and stay connected.
+            </Paragraph>
+            <ChevronLink href="#">Learn more</ChevronLink>
+          </Box>
+        </FlexGrid.Col>
+      </FlexGrid.Row>
+    </FlexGrid>
+  </Box>
+  <div style={{ 'background-color': 'rgb(42, 44, 46)' }}>
+    <FlexGrid>
+      <FlexGrid.Row>
+        <FlexGrid.Col xs={3}>
+          <Box between={3} vertical={3}>
+            <Link href="#" invert>
+              About us
+            </Link>
+            <Link href="#" invert>
+              Accessibility
+            </Link>
+            <Link href="#" invert>
+              Careers
+            </Link>
+          </Box>
+        </FlexGrid.Col>
+        <FlexGrid.Col xs={3}>
+          <Box between={3} vertical={3}>
+            <Link href="#" invert>
+              Support
+            </Link>
+            <Link href="#" invert>
+              Contact Us
+            </Link>
+            <Link href="#" invert>
+              Neighbourhood
+            </Link>
+          </Box>
+        </FlexGrid.Col>
+        <FlexGrid.Col xs={3}>
+          <Box between={3} vertical={3}>
+            <Link href="#" invert>
+              TELUS & CRTC Internet Code
+            </Link>
+            <Link href="#" invert>
+              Internet Code, SimplifiedAccessibility
+            </Link>
+            <Link href="#" invert>
+              TELUS & CRTC Wireless Code
+            </Link>
+          </Box>
+        </FlexGrid.Col>
+        <FlexGrid.Col xs={3}>
+          <Box between={3} vertical={3}>
+            <Link href="#" invert>
+              TELUS Digital
+            </Link>
+            <Link href="#" invert>
+              TELUS International
+            </Link>
+            <Link href="#" invert>
+              TELUS Partner Solutions
+            </Link>
+          </Box>
+        </FlexGrid.Col>
+      </FlexGrid.Row>
+    </FlexGrid>
+  </div>
+</div>
+```

--- a/packages/Box/Box.md
+++ b/packages/Box/Box.md
@@ -95,7 +95,7 @@ This will do the following:
 - Spacing between the buttons will increase as the viewport size increases to make things look less dense on larger screens
 - Below the `lg` viewport (≤992px), `inline` will be set to `false`, making the buttons stack. On `lg` and larger, the buttons will appear side to side
 
-To learn more about responsive props see [`@tds/util-prop-types`](#/Utilities?id=section-proptypes). The following `Box` props support responsive props: `vertical`, `horizontal`, `inset`, `between`, and `inline`.
+To learn more about responsive props see [`@tds/util-prop-types`](#/Utilities?id=section-proptypes). The following `Box` props support responsive props: `vertical`, `horizontal`, `inset`, `between`, `inline`, and `below`.
 
 ### Using space-between
 


### PR DESCRIPTION
- Adjusts prop types to make below public
- tests for below were already existing, confirmed that these worked
- added mention of below to readme to let users know that it is a valid responsive prop for box