### PR TITLE
feat(core-interactive-icon): add size property to limited icons

### DIFF
--- a/packages/InteractiveIcon/Limited.jsx
+++ b/packages/InteractiveIcon/Limited.jsx
@@ -19,7 +19,11 @@ export const StyledLimitedInteractiveIconSVG = styled(StyledInteractiveIconSVG)(
       }(${animationDirection === 'up' || animationDirection === 'left' ? '-' : ''}4px)`,
     },
   }),
-  animations.reduceMotion
+  animations.reduceMotion,
+  ({ size }) => ({
+    width: size === 20 ? '20px' : '24px',
+    height: size === 20 ? '20px' : '24px',
+  })
 )
 
 const getTheme = variant => {

--- a/packages/InteractiveIcon/Limited.jsx
+++ b/packages/InteractiveIcon/Limited.jsx
@@ -1,11 +1,19 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled, { ThemeProvider } from 'styled-components'
+import { responsiveProps } from '@tds/util-prop-types'
+import { handleResponsiveStyles } from '@tds/util-helpers'
 
 import { colorShark, colorTelusPurple, colorWhite, colorAccessibleGreen } from '@tds/core-colours'
 
 import animations from './shared/animations'
 import StyledInteractiveIconSVG from './shared/StyledInteractiveIconSVG'
+
+const iconSize = props =>
+  handleResponsiveStyles({ size: props.size }, ({ size }) => ({
+    width: size === 20 ? '20px' : '24px',
+    height: size === 20 ? '20px' : '24px',
+  }))
 
 export const StyledLimitedInteractiveIconSVG = styled(StyledInteractiveIconSVG)(
   ({ animationDirection }) => ({
@@ -20,10 +28,7 @@ export const StyledLimitedInteractiveIconSVG = styled(StyledInteractiveIconSVG)(
     },
   }),
   animations.reduceMotion,
-  ({ size }) => ({
-    width: size === 20 ? '20px' : '24px',
-    height: size === 20 ? '20px' : '24px',
-  })
+  iconSize
 )
 
 const getTheme = variant => {
@@ -68,9 +73,9 @@ Limited.propTypes = {
    */
   variant: PropTypes.oneOf(['default', 'basic', 'alternative', 'inverted']),
   /**
-   * The icon size in pixels.
+   * The icon size in pixels as a [**responsive prop**](#responsiveProps).
    */
-  size: PropTypes.oneOf([20, 24]),
+  size: responsiveProps(PropTypes.oneOf([20, 24])),
   /**
    * @ignore
    */

--- a/packages/InteractiveIcon/Limited.jsx
+++ b/packages/InteractiveIcon/Limited.jsx
@@ -54,8 +54,10 @@ const getTheme = variant => {
 /**
  * @version ./package.json
  */
-const Limited = ({ variant, children }) => (
-  <ThemeProvider theme={getTheme(variant)}>{children}</ThemeProvider>
+const Limited = ({ variant, children, size }) => (
+  <ThemeProvider theme={getTheme(variant)} size={size}>
+    {children}
+  </ThemeProvider>
 )
 
 Limited.displayName = 'Limited'
@@ -66,6 +68,10 @@ Limited.propTypes = {
    */
   variant: PropTypes.oneOf(['default', 'basic', 'alternative', 'inverted']),
   /**
+   * The icon size in pixels.
+   */
+  size: PropTypes.oneOf([20, 24]),
+  /**
    * @ignore
    */
   children: PropTypes.node.isRequired,
@@ -73,6 +79,7 @@ Limited.propTypes = {
 
 Limited.defaultProps = {
   variant: 'default',
+  size: 24,
 }
 
 export default Limited

--- a/packages/InteractiveIcon/Limited.md
+++ b/packages/InteractiveIcon/Limited.md
@@ -67,14 +67,3 @@ These interactive icons have a default colour of Accessible Green with the follo
   </div>
 </Box>
 ```
-
-```jsx
-<Box between={2}>
-  <Heading level="h4">Icon size 20</Heading>
-  <ChevronRight variant="basic" size={20} />
-  <CaretDown variant="basic" size={20} />
-  <Heading level="h4">Icon size 24</Heading>
-  <ChevronRight variant="basic" />
-  <CaretDown variant="basic" />
-</Box>
-```

