### PR TITLE
fix(core-responsive): moving react media to dependancy

### DIFF
--- a/packages/Responsive/package.json
+++ b/packages/Responsive/package.json
@@ -26,9 +26,7 @@
   },
   "dependencies": {
     "prop-types": "^15.5.10",
-    "sass-mq": "^5.0.0"
-  },
-  "devDependencies": {
+    "sass-mq": "^5.0.0",
     "react-media": "^1.10.0"
   }
 }


### PR DESCRIPTION
## Description

Bug fix - this is stopping tds-community from building as it can't render <Media /> in core-responsive. 

## Checklist before submitting pull request

- [] New code is unit tested
- Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [ ] For code changes, run `npm run prepr` locally
  - make sure visual and accessibility tests pass
