### PR TITLE
fix(core-select): hide firefox duplicate dropdown arrow

### DIFF
--- a/packages/Select/Select.jsx
+++ b/packages/Select/Select.jsx
@@ -64,7 +64,6 @@ const StyledSelect = styled.select(
       appearance: 'none',
       margin: 0,
     },
-    '-moz-appearance': 'textfield',
     minHeight: forms.inputHeight.height,
     maxHeight: forms.inputHeight.height,
     padding: withFeedbackIcon ? '0.5rem 4rem 0.5rem 1rem' : '0.5rem 3rem 0.5rem 1rem',

--- a/packages/Select/__tests__/__snapshots__/Select.spec.jsx.snap
+++ b/packages/Select/__tests__/__snapshots__/Select.spec.jsx.snap
@@ -160,7 +160,6 @@ exports[`Select can have an error message 1`] = `
   line-height: 1.5;
   font-weight: 400;
   color: #2a2c2e;
-  -moz-appearance: textfield;
   min-height: 3rem;
   max-height: 3rem;
   padding: 0.5rem 3rem 0.5rem 1rem;
@@ -2239,7 +2238,6 @@ exports[`Select renders 1`] = `
   line-height: 1.5;
   font-weight: 400;
   color: #2a2c2e;
-  -moz-appearance: textfield;
   min-height: 3rem;
   max-height: 3rem;
   padding: 0.5rem 3rem 0.5rem 1rem;
@@ -2510,7 +2508,6 @@ exports[`Select renders with a feedback state and icon 1`] = `
   line-height: 1.5;
   font-weight: 400;
   color: #2a2c2e;
-  -moz-appearance: textfield;
   min-height: 3rem;
   max-height: 3rem;
   padding: 0.5rem 3rem 0.5rem 1rem;


### PR DESCRIPTION
<!--
  ### IMPORTANT SECURITY NOTE ###

  When opening pull requests, be sure NOT to include any private or personal
  information such as secrets, passwords, or any source code that involves
  data retrieval.

  Also, do not include links to sites on staging.
-->

## Related issues

See #1500 

## Description

<!-- 'Description' section is optional -->
- Hides duplicate dropdown arrow in Firefox by removing the style: `'-moz-appearance': 'textfield'`

## Checklist before submitting pull request

- [x] New code is unit tested
- Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [ ] For code changes, run `npm run prepr` locally
  - make sure visual and accessibility tests pass