--- a/packages/InteractiveIcon/Limited.md
+++ b/packages/InteractiveIcon/Limited.md
@@ -7,7 +7,7 @@ They're not to be used or displayed on their own.
 - Must depend on other interactive components
 - Must appear with a visible label as part of the wrapper component
 - May include additional accessible but hidden text
-- Icon size is specified through the `size` property. The default is 24px height and width.
+- Icon size is specified through the `size` property. The default is 24px height and width
 - Additional colour variants (green) are available to limited icons
 
 ```jsx noeditor

--- a/packages/InteractiveIcon/Limited.md
+++ b/packages/InteractiveIcon/Limited.md
@@ -7,7 +7,7 @@ They're not to be used or displayed on their own.
 - Must depend on other interactive components
 - Must appear with a visible label as part of the wrapper component
 - May include additional accessible but hidden text
-- Icon size is specified through the `size` property. The default is 24px height and width
+- Icon size is specified through the `size` property as a responsive prop. The default is 24px height and width
 - Additional colour variants (green) are available to limited icons
 
 ```jsx noeditor

--- a/packages/InteractiveIcon/Limited.md
+++ b/packages/InteractiveIcon/Limited.md
@@ -7,7 +7,7 @@ They're not to be used or displayed on their own.
 - Must depend on other interactive components
 - Must appear with a visible label as part of the wrapper component
 - May include additional accessible but hidden text
-- Icon size is 24px height and width
+- Icon size is specified through the `size` property. The default is 24px height and width.
 - Additional colour variants (green) are available to limited icons
 
 ```jsx noeditor
@@ -65,5 +65,16 @@ These interactive icons have a default colour of Accessible Green with the follo
   <div style={{ backgroundColor: '#4B286D', display: 'inline-block' }}>
     <ChevronRight variant="inverted" />
   </div>
+</Box>
+```
+
+```jsx
+<Box between={2}>
+  <Heading level="h4">Icon size 20</Heading>
+  <ChevronRight variant="basic" size={20} />
+  <CaretDown variant="basic" size={20} />
+  <Heading level="h4">Icon size 24</Heading>
+  <ChevronRight variant="basic" />
+  <CaretDown variant="basic" />
 </Box>
 ```

