### PR TITLE
feat(core-flex-grid): added outsideGutter property to remove left and right padding

### DIFF
--- a/packages/FlexGrid/FlexGrid.jsx
+++ b/packages/FlexGrid/FlexGrid.jsx
@@ -88,6 +88,7 @@ FlexGrid.propTypes = {
    */
   gutter: PropTypes.bool,
   /**
+   * @since 3.1.0
    * Whether or not to include gutter at the ends to the left and right of the FlexGrid
    */
   outsideGutter: PropTypes.bool,

--- a/packages/FlexGrid/FlexGrid.jsx
+++ b/packages/FlexGrid/FlexGrid.jsx
@@ -15,35 +15,34 @@ import GutterContext from './gutterContext'
 const rem = breakpoint => {
   return `${breakpoints[breakpoint] / 16}rem`
 }
-
-const StyledGrid = styled(({ reverseLevel, limitWidth, ...rest }) => <Grid {...rest} />)(
-  ({ reverseLevel, limitWidth }) => ({
-    display: 'flex',
-    flexWrap: 'wrap',
-    margin: '0 auto',
-    width: '100%',
-    'div&': { padding: 0 },
-    ...media.until('sm').css({
-      flexDirection: reverseLevel[0] ? 'column-reverse' : 'column',
-    }),
-    ...media.from('sm').css({
-      ...(limitWidth && { maxWidth: rem('sm') }),
-      flexDirection: reverseLevel[1] ? 'column-reverse' : 'column',
-    }),
-    ...media.from('md').css({
-      ...(limitWidth && { maxWidth: rem('md') }),
-      flexDirection: reverseLevel[2] ? 'column-reverse' : 'column',
-    }),
-    ...media.from('lg').css({
-      ...(limitWidth && { maxWidth: rem('lg') }),
-      flexDirection: reverseLevel[3] ? 'column-reverse' : 'column',
-    }),
-    ...media.from('xl').css({
-      ...(limitWidth && { maxWidth: rem('xl') }),
-      flexDirection: reverseLevel[4] ? 'column-reverse' : 'column',
-    }),
-  })
-)
+const StyledGrid = styled(({ reverseLevel, limitWidth, outsideGutter, ...rest }) => (
+  <Grid {...rest} />
+))(({ reverseLevel, limitWidth, outsideGutter }) => ({
+  display: 'flex',
+  flexWrap: 'wrap',
+  margin: `0 ${!outsideGutter ? '-1rem' : 'auto'}`,
+  width: !outsideGutter ? undefined : '100%',
+  'div&': { padding: 0 },
+  ...media.until('sm').css({
+    flexDirection: reverseLevel[0] ? 'column-reverse' : 'column',
+  }),
+  ...media.from('sm').css({
+    ...(limitWidth && { maxWidth: rem('sm') }),
+    flexDirection: reverseLevel[1] ? 'column-reverse' : 'column',
+  }),
+  ...media.from('md').css({
+    ...(limitWidth && { maxWidth: rem('md') }),
+    flexDirection: reverseLevel[2] ? 'column-reverse' : 'column',
+  }),
+  ...media.from('lg').css({
+    ...(limitWidth && { maxWidth: rem('lg') }),
+    flexDirection: reverseLevel[3] ? 'column-reverse' : 'column',
+  }),
+  ...media.from('xl').css({
+    ...(limitWidth && { maxWidth: rem('xl') }),
+    flexDirection: reverseLevel[4] ? 'column-reverse' : 'column',
+  }),
+}))
 
 /**
  * A mobile-first flexbox grid.
@@ -54,6 +53,7 @@ const StyledGrid = styled(({ reverseLevel, limitWidth, ...rest }) => <Grid {...r
 const FlexGrid = ({
   limitWidth,
   gutter,
+  outsideGutter,
   xsReverse,
   smReverse,
   mdReverse,
@@ -65,7 +65,13 @@ const FlexGrid = ({
   const reverseLevel = calculateLevel(xsReverse, smReverse, mdReverse, lgReverse, xlReverse)
   return (
     <GutterContext.Provider value={gutter}>
-      <StyledGrid {...safeRest(rest)} fluid reverseLevel={reverseLevel} limitWidth={limitWidth}>
+      <StyledGrid
+        {...safeRest(rest)}
+        fluid
+        outsideGutter={outsideGutter}
+        reverseLevel={reverseLevel}
+        limitWidth={limitWidth}
+      >
         {children}
       </StyledGrid>
     </GutterContext.Provider>
@@ -81,6 +87,10 @@ FlexGrid.propTypes = {
    * Whether or not to include gutters in between columns.
    */
   gutter: PropTypes.bool,
+  /**
+   * Whether or not to include gutter at the ends to the left and right of the FlexGrid
+   */
+  outsideGutter: PropTypes.bool,
   /**
    * Choose if the item order should be reversed from the 'xs' breakpoint. When you pass in false, the order will be normal from the xs breakpoint. By default, it inherits the behaviour set by the preceding prop.
    */
@@ -110,6 +120,7 @@ FlexGrid.propTypes = {
 FlexGrid.defaultProps = {
   limitWidth: true,
   gutter: true,
+  outsideGutter: true,
   xsReverse: undefined,
   smReverse: undefined,
   mdReverse: undefined,

--- a/packages/FlexGrid/FlexGrid.md
+++ b/packages/FlexGrid/FlexGrid.md
@@ -74,6 +74,53 @@ horizontal padding from all child columns.
 </FlexGrid>
 ```
 
+### Removing the outside gutter
+
+In some layouts, there might be the need to remove the gutter from the left and right of the row.
+For example, if the layout requires a `FlexGrid` to be nested under another `FlexGrid` Column,
+the child `FlexGrid`'s columns will not line up with the parent `FlexGrid`'s columns due to the additional gutter between the child columns.
+
+It is possible to avoid this situation while keeping the gutters between the columns,
+to do so, pass `outsideGutter={false}` to the child `FlexGrid`.
+This will remove the gutter on the left and the right of the `FlexGrid`.
+
+`outsideGutter` should not be false if parent `FlexGrid` has `gutter={false}`.
+
+```jsx { "props": { "className": "docs_full-width-playground docs_flex-grid-coloring" } }
+<FlexGrid>
+  <FlexGrid.Row>
+    <FlexGrid.Col>
+      <Box vertical={2}>
+        <Text>Parent Column</Text>
+      </Box>
+    </FlexGrid.Col>
+    <FlexGrid.Col>
+      <Box vertical={2}>
+        <Text>Parent Column</Text>
+      </Box>
+    </FlexGrid.Col>
+  </FlexGrid.Row>
+  <FlexGrid.Row>
+    <FlexGrid.Col>
+      <FlexGrid outsideGutter={false}>
+        <FlexGrid.Row>
+          <FlexGrid.Col>
+            <Box vertical={2}>
+              <Text>Child Column</Text>
+            </Box>
+          </FlexGrid.Col>
+          <FlexGrid.Col>
+            <Box vertical={2}>
+              <Text>Child Column</Text>
+            </Box>
+          </FlexGrid.Col>
+        </FlexGrid.Row>
+      </FlexGrid>
+    </FlexGrid.Col>
+  </FlexGrid.Row>
+</FlexGrid>
+```
+
 ### Working with full-width and limited-width content
 
 Pages should have multiple instances of `FlexGrid` to separate full-width content and regular limited-width content.

--- a/packages/FlexGrid/__tests__/FlexGrid.spec.jsx
+++ b/packages/FlexGrid/__tests__/FlexGrid.spec.jsx
@@ -110,7 +110,7 @@ describe('FlexGrid', () => {
 
   it('renders with no outside gutter', () => {
     const { flexGrid } = doMount({
-      outsideGutter: true,
+      outsideGutter: false,
     })
     expect(flexGrid).toMatchSnapshot()
   })

--- a/packages/FlexGrid/__tests__/FlexGrid.spec.jsx
+++ b/packages/FlexGrid/__tests__/FlexGrid.spec.jsx
@@ -107,4 +107,11 @@ describe('FlexGrid', () => {
 
     expect(flexGrid).toMatchSnapshot()
   })
+
+  it('renders with no outside gutter', () => {
+    const { flexGrid } = doMount({
+      outsideGutter: true,
+    })
+    expect(flexGrid).toMatchSnapshot()
+  })
 })

--- a/packages/FlexGrid/__tests__/__snapshots__/FlexGrid.spec.jsx.snap
+++ b/packages/FlexGrid/__tests__/__snapshots__/FlexGrid.spec.jsx.snap
@@ -1137,8 +1137,7 @@ div.c1 {
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  margin: 0 auto;
-  width: 100%;
+  margin: 0 -1rem;
 }
 
 div.c0 {

--- a/packages/FlexGrid/__tests__/__snapshots__/FlexGrid.spec.jsx.snap
+++ b/packages/FlexGrid/__tests__/__snapshots__/FlexGrid.spec.jsx.snap
@@ -1108,6 +1108,474 @@ div.c0 {
 </div>
 `;
 
+exports[`FlexGrid renders with no outside gutter 1`] = `
+div.c2 {
+  padding-left: 1rem;
+  padding-right: 1rem;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c1 {
+  width: 100%;
+}
+
+div.c1 {
+  margin: 0 auto;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  margin: 0 auto;
+  width: 100%;
+}
+
+div.c0 {
+  padding: 0;
+}
+
+@media (max-width:575px) {
+  .c2 {
+    display: block;
+    text-align: inherit;
+  }
+}
+
+@media (min-width:576px) {
+  .c2 {
+    display: block;
+    text-align: inherit;
+  }
+}
+
+@media (min-width:768px) {
+  .c2 {
+    display: block;
+    text-align: inherit;
+  }
+}
+
+@media (min-width:992px) {
+  .c2 {
+    display: block;
+    text-align: inherit;
+  }
+}
+
+@media (min-width:1200px) {
+  .c2 {
+    display: block;
+    text-align: inherit;
+  }
+}
+
+@media (max-width:575px) {
+  div.c1 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media (min-width:576px) {
+  div.c1 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media (min-width:768px) {
+  div.c1 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media (min-width:992px) {
+  div.c1 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media (min-width:1200px) {
+  div.c1 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+@media (max-width:575px) {
+  .c0 {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media (min-width:576px) {
+  .c0 {
+    max-width: 36rem;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media (min-width:768px) {
+  .c0 {
+    max-width: 48rem;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media (min-width:992px) {
+  .c0 {
+    max-width: 62rem;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media (min-width:1200px) {
+  .c0 {
+    max-width: 75rem;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+<Grid
+  className="c0"
+  fluid={true}
+>
+  <div
+    className="c0 container-fluid"
+  >
+    <Row
+      id="row-1"
+    >
+      <Styled(Component)
+        id="row-1"
+        reverseLevel={
+          Array [
+            false,
+            false,
+            false,
+            false,
+            false,
+          ]
+        }
+      >
+        <StyledComponent
+          forwardedComponent={
+            Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "attrs": Array [],
+              "componentStyle": ComponentStyle {
+                "componentId": "sc-bwzfXH",
+                "isStatic": false,
+                "lastClassName": "c1",
+                "rules": Array [
+                  [Function],
+                ],
+              },
+              "displayName": "Styled(Component)",
+              "foldedComponentIds": Array [],
+              "render": [Function],
+              "styledComponentId": "sc-bwzfXH",
+              "target": [Function],
+              "toString": [Function],
+              "warnTooManyClasses": [Function],
+              "withComponent": [Function],
+            }
+          }
+          forwardedRef={null}
+          id="row-1"
+          reverseLevel={
+            Array [
+              false,
+              false,
+              false,
+              false,
+              false,
+            ]
+          }
+        >
+          <Component
+            className="c1"
+            id="row-1"
+            reverseLevel={
+              Array [
+                false,
+                false,
+                false,
+                false,
+                false,
+              ]
+            }
+          >
+            <Row
+              className="c1"
+              id="row-1"
+            >
+              <div
+                className="c1 row"
+                id="row-1"
+              >
+                <Col
+                  id="col-1"
+                >
+                  <Styled(Component)
+                    gutter={true}
+                    hiddenLevel={
+                      Array [
+                        false,
+                        false,
+                        false,
+                        false,
+                        false,
+                      ]
+                    }
+                    horizontalAlignLevel={
+                      Array [
+                        "inherit",
+                        "inherit",
+                        "inherit",
+                        "inherit",
+                        "inherit",
+                      ]
+                    }
+                    id="col-1"
+                    xs={true}
+                  >
+                    <StyledComponent
+                      forwardedComponent={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "attrs": Array [],
+                          "componentStyle": ComponentStyle {
+                            "componentId": "sc-bdVaJa",
+                            "isStatic": false,
+                            "lastClassName": "c2",
+                            "rules": Array [
+                              [Function],
+                            ],
+                          },
+                          "displayName": "Styled(Component)",
+                          "foldedComponentIds": Array [],
+                          "render": [Function],
+                          "styledComponentId": "sc-bdVaJa",
+                          "target": [Function],
+                          "toString": [Function],
+                          "warnTooManyClasses": [Function],
+                          "withComponent": [Function],
+                        }
+                      }
+                      forwardedRef={null}
+                      gutter={true}
+                      hiddenLevel={
+                        Array [
+                          false,
+                          false,
+                          false,
+                          false,
+                          false,
+                        ]
+                      }
+                      horizontalAlignLevel={
+                        Array [
+                          "inherit",
+                          "inherit",
+                          "inherit",
+                          "inherit",
+                          "inherit",
+                        ]
+                      }
+                      id="col-1"
+                      xs={true}
+                    >
+                      <Component
+                        className="c2"
+                        gutter={true}
+                        hiddenLevel={
+                          Array [
+                            false,
+                            false,
+                            false,
+                            false,
+                            false,
+                          ]
+                        }
+                        horizontalAlignLevel={
+                          Array [
+                            "inherit",
+                            "inherit",
+                            "inherit",
+                            "inherit",
+                            "inherit",
+                          ]
+                        }
+                        id="col-1"
+                        xs={true}
+                      >
+                        <Col
+                          className="c2"
+                          id="col-1"
+                          xs={true}
+                        >
+                          <div
+                            className="col-xs c2"
+                            id="col-1"
+                          >
+                            1st column content
+                          </div>
+                        </Col>
+                      </Component>
+                    </StyledComponent>
+                  </Styled(Component)>
+                </Col>
+                <Col
+                  id="col-2"
+                >
+                  <Styled(Component)
+                    gutter={true}
+                    hiddenLevel={
+                      Array [
+                        false,
+                        false,
+                        false,
+                        false,
+                        false,
+                      ]
+                    }
+                    horizontalAlignLevel={
+                      Array [
+                        "inherit",
+                        "inherit",
+                        "inherit",
+                        "inherit",
+                        "inherit",
+                      ]
+                    }
+                    id="col-2"
+                    xs={true}
+                  >
+                    <StyledComponent
+                      forwardedComponent={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "attrs": Array [],
+                          "componentStyle": ComponentStyle {
+                            "componentId": "sc-bdVaJa",
+                            "isStatic": false,
+                            "lastClassName": "c2",
+                            "rules": Array [
+                              [Function],
+                            ],
+                          },
+                          "displayName": "Styled(Component)",
+                          "foldedComponentIds": Array [],
+                          "render": [Function],
+                          "styledComponentId": "sc-bdVaJa",
+                          "target": [Function],
+                          "toString": [Function],
+                          "warnTooManyClasses": [Function],
+                          "withComponent": [Function],
+                        }
+                      }
+                      forwardedRef={null}
+                      gutter={true}
+                      hiddenLevel={
+                        Array [
+                          false,
+                          false,
+                          false,
+                          false,
+                          false,
+                        ]
+                      }
+                      horizontalAlignLevel={
+                        Array [
+                          "inherit",
+                          "inherit",
+                          "inherit",
+                          "inherit",
+                          "inherit",
+                        ]
+                      }
+                      id="col-2"
+                      xs={true}
+                    >
+                      <Component
+                        className="c2"
+                        gutter={true}
+                        hiddenLevel={
+                          Array [
+                            false,
+                            false,
+                            false,
+                            false,
+                            false,
+                          ]
+                        }
+                        horizontalAlignLevel={
+                          Array [
+                            "inherit",
+                            "inherit",
+                            "inherit",
+                            "inherit",
+                            "inherit",
+                          ]
+                        }
+                        id="col-2"
+                        xs={true}
+                      >
+                        <Col
+                          className="c2"
+                          id="col-2"
+                          xs={true}
+                        >
+                          <div
+                            className="col-xs c2"
+                            id="col-2"
+                          >
+                            2nd column content
+                          </div>
+                        </Col>
+                      </Component>
+                    </StyledComponent>
+                  </Styled(Component)>
+                </Col>
+              </div>
+            </Row>
+          </Component>
+        </StyledComponent>
+      </Styled(Component)>
+    </Row>
+  </div>
+</Grid>
+`;
+
 exports[`FlexGrid supports responsive reversal 1`] = `
 div.c2 {
   padding-left: 1rem;

--- a/packages/Notification/__tests__/__snapshots__/Notification.spec.jsx.snap
+++ b/packages/Notification/__tests__/__snapshots__/Notification.spec.jsx.snap
@@ -346,10 +346,12 @@ div.c2 {
                 <FlexGrid
                   gutter={true}
                   limitWidth={true}
+                  outsideGutter={true}
                 >
                   <Styled(Component)
                     fluid={true}
                     limitWidth={true}
+                    outsideGutter={true}
                     reverseLevel={
                       Array [
                         false,
@@ -386,6 +388,7 @@ div.c2 {
                       }
                       forwardedRef={null}
                       limitWidth={true}
+                      outsideGutter={true}
                       reverseLevel={
                         Array [
                           false,
@@ -400,6 +403,7 @@ div.c2 {
                         className="c2"
                         fluid={true}
                         limitWidth={true}
+                        outsideGutter={true}
                         reverseLevel={
                           Array [
                             false,
@@ -582,10 +586,12 @@ div.c2 {
                                                     <FlexGrid
                                                       gutter={false}
                                                       limitWidth={true}
+                                                      outsideGutter={true}
                                                     >
                                                       <Styled(Component)
                                                         fluid={true}
                                                         limitWidth={true}
+                                                        outsideGutter={true}
                                                         reverseLevel={
                                                           Array [
                                                             false,
@@ -622,6 +628,7 @@ div.c2 {
                                                           }
                                                           forwardedRef={null}
                                                           limitWidth={true}
+                                                          outsideGutter={true}
                                                           reverseLevel={
                                                             Array [
                                                               false,
@@ -636,6 +643,7 @@ div.c2 {
                                                             className="c2"
                                                             fluid={true}
                                                             limitWidth={true}
+                                                            outsideGutter={true}
                                                             reverseLevel={
                                                               Array [
                                                                 false,
@@ -1406,10 +1414,12 @@ div.c2 {
                 <FlexGrid
                   gutter={true}
                   limitWidth={true}
+                  outsideGutter={true}
                 >
                   <Styled(Component)
                     fluid={true}
                     limitWidth={true}
+                    outsideGutter={true}
                     reverseLevel={
                       Array [
                         false,
@@ -1446,6 +1456,7 @@ div.c2 {
                       }
                       forwardedRef={null}
                       limitWidth={true}
+                      outsideGutter={true}
                       reverseLevel={
                         Array [
                           false,
@@ -1460,6 +1471,7 @@ div.c2 {
                         className="c2"
                         fluid={true}
                         limitWidth={true}
+                        outsideGutter={true}
                         reverseLevel={
                           Array [
                             false,
@@ -1642,10 +1654,12 @@ div.c2 {
                                                     <FlexGrid
                                                       gutter={false}
                                                       limitWidth={true}
+                                                      outsideGutter={true}
                                                     >
                                                       <Styled(Component)
                                                         fluid={true}
                                                         limitWidth={true}
+                                                        outsideGutter={true}
                                                         reverseLevel={
                                                           Array [
                                                             false,
@@ -1682,6 +1696,7 @@ div.c2 {
                                                           }
                                                           forwardedRef={null}
                                                           limitWidth={true}
+                                                          outsideGutter={true}
                                                           reverseLevel={
                                                             Array [
                                                               false,
@@ -1696,6 +1711,7 @@ div.c2 {
                                                             className="c2"
                                                             fluid={true}
                                                             limitWidth={true}
+                                                            outsideGutter={true}
                                                             reverseLevel={
                                                               Array [
                                                                 false,

--- a/packages/TermsAndConditions/__tests__/__snapshots__/TermsAndConditions.spec.jsx.snap
+++ b/packages/TermsAndConditions/__tests__/__snapshots__/TermsAndConditions.spec.jsx.snap
@@ -1098,10 +1098,12 @@ div.c14 {
     <FlexGrid
       gutter={false}
       limitWidth={false}
+      outsideGutter={true}
     >
       <Styled(Component)
         fluid={true}
         limitWidth={false}
+        outsideGutter={true}
         reverseLevel={
           Array [
             false,
@@ -1138,6 +1140,7 @@ div.c14 {
           }
           forwardedRef={null}
           limitWidth={false}
+          outsideGutter={true}
           reverseLevel={
             Array [
               false,
@@ -1152,6 +1155,7 @@ div.c14 {
             className="c1"
             fluid={true}
             limitWidth={false}
+            outsideGutter={true}
             reverseLevel={
               Array [
                 false,
@@ -1794,10 +1798,12 @@ div.c14 {
                   <FlexGrid
                     gutter={false}
                     limitWidth={false}
+                    outsideGutter={true}
                   >
                     <Styled(Component)
                       fluid={true}
                       limitWidth={false}
+                      outsideGutter={true}
                       reverseLevel={
                         Array [
                           false,
@@ -1834,6 +1840,7 @@ div.c14 {
                         }
                         forwardedRef={null}
                         limitWidth={false}
+                        outsideGutter={true}
                         reverseLevel={
                           Array [
                             false,
@@ -1848,6 +1855,7 @@ div.c14 {
                           className="c1"
                           fluid={true}
                           limitWidth={false}
+                          outsideGutter={true}
                           reverseLevel={
                             Array [
                               false,
@@ -2161,10 +2169,12 @@ div.c14 {
                             <FlexGrid
                               gutter={true}
                               limitWidth={true}
+                              outsideGutter={true}
                             >
                               <Styled(Component)
                                 fluid={true}
                                 limitWidth={true}
+                                outsideGutter={true}
                                 reverseLevel={
                                   Array [
                                     false,
@@ -2201,6 +2211,7 @@ div.c14 {
                                   }
                                   forwardedRef={null}
                                   limitWidth={true}
+                                  outsideGutter={true}
                                   reverseLevel={
                                     Array [
                                       false,
@@ -2215,6 +2226,7 @@ div.c14 {
                                     className="c14"
                                     fluid={true}
                                     limitWidth={true}
+                                    outsideGutter={true}
                                     reverseLevel={
                                       Array [
                                         false,
@@ -3482,10 +3494,12 @@ div.c14 {
     <FlexGrid
       gutter={false}
       limitWidth={false}
+      outsideGutter={true}
     >
       <Styled(Component)
         fluid={true}
         limitWidth={false}
+        outsideGutter={true}
         reverseLevel={
           Array [
             false,
@@ -3522,6 +3536,7 @@ div.c14 {
           }
           forwardedRef={null}
           limitWidth={false}
+          outsideGutter={true}
           reverseLevel={
             Array [
               false,
@@ -3536,6 +3551,7 @@ div.c14 {
             className="c1"
             fluid={true}
             limitWidth={false}
+            outsideGutter={true}
             reverseLevel={
               Array [
                 false,
@@ -4178,10 +4194,12 @@ div.c14 {
                   <FlexGrid
                     gutter={false}
                     limitWidth={false}
+                    outsideGutter={true}
                   >
                     <Styled(Component)
                       fluid={true}
                       limitWidth={false}
+                      outsideGutter={true}
                       reverseLevel={
                         Array [
                           false,
@@ -4218,6 +4236,7 @@ div.c14 {
                         }
                         forwardedRef={null}
                         limitWidth={false}
+                        outsideGutter={true}
                         reverseLevel={
                           Array [
                             false,
@@ -4232,6 +4251,7 @@ div.c14 {
                           className="c1"
                           fluid={true}
                           limitWidth={false}
+                          outsideGutter={true}
                           reverseLevel={
                             Array [
                               false,
@@ -4545,10 +4565,12 @@ div.c14 {
                             <FlexGrid
                               gutter={true}
                               limitWidth={true}
+                              outsideGutter={true}
                             >
                               <Styled(Component)
                                 fluid={true}
                                 limitWidth={true}
+                                outsideGutter={true}
                                 reverseLevel={
                                   Array [
                                     false,
@@ -4585,6 +4607,7 @@ div.c14 {
                                   }
                                   forwardedRef={null}
                                   limitWidth={true}
+                                  outsideGutter={true}
                                   reverseLevel={
                                     Array [
                                       false,
@@ -4599,6 +4622,7 @@ div.c14 {
                                     className="c14"
                                     fluid={true}
                                     limitWidth={true}
+                                    outsideGutter={true}
                                     reverseLevel={
                                       Array [
                                         false,
@@ -5250,10 +5274,12 @@ div.c14 {
                             <FlexGrid
                               gutter={true}
                               limitWidth={true}
+                              outsideGutter={true}
                             >
                               <Styled(Component)
                                 fluid={true}
                                 limitWidth={true}
+                                outsideGutter={true}
                                 reverseLevel={
                                   Array [
                                     false,
@@ -5290,6 +5316,7 @@ div.c14 {
                                   }
                                   forwardedRef={null}
                                   limitWidth={true}
+                                  outsideGutter={true}
                                   reverseLevel={
                                     Array [
                                       false,
@@ -5304,6 +5331,7 @@ div.c14 {
                                     className="c14"
                                     fluid={true}
                                     limitWidth={true}
+                                    outsideGutter={true}
                                     reverseLevel={
                                       Array [
                                         false,
@@ -6621,10 +6649,12 @@ div.c14 {
     <FlexGrid
       gutter={false}
       limitWidth={false}
+      outsideGutter={true}
     >
       <Styled(Component)
         fluid={true}
         limitWidth={false}
+        outsideGutter={true}
         reverseLevel={
           Array [
             false,
@@ -6661,6 +6691,7 @@ div.c14 {
           }
           forwardedRef={null}
           limitWidth={false}
+          outsideGutter={true}
           reverseLevel={
             Array [
               false,
@@ -6675,6 +6706,7 @@ div.c14 {
             className="c1"
             fluid={true}
             limitWidth={false}
+            outsideGutter={true}
             reverseLevel={
               Array [
                 false,
@@ -7317,10 +7349,12 @@ div.c14 {
                   <FlexGrid
                     gutter={false}
                     limitWidth={false}
+                    outsideGutter={true}
                   >
                     <Styled(Component)
                       fluid={true}
                       limitWidth={false}
+                      outsideGutter={true}
                       reverseLevel={
                         Array [
                           false,
@@ -7357,6 +7391,7 @@ div.c14 {
                         }
                         forwardedRef={null}
                         limitWidth={false}
+                        outsideGutter={true}
                         reverseLevel={
                           Array [
                             false,
@@ -7371,6 +7406,7 @@ div.c14 {
                           className="c1"
                           fluid={true}
                           limitWidth={false}
+                          outsideGutter={true}
                           reverseLevel={
                             Array [
                               false,
@@ -7684,10 +7720,12 @@ div.c14 {
                             <FlexGrid
                               gutter={true}
                               limitWidth={true}
+                              outsideGutter={true}
                             >
                               <Styled(Component)
                                 fluid={true}
                                 limitWidth={true}
+                                outsideGutter={true}
                                 reverseLevel={
                                   Array [
                                     false,
@@ -7724,6 +7762,7 @@ div.c14 {
                                   }
                                   forwardedRef={null}
                                   limitWidth={true}
+                                  outsideGutter={true}
                                   reverseLevel={
                                     Array [
                                       false,
@@ -7738,6 +7777,7 @@ div.c14 {
                                     className="c14"
                                     fluid={true}
                                     limitWidth={true}
+                                    outsideGutter={true}
                                     reverseLevel={
                                       Array [
                                         false,


### PR DESCRIPTION
## Description

Added outsideGutter property to FlexGrid to enable the removal of left and right padding. This is important for layouts that require nesting of FlexGrid. With outsideGutter set to false, the child columns will align with parent FlexGrid columns as if it's under one FlexGrid.

## Screenshots
![image](https://user-images.githubusercontent.com/30837029/90800633-ed4db300-e2e2-11ea-9bbb-5d52096213ce.png)