--- a/packages/InteractiveIcon/svgs/Limited/CaretDown.jsx
+++ b/packages/InteractiveIcon/svgs/Limited/CaretDown.jsx
@@ -4,12 +4,7 @@ import LimitedInteractiveIcon, { StyledLimitedInteractiveIconSVG } from '../../L
 
 const CaretDown = forwardRef((props, ref) => (
   <LimitedInteractiveIcon {...props} ref={ref}>
-    <StyledLimitedInteractiveIconSVG
-      animationDirection="down"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-    >
+    <StyledLimitedInteractiveIconSVG animationDirection="down" viewBox="0 0 24 24" {...props}>
       <path d="M17.7940812,9.18323023 C17.4424627,8.8825106 17.0896181,9.04504427 16.8868854,9.24527574 L11.9968161,13.740553 L7.11722187,9.24527573 C6.93839231,9.08145209 6.49053328,8.81996721 6.16524043,9.18323023 C5.83994757,9.54649326 6.06520964,9.91610528 6.24327169,10.0799289 L11.6348225,15.8766027 C11.8136521,16.0411324 12.1060729,16.0411324 12.2849025,15.8766027 C12.2849025,15.8758965 17.7940809,10.079929 17.7940809,10.079929 C17.9792355,9.93504267 18.1456996,9.48394985 17.7940812,9.18323023 Z" />
     </StyledLimitedInteractiveIconSVG>
   </LimitedInteractiveIcon>

--- a/packages/InteractiveIcon/svgs/Limited/CaretUp.jsx
+++ b/packages/InteractiveIcon/svgs/Limited/CaretUp.jsx
@@ -4,12 +4,7 @@ import LimitedInteractiveIcon, { StyledLimitedInteractiveIconSVG } from '../../L
 
 const CaretUp = forwardRef((props, ref) => (
   <LimitedInteractiveIcon {...props} animationDirection="up" ref={ref}>
-    <StyledLimitedInteractiveIconSVG
-      animationDirection="up"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-    >
+    <StyledLimitedInteractiveIconSVG animationDirection="up" viewBox="0 0 24 24" {...props}>
       <path d="M17.7940812,14.8167698 C17.4424627,15.1174894 17.0896181,14.9549557 16.8868854,14.7547243 L11.9968161,10.259447 L7.11722187,14.7547243 C6.93839231,14.9185479 6.49053328,15.1800328 6.16524043,14.8167698 C5.83994757,14.4535067 6.06520964,14.0838947 6.24327169,13.9200711 L11.6348225,8.12339734 C11.8136521,7.95886755 12.1060729,7.95886755 12.2849025,8.12339734 C12.2849025,8.12410347 17.7940809,13.920071 17.7940809,13.920071 C17.9792355,14.0649573 18.1456996,14.5160501 17.7940812,14.8167698 Z" />
     </StyledLimitedInteractiveIconSVG>
   </LimitedInteractiveIcon>

--- a/packages/InteractiveIcon/svgs/Limited/ChevronLeft.jsx
+++ b/packages/InteractiveIcon/svgs/Limited/ChevronLeft.jsx
@@ -4,12 +4,7 @@ import LimitedInteractiveIcon, { StyledLimitedInteractiveIconSVG } from '../../L
 
 const ChevronLeft = forwardRef((props, ref) => (
   <LimitedInteractiveIcon {...props} ref={ref}>
-    <StyledLimitedInteractiveIconSVG
-      animationDirection="left"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-    >
+    <StyledLimitedInteractiveIconSVG animationDirection="left" viewBox="0 0 24 24" {...props}>
       <path d="M14.8167698,17.7940812 C14.5160501,18.1456996 14.0649573,17.9792355 13.920071,17.7940809 C13.920071,17.7940809 8.12410347,12.2849025 8.12339734,12.2849025 C7.95886755,12.1060729 7.95886755,11.8136521 8.12339734,11.6348225 L13.9200711,6.24327169 C14.0838947,6.06520964 14.4535067,5.83994757 14.8167698,6.16524043 C15.1800328,6.49053328 14.9185479,6.93839231 14.7547243,7.11722187 L10.259447,11.9968161 L14.7547243,16.8868854 C14.9549557,17.0896181 15.1174894,17.4424627 14.8167698,17.7940812 Z" />
     </StyledLimitedInteractiveIconSVG>
   </LimitedInteractiveIcon>

--- a/packages/InteractiveIcon/svgs/Limited/ChevronRight.jsx
+++ b/packages/InteractiveIcon/svgs/Limited/ChevronRight.jsx
@@ -4,12 +4,7 @@ import LimitedInteractiveIcon, { StyledLimitedInteractiveIconSVG } from '../../L
 
 const ChevronRight = forwardRef((props, ref) => (
   <LimitedInteractiveIcon {...props} ref={ref}>
-    <StyledLimitedInteractiveIconSVG
-      animationDirection="right"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-    >
+    <StyledLimitedInteractiveIconSVG animationDirection="right" viewBox="0 0 24 24" {...props}>
       <path d="M9.18323023,17.7940812 C8.8825106,17.4424627 9.04504427,17.0896181 9.24527574,16.8868854 L13.740553,11.9968161 L9.24527573,7.11722187 C9.08145209,6.93839231 8.81996721,6.49053328 9.18323023,6.16524043 C9.54649326,5.83994757 9.91610528,6.06520964 10.0799289,6.24327169 L15.8766027,11.6348225 C16.0411324,11.8136521 16.0411324,12.1060729 15.8766027,12.2849025 C15.8758965,12.2849025 10.079929,17.7940809 10.079929,17.7940809 C9.93504267,17.9792355 9.48394985,18.1456996 9.18323023,17.7940812 Z" />
     </StyledLimitedInteractiveIconSVG>
   </LimitedInteractiveIcon>


### PR DESCRIPTION
**Description**
Adds sizing property to Limited Interactive Icons (CaretUp, CaretDown, ChevronRight, ChevronLeft). 
This change is needed for the future community component Expand Collapse Mini ([design here](https://telus.invisionapp.com/d/main#/console/13362811/428786216/preview)).
There are two size options indicating height and width in pixels, 20 and 24. 

**ScreenShots**
<img width="1077" alt="Screen Shot 2020-08-17 at 1 28 49 PM" src="https://user-images.githubusercontent.com/55095713/90425387-a4e98780-e08d-11ea-8745-fcb36a3be1db.png">

