### PR TITLE
feat(core-card): add prop to disable shadow & enabled by default

### DIFF
--- a/packages/Card/Card.jsx
+++ b/packages/Card/Card.jsx
@@ -15,7 +15,6 @@ import { deprecate } from '../../shared/utils/warn'
 const getVariant = ({ variant }) => {
   if (variant === 'white' || variant === 'default' || variant === 'defaultWithBorder') {
     return {
-      boxShadow: '0 0 16px 0 rgba(0, 0, 0, 0.1)',
       backgroundColor: colorWhite,
       border: variant === 'defaultWithBorder' ? `1px solid ${colorGreyGainsboro}` : undefined,
     }
@@ -39,13 +38,21 @@ const deprecationWarning = deprecatedVariant => {
   }' variant.`
 }
 
-export const StyledCard = styled(({ fullHeight, ...props }) => <Box {...props} />)(
+export const StyledCard = styled(({ fullHeight, shadow, ...props }) => <Box {...props} />)(
   borders.none,
   borders.rounded,
   getVariant,
   ({ fullHeight }) => {
     if (fullHeight) {
       return { height: '100%' }
+    }
+    return {}
+  },
+  ({ shadow }) => {
+    if (shadow) {
+      return {
+        boxShadow: '0 0 16px 0 rgba(0, 0, 0, 0.1)',
+      }
     }
     return {}
   }
@@ -84,7 +91,7 @@ const StyledImageCard = styled(({ fullBleedImage, ...props }) => <div {...props}
  *
  * @version ./package.json
  */
-const Card = ({ variant, children, fullHeight, spacing, fullBleedImage, ...rest }) => {
+const Card = ({ variant, children, fullHeight, shadow, spacing, fullBleedImage, ...rest }) => {
   if (variant === 'white' || variant === 'lavendar' || variant === 'grey') {
     deprecate('@tds/core-card', deprecationWarning(variant))
   }
@@ -104,7 +111,7 @@ const Card = ({ variant, children, fullHeight, spacing, fullBleedImage, ...rest 
 
   if (fullBleedImage) {
     return (
-      <StyledCard {...safeRest(rest)} fullHeight={fullHeight} variant={variant}>
+      <StyledCard {...safeRest(rest)} fullHeight={fullHeight} variant={variant} shadow={shadow}>
         <StyledImageCard fullBleedImage={fullBleedImage}>
           <Image
             src={fullBleedImage.src}
@@ -119,7 +126,13 @@ const Card = ({ variant, children, fullHeight, spacing, fullBleedImage, ...rest 
   }
 
   return (
-    <StyledCard {...safeRest(rest)} fullHeight={fullHeight} variant={variant} {...spacingProps}>
+    <StyledCard
+      {...safeRest(rest)}
+      fullHeight={fullHeight}
+      variant={variant}
+      shadow={shadow}
+      {...spacingProps}
+    >
       {children}
     </StyledCard>
   )
@@ -159,6 +172,10 @@ Card.propTypes = {
     position: responsiveProps(PropTypes.oneOf(['left', 'right', 'top', 'bottom', 'none']))
       .isRequired,
   }),
+  /**
+   * Sets the `Card`'s `shadow` enabled by default.
+   */
+  shadow: PropTypes.bool,
 }
 
 Card.defaultProps = {
@@ -166,6 +183,7 @@ Card.defaultProps = {
   fullHeight: false,
   spacing: 'default',
   fullBleedImage: undefined,
+  shadow: true,
 }
 
 export default Card

--- a/packages/Card/Card.jsx
+++ b/packages/Card/Card.jsx
@@ -13,10 +13,14 @@ import { safeRest, handleResponsiveStyles } from '@tds/util-helpers'
 import { deprecate } from '../../shared/utils/warn'
 
 const getVariant = ({ variant }) => {
-  if (variant === 'white' || variant === 'default' || variant === 'defaultWithBorder') {
+  if (['white', 'default', 'defaultWithBorder', 'noShadow'].includes(variant)) {
     return {
+      boxShadow: variant === 'noShadow' ? undefined : '0 0 16px 0 rgba(0, 0, 0, 0.1)',
       backgroundColor: colorWhite,
-      border: variant === 'defaultWithBorder' ? `1px solid ${colorGreyGainsboro}` : undefined,
+      border:
+        variant === 'defaultWithBorder' || variant === 'noShadow'
+          ? `1px solid ${colorGreyGainsboro}`
+          : undefined,
     }
   }
   if (variant === 'lavender' || variant === 'branded') {
@@ -38,21 +42,13 @@ const deprecationWarning = deprecatedVariant => {
   }' variant.`
 }
 
-export const StyledCard = styled(({ fullHeight, shadow, ...props }) => <Box {...props} />)(
+export const StyledCard = styled(({ fullHeight, ...props }) => <Box {...props} />)(
   borders.none,
   borders.rounded,
   getVariant,
   ({ fullHeight }) => {
     if (fullHeight) {
       return { height: '100%' }
-    }
-    return {}
-  },
-  ({ shadow }) => {
-    if (shadow) {
-      return {
-        boxShadow: '0 0 16px 0 rgba(0, 0, 0, 0.1)',
-      }
     }
     return {}
   }
@@ -91,7 +87,7 @@ const StyledImageCard = styled(({ fullBleedImage, ...props }) => <div {...props}
  *
  * @version ./package.json
  */
-const Card = ({ variant, children, fullHeight, shadow, spacing, fullBleedImage, ...rest }) => {
+const Card = ({ variant, children, fullHeight, spacing, fullBleedImage, ...rest }) => {
   if (variant === 'white' || variant === 'lavendar' || variant === 'grey') {
     deprecate('@tds/core-card', deprecationWarning(variant))
   }
@@ -111,7 +107,7 @@ const Card = ({ variant, children, fullHeight, shadow, spacing, fullBleedImage, 
 
   if (fullBleedImage) {
     return (
-      <StyledCard {...safeRest(rest)} fullHeight={fullHeight} variant={variant} shadow={shadow}>
+      <StyledCard {...safeRest(rest)} fullHeight={fullHeight} variant={variant}>
         <StyledImageCard fullBleedImage={fullBleedImage}>
           <Image
             src={fullBleedImage.src}
@@ -126,13 +122,7 @@ const Card = ({ variant, children, fullHeight, shadow, spacing, fullBleedImage, 
   }
 
   return (
-    <StyledCard
-      {...safeRest(rest)}
-      fullHeight={fullHeight}
-      variant={variant}
-      shadow={shadow}
-      {...spacingProps}
-    >
+    <StyledCard {...safeRest(rest)} fullHeight={fullHeight} variant={variant} {...spacingProps}>
       {children}
     </StyledCard>
   )
@@ -142,7 +132,7 @@ Card.propTypes = {
   /**
    * The style.
    *
-   * @since 2.1.0  added `default`, `defaultWithBorder`, `branded`, `alternative`.
+   * @since 2.1.0  added `default`, `defaultWithBorder`, `branded`, `alternative`, `noShadow`.
    *
    * **Deprecated:** `white`, `lavendar`,`grey`
    */
@@ -172,10 +162,6 @@ Card.propTypes = {
     position: responsiveProps(PropTypes.oneOf(['left', 'right', 'top', 'bottom', 'none']))
       .isRequired,
   }),
-  /**
-   * Sets the `Card`'s `shadow` enabled by default.
-   */
-  shadow: PropTypes.bool,
 }
 
 Card.defaultProps = {
@@ -183,7 +169,6 @@ Card.defaultProps = {
   fullHeight: false,
   spacing: 'default',
   fullBleedImage: undefined,
-  shadow: true,
 }
 
 export default Card

--- a/packages/Card/Card.jsx
+++ b/packages/Card/Card.jsx
@@ -13,12 +13,12 @@ import { safeRest, handleResponsiveStyles } from '@tds/util-helpers'
 import { deprecate } from '../../shared/utils/warn'
 
 const getVariant = ({ variant }) => {
-  if (['white', 'default', 'defaultWithBorder', 'noShadow'].includes(variant)) {
+  if (['white', 'default', 'defaultWithBorder', 'defaultOnlyBorder'].indexOf(variant) >= 0) {
     return {
-      boxShadow: variant === 'noShadow' ? undefined : '0 0 16px 0 rgba(0, 0, 0, 0.1)',
+      boxShadow: variant === 'defaultOnlyBorder' ? undefined : '0 0 16px 0 rgba(0, 0, 0, 0.1)',
       backgroundColor: colorWhite,
       border:
-        variant === 'defaultWithBorder' || variant === 'noShadow'
+        variant === 'defaultWithBorder' || variant === 'defaultOnlyBorder'
           ? `1px solid ${colorGreyGainsboro}`
           : undefined,
     }
@@ -132,7 +132,7 @@ Card.propTypes = {
   /**
    * The style.
    *
-   * @since 2.1.0  added `default`, `defaultWithBorder`, `branded`, `alternative`, `noShadow`.
+   * @since 2.5.0  added `defaultOnlyBorder`.
    *
    * **Deprecated:** `white`, `lavendar`,`grey`
    */
@@ -144,6 +144,7 @@ Card.propTypes = {
     'branded',
     'alternative',
     'defaultWithBorder',
+    'defaultOnlyBorder',
   ]),
   /**
    * The content. Can be text, any HTML element, or any component.

--- a/packages/Card/Card.md
+++ b/packages/Card/Card.md
@@ -113,6 +113,48 @@ Teams can use the `defaultWithBorder` variant to add a border to the `Card` for 
 </FlexGrid>
 ```
 
+### Card with borders - no shadow
+
+Cards with border `no-shadow` variant is to be used to create less visual emphasis than other variants of cards with border or shadow. It also matches the same z-index as other coloured variant cards without shadow. It should be used near forms, but not containing forms.
+
+```jsx
+<FlexGrid>
+  <FlexGrid.Row>
+    <FlexGrid.Col xs={12} md={7}>
+      <Card spacing="compact" variant="noShadow">
+        <FlexGrid gutter={false}>
+          <FlexGrid.Row verticalAlign="middle" horizontalAlign="center">
+            <FlexGrid.Col md={2} xs={0}>
+              <Bank size="48" />
+            </FlexGrid.Col>
+            <FlexGrid.Col md={6} xs={12} horizontalAlign="left">
+              <Box horizontal={2}>
+                <Text>Chequing account number</Text>
+                <Heading level="h3">**********1234</Heading>
+              </Box>
+            </FlexGrid.Col>
+            <FlexGrid.Col md={1} xs={12} horizontalAlign="left">
+              <Box inline between={1}>
+                <HairlineDivider vertical />
+                <Box vertical={4}>
+                  <div />
+                </Box>
+              </Box>
+            </FlexGrid.Col>
+            <FlexGrid.Col md={3} xs={12} horizontalAlign="left">
+              <Box between={2}>
+                <Link href="#">Update Card</Link>
+                <Link href="#">Delete Card</Link>
+              </Box>
+            </FlexGrid.Col>
+          </FlexGrid.Row>
+        </FlexGrid>
+      </Card>
+    </FlexGrid.Col>
+  </FlexGrid.Row>
+</FlexGrid>
+```
+
 ### Full Height Cards
 
 In some cases you want cards to match the height of their parent so that the bottom edge of the cards are aligned. This is usually needed when using cards in a `FlexGrid`. Use the `fullHeight` prop to achieve this.

--- a/packages/Card/Card.md
+++ b/packages/Card/Card.md
@@ -115,7 +115,7 @@ Teams can use the `defaultWithBorder` variant to add a border to the `Card` for 
 
 ### Card with borders - no shadow
 
-Cards with border `no-shadow` variant is to be used to create less visual emphasis than other variants of cards with border or shadow. It also matches the same z-index as other coloured variant cards without shadow. It should be used near forms, but not containing forms.
+Cards with border `noShadow` variant is to be used to create less visual emphasis than other variants of cards with border or shadow. It also matches the same z-index as other coloured variant cards without shadow. It should be used near forms, but not containing forms.
 
 ```jsx
 <FlexGrid>

--- a/packages/Card/Card.md
+++ b/packages/Card/Card.md
@@ -115,13 +115,13 @@ Teams can use the `defaultWithBorder` variant to add a border to the `Card` for 
 
 ### Card with borders - no shadow
 
-Cards with border `noShadow` variant is to be used to create less visual emphasis than other variants of cards with border or shadow. It also matches the same z-index as other coloured variant cards without shadow. It should be used near forms, but not containing forms.
+Cards with border `defaultOnlyBorder` variant is to be used to create less visual emphasis than other variants of cards with border or shadow. It also matches the same z-index as other coloured variant cards without shadow. It should be used near forms, but not containing forms.
 
 ```jsx
 <FlexGrid>
   <FlexGrid.Row>
     <FlexGrid.Col xs={12} md={7}>
-      <Card spacing="compact" variant="noShadow">
+      <Card spacing="compact" variant="defaultOnlyBorder">
         <FlexGrid gutter={false}>
           <FlexGrid.Row verticalAlign="middle" horizontalAlign="center">
             <FlexGrid.Col md={2} xs={0}>

--- a/packages/Card/__tests__/__snapshots__/Card.spec.jsx.snap
+++ b/packages/Card/__tests__/__snapshots__/Card.spec.jsx.snap
@@ -11,8 +11,8 @@ exports[`<Card /> can be presented as one of the allowed variants 1`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  background-color: #fff;
   box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
+  background-color: #fff;
 }
 
 @media (max-width:767px) {
@@ -45,14 +45,12 @@ exports[`<Card /> can be presented as one of the allowed variants 1`] = `
 
 <Card
   fullHeight={false}
-  shadow={true}
   spacing="default"
   variant="default"
 >
   <Styled(Component)
     fullHeight={false}
     horizontal={4}
-    shadow={true}
     variant="default"
     vertical={5}
   >
@@ -70,7 +68,6 @@ exports[`<Card /> can be presented as one of the allowed variants 1`] = `
               "border-radius: 4px;",
               [Function],
               [Function],
-              [Function],
             ],
           },
           "displayName": "Styled(Component)",
@@ -86,7 +83,6 @@ exports[`<Card /> can be presented as one of the allowed variants 1`] = `
       forwardedRef={null}
       fullHeight={false}
       horizontal={4}
-      shadow={true}
       variant="default"
       vertical={5}
     >
@@ -94,7 +90,6 @@ exports[`<Card /> can be presented as one of the allowed variants 1`] = `
         className="c0"
         fullHeight={false}
         horizontal={4}
-        shadow={true}
         variant="default"
         vertical={5}
       >
@@ -176,8 +171,8 @@ exports[`<Card /> can be presented as one of the allowed variants 2`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  background-color: #fff;
   box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
+  background-color: #fff;
 }
 
 @media (max-width:767px) {
@@ -210,14 +205,12 @@ exports[`<Card /> can be presented as one of the allowed variants 2`] = `
 
 <Card
   fullHeight={false}
-  shadow={true}
   spacing="default"
   variant="default"
 >
   <Styled(Component)
     fullHeight={false}
     horizontal={4}
-    shadow={true}
     variant="default"
     vertical={5}
   >
@@ -235,7 +228,6 @@ exports[`<Card /> can be presented as one of the allowed variants 2`] = `
               "border-radius: 4px;",
               [Function],
               [Function],
-              [Function],
             ],
           },
           "displayName": "Styled(Component)",
@@ -251,7 +243,6 @@ exports[`<Card /> can be presented as one of the allowed variants 2`] = `
       forwardedRef={null}
       fullHeight={false}
       horizontal={4}
-      shadow={true}
       variant="default"
       vertical={5}
     >
@@ -259,7 +250,6 @@ exports[`<Card /> can be presented as one of the allowed variants 2`] = `
         className="c0"
         fullHeight={false}
         horizontal={4}
-        shadow={true}
         variant="default"
         vertical={5}
       >
@@ -342,7 +332,6 @@ exports[`<Card /> can be presented as one of the allowed variants 3`] = `
   border-width: 0;
   border-radius: 4px;
   background-color: #f2eff4;
-  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
 }
 
 @media (max-width:767px) {
@@ -375,14 +364,12 @@ exports[`<Card /> can be presented as one of the allowed variants 3`] = `
 
 <Card
   fullHeight={false}
-  shadow={true}
   spacing="default"
   variant="branded"
 >
   <Styled(Component)
     fullHeight={false}
     horizontal={4}
-    shadow={true}
     variant="branded"
     vertical={5}
   >
@@ -400,7 +387,6 @@ exports[`<Card /> can be presented as one of the allowed variants 3`] = `
               "border-radius: 4px;",
               [Function],
               [Function],
-              [Function],
             ],
           },
           "displayName": "Styled(Component)",
@@ -416,7 +402,6 @@ exports[`<Card /> can be presented as one of the allowed variants 3`] = `
       forwardedRef={null}
       fullHeight={false}
       horizontal={4}
-      shadow={true}
       variant="branded"
       vertical={5}
     >
@@ -424,7 +409,6 @@ exports[`<Card /> can be presented as one of the allowed variants 3`] = `
         className="c0"
         fullHeight={false}
         horizontal={4}
-        shadow={true}
         variant="branded"
         vertical={5}
       >
@@ -507,7 +491,6 @@ exports[`<Card /> can be presented as one of the allowed variants 4`] = `
   border-width: 0;
   border-radius: 4px;
   background-color: #f7f7f8;
-  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
 }
 
 @media (max-width:767px) {
@@ -540,14 +523,12 @@ exports[`<Card /> can be presented as one of the allowed variants 4`] = `
 
 <Card
   fullHeight={false}
-  shadow={true}
   spacing="default"
   variant="alternative"
 >
   <Styled(Component)
     fullHeight={false}
     horizontal={4}
-    shadow={true}
     variant="alternative"
     vertical={5}
   >
@@ -565,7 +546,6 @@ exports[`<Card /> can be presented as one of the allowed variants 4`] = `
               "border-radius: 4px;",
               [Function],
               [Function],
-              [Function],
             ],
           },
           "displayName": "Styled(Component)",
@@ -581,7 +561,6 @@ exports[`<Card /> can be presented as one of the allowed variants 4`] = `
       forwardedRef={null}
       fullHeight={false}
       horizontal={4}
-      shadow={true}
       variant="alternative"
       vertical={5}
     >
@@ -589,7 +568,6 @@ exports[`<Card /> can be presented as one of the allowed variants 4`] = `
         className="c0"
         fullHeight={false}
         horizontal={4}
-        shadow={true}
         variant="alternative"
         vertical={5}
       >
@@ -671,9 +649,9 @@ exports[`<Card /> can be presented as one of the allowed variants 5`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
+  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
   background-color: #fff;
   border: 1px solid #d8d8d8;
-  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
 }
 
 @media (max-width:767px) {
@@ -706,14 +684,12 @@ exports[`<Card /> can be presented as one of the allowed variants 5`] = `
 
 <Card
   fullHeight={false}
-  shadow={true}
   spacing="default"
   variant="defaultWithBorder"
 >
   <Styled(Component)
     fullHeight={false}
     horizontal={4}
-    shadow={true}
     variant="defaultWithBorder"
     vertical={5}
   >
@@ -731,7 +707,6 @@ exports[`<Card /> can be presented as one of the allowed variants 5`] = `
               "border-radius: 4px;",
               [Function],
               [Function],
-              [Function],
             ],
           },
           "displayName": "Styled(Component)",
@@ -747,7 +722,6 @@ exports[`<Card /> can be presented as one of the allowed variants 5`] = `
       forwardedRef={null}
       fullHeight={false}
       horizontal={4}
-      shadow={true}
       variant="defaultWithBorder"
       vertical={5}
     >
@@ -755,7 +729,6 @@ exports[`<Card /> can be presented as one of the allowed variants 5`] = `
         className="c0"
         fullHeight={false}
         horizontal={4}
-        shadow={true}
         variant="defaultWithBorder"
         vertical={5}
       >
@@ -849,8 +822,8 @@ exports[`<Card /> full bleed image renders with an image 1`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  background-color: #fff;
   box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
+  background-color: #fff;
 }
 
 .c2 {
@@ -911,13 +884,11 @@ exports[`<Card /> full bleed image renders with an image 1`] = `
     }
   }
   fullHeight={false}
-  shadow={true}
   spacing="default"
   variant="default"
 >
   <Styled(Component)
     fullHeight={false}
-    shadow={true}
     variant="default"
   >
     <StyledComponent
@@ -934,7 +905,6 @@ exports[`<Card /> full bleed image renders with an image 1`] = `
               "border-radius: 4px;",
               [Function],
               [Function],
-              [Function],
             ],
           },
           "displayName": "Styled(Component)",
@@ -949,13 +919,11 @@ exports[`<Card /> full bleed image renders with an image 1`] = `
       }
       forwardedRef={null}
       fullHeight={false}
-      shadow={true}
       variant="default"
     >
       <Component
         className="c0"
         fullHeight={false}
-        shadow={true}
         variant="default"
       >
         <Box
@@ -1212,8 +1180,8 @@ exports[`<Card /> full bleed image renders with responsive image props 1`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  background-color: #fff;
   box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
+  background-color: #fff;
 }
 
 @media (max-width:767px) {
@@ -1300,13 +1268,11 @@ exports[`<Card /> full bleed image renders with responsive image props 1`] = `
     }
   }
   fullHeight={false}
-  shadow={true}
   spacing="default"
   variant="default"
 >
   <Styled(Component)
     fullHeight={false}
-    shadow={true}
     variant="default"
   >
     <StyledComponent
@@ -1323,7 +1289,6 @@ exports[`<Card /> full bleed image renders with responsive image props 1`] = `
               "border-radius: 4px;",
               [Function],
               [Function],
-              [Function],
             ],
           },
           "displayName": "Styled(Component)",
@@ -1338,13 +1303,11 @@ exports[`<Card /> full bleed image renders with responsive image props 1`] = `
       }
       forwardedRef={null}
       fullHeight={false}
-      shadow={true}
       variant="default"
     >
       <Component
         className="c0"
         fullHeight={false}
-        shadow={true}
         variant="default"
       >
         <Box
@@ -1598,8 +1561,8 @@ exports[`<Card /> full bleed image renders without an image 1`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  background-color: #fff;
   box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
+  background-color: #fff;
 }
 
 @media (max-width:767px) {
@@ -1632,14 +1595,12 @@ exports[`<Card /> full bleed image renders without an image 1`] = `
 
 <Card
   fullHeight={false}
-  shadow={true}
   spacing="default"
   variant="default"
 >
   <Styled(Component)
     fullHeight={false}
     horizontal={4}
-    shadow={true}
     variant="default"
     vertical={5}
   >
@@ -1657,7 +1618,6 @@ exports[`<Card /> full bleed image renders without an image 1`] = `
               "border-radius: 4px;",
               [Function],
               [Function],
-              [Function],
             ],
           },
           "displayName": "Styled(Component)",
@@ -1673,7 +1633,6 @@ exports[`<Card /> full bleed image renders without an image 1`] = `
       forwardedRef={null}
       fullHeight={false}
       horizontal={4}
-      shadow={true}
       variant="default"
       vertical={5}
     >
@@ -1681,7 +1640,6 @@ exports[`<Card /> full bleed image renders without an image 1`] = `
         className="c0"
         fullHeight={false}
         horizontal={4}
-        shadow={true}
         variant="default"
         vertical={5}
       >
@@ -1763,8 +1721,8 @@ exports[`<Card /> renders 1`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  background-color: #fff;
   box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
+  background-color: #fff;
 }
 
 @media (max-width:767px) {
@@ -1817,20 +1775,18 @@ exports[`<Card /> spacing renders compact spacing 1`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  background-color: #fff;
   box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
+  background-color: #fff;
 }
 
 <Card
   fullHeight={false}
-  shadow={true}
   spacing="compact"
   variant="default"
 >
   <Styled(Component)
     fullHeight={false}
     inset={3}
-    shadow={true}
     variant="default"
   >
     <StyledComponent
@@ -1845,7 +1801,6 @@ exports[`<Card /> spacing renders compact spacing 1`] = `
             "rules": Array [
               "border-width: 0;",
               "border-radius: 4px;",
-              [Function],
               [Function],
               [Function],
             ],
@@ -1863,14 +1818,12 @@ exports[`<Card /> spacing renders compact spacing 1`] = `
       forwardedRef={null}
       fullHeight={false}
       inset={3}
-      shadow={true}
       variant="default"
     >
       <Component
         className="c0"
         fullHeight={false}
         inset={3}
-        shadow={true}
         variant="default"
       >
         <Box
@@ -1948,8 +1901,8 @@ exports[`<Card /> spacing renders default spacing 1`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  background-color: #fff;
   box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
+  background-color: #fff;
 }
 
 @media (max-width:767px) {
@@ -1982,14 +1935,12 @@ exports[`<Card /> spacing renders default spacing 1`] = `
 
 <Card
   fullHeight={false}
-  shadow={true}
   spacing="default"
   variant="default"
 >
   <Styled(Component)
     fullHeight={false}
     horizontal={4}
-    shadow={true}
     variant="default"
     vertical={5}
   >
@@ -2007,7 +1958,6 @@ exports[`<Card /> spacing renders default spacing 1`] = `
               "border-radius: 4px;",
               [Function],
               [Function],
-              [Function],
             ],
           },
           "displayName": "Styled(Component)",
@@ -2023,7 +1973,6 @@ exports[`<Card /> spacing renders default spacing 1`] = `
       forwardedRef={null}
       fullHeight={false}
       horizontal={4}
-      shadow={true}
       variant="default"
       vertical={5}
     >
@@ -2031,7 +1980,6 @@ exports[`<Card /> spacing renders default spacing 1`] = `
         className="c0"
         fullHeight={false}
         horizontal={4}
-        shadow={true}
         variant="default"
         vertical={5}
       >
@@ -2113,8 +2061,8 @@ exports[`<Card /> spacing renders intermediate spacing 1`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  background-color: #fff;
   box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
+  background-color: #fff;
 }
 
 @media (max-width:767px) {
@@ -2137,14 +2085,12 @@ exports[`<Card /> spacing renders intermediate spacing 1`] = `
 
 <Card
   fullHeight={false}
-  shadow={true}
   spacing="intermediate"
   variant="default"
 >
   <Styled(Component)
     fullHeight={false}
     inset={4}
-    shadow={true}
     variant="default"
   >
     <StyledComponent
@@ -2159,7 +2105,6 @@ exports[`<Card /> spacing renders intermediate spacing 1`] = `
             "rules": Array [
               "border-width: 0;",
               "border-radius: 4px;",
-              [Function],
               [Function],
               [Function],
             ],
@@ -2177,14 +2122,12 @@ exports[`<Card /> spacing renders intermediate spacing 1`] = `
       forwardedRef={null}
       fullHeight={false}
       inset={4}
-      shadow={true}
       variant="default"
     >
       <Component
         className="c0"
         fullHeight={false}
         inset={4}
-        shadow={true}
         variant="default"
       >
         <Box
@@ -2264,8 +2207,8 @@ exports[`<Card /> spacing renders narrow spacing 1`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  background-color: #fff;
   box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
+  background-color: #fff;
 }
 
 @media (max-width:767px) {
@@ -2284,14 +2227,12 @@ exports[`<Card /> spacing renders narrow spacing 1`] = `
 
 <Card
   fullHeight={false}
-  shadow={true}
   spacing="narrow"
   variant="default"
 >
   <Styled(Component)
     fullHeight={false}
     horizontal={3}
-    shadow={true}
     variant="default"
     vertical={4}
   >
@@ -2309,7 +2250,6 @@ exports[`<Card /> spacing renders narrow spacing 1`] = `
               "border-radius: 4px;",
               [Function],
               [Function],
-              [Function],
             ],
           },
           "displayName": "Styled(Component)",
@@ -2325,7 +2265,6 @@ exports[`<Card /> spacing renders narrow spacing 1`] = `
       forwardedRef={null}
       fullHeight={false}
       horizontal={3}
-      shadow={true}
       variant="default"
       vertical={4}
     >
@@ -2333,7 +2272,6 @@ exports[`<Card /> spacing renders narrow spacing 1`] = `
         className="c0"
         fullHeight={false}
         horizontal={3}
-        shadow={true}
         variant="default"
         vertical={4}
       >

--- a/packages/Card/__tests__/__snapshots__/Card.spec.jsx.snap
+++ b/packages/Card/__tests__/__snapshots__/Card.spec.jsx.snap
@@ -11,8 +11,8 @@ exports[`<Card /> can be presented as one of the allowed variants 1`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
   background-color: #fff;
+  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
 }
 
 @media (max-width:767px) {
@@ -45,12 +45,14 @@ exports[`<Card /> can be presented as one of the allowed variants 1`] = `
 
 <Card
   fullHeight={false}
+  shadow={true}
   spacing="default"
   variant="default"
 >
   <Styled(Component)
     fullHeight={false}
     horizontal={4}
+    shadow={true}
     variant="default"
     vertical={5}
   >
@@ -68,6 +70,7 @@ exports[`<Card /> can be presented as one of the allowed variants 1`] = `
               "border-radius: 4px;",
               [Function],
               [Function],
+              [Function],
             ],
           },
           "displayName": "Styled(Component)",
@@ -83,6 +86,7 @@ exports[`<Card /> can be presented as one of the allowed variants 1`] = `
       forwardedRef={null}
       fullHeight={false}
       horizontal={4}
+      shadow={true}
       variant="default"
       vertical={5}
     >
@@ -90,6 +94,7 @@ exports[`<Card /> can be presented as one of the allowed variants 1`] = `
         className="c0"
         fullHeight={false}
         horizontal={4}
+        shadow={true}
         variant="default"
         vertical={5}
       >
@@ -171,8 +176,8 @@ exports[`<Card /> can be presented as one of the allowed variants 2`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
   background-color: #fff;
+  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
 }
 
 @media (max-width:767px) {
@@ -205,12 +210,14 @@ exports[`<Card /> can be presented as one of the allowed variants 2`] = `
 
 <Card
   fullHeight={false}
+  shadow={true}
   spacing="default"
   variant="default"
 >
   <Styled(Component)
     fullHeight={false}
     horizontal={4}
+    shadow={true}
     variant="default"
     vertical={5}
   >
@@ -228,6 +235,7 @@ exports[`<Card /> can be presented as one of the allowed variants 2`] = `
               "border-radius: 4px;",
               [Function],
               [Function],
+              [Function],
             ],
           },
           "displayName": "Styled(Component)",
@@ -243,6 +251,7 @@ exports[`<Card /> can be presented as one of the allowed variants 2`] = `
       forwardedRef={null}
       fullHeight={false}
       horizontal={4}
+      shadow={true}
       variant="default"
       vertical={5}
     >
@@ -250,6 +259,7 @@ exports[`<Card /> can be presented as one of the allowed variants 2`] = `
         className="c0"
         fullHeight={false}
         horizontal={4}
+        shadow={true}
         variant="default"
         vertical={5}
       >
@@ -332,6 +342,7 @@ exports[`<Card /> can be presented as one of the allowed variants 3`] = `
   border-width: 0;
   border-radius: 4px;
   background-color: #f2eff4;
+  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
 }
 
 @media (max-width:767px) {
@@ -364,12 +375,14 @@ exports[`<Card /> can be presented as one of the allowed variants 3`] = `
 
 <Card
   fullHeight={false}
+  shadow={true}
   spacing="default"
   variant="branded"
 >
   <Styled(Component)
     fullHeight={false}
     horizontal={4}
+    shadow={true}
     variant="branded"
     vertical={5}
   >
@@ -387,6 +400,7 @@ exports[`<Card /> can be presented as one of the allowed variants 3`] = `
               "border-radius: 4px;",
               [Function],
               [Function],
+              [Function],
             ],
           },
           "displayName": "Styled(Component)",
@@ -402,6 +416,7 @@ exports[`<Card /> can be presented as one of the allowed variants 3`] = `
       forwardedRef={null}
       fullHeight={false}
       horizontal={4}
+      shadow={true}
       variant="branded"
       vertical={5}
     >
@@ -409,6 +424,7 @@ exports[`<Card /> can be presented as one of the allowed variants 3`] = `
         className="c0"
         fullHeight={false}
         horizontal={4}
+        shadow={true}
         variant="branded"
         vertical={5}
       >
@@ -491,6 +507,7 @@ exports[`<Card /> can be presented as one of the allowed variants 4`] = `
   border-width: 0;
   border-radius: 4px;
   background-color: #f7f7f8;
+  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
 }
 
 @media (max-width:767px) {
@@ -523,12 +540,14 @@ exports[`<Card /> can be presented as one of the allowed variants 4`] = `
 
 <Card
   fullHeight={false}
+  shadow={true}
   spacing="default"
   variant="alternative"
 >
   <Styled(Component)
     fullHeight={false}
     horizontal={4}
+    shadow={true}
     variant="alternative"
     vertical={5}
   >
@@ -546,6 +565,7 @@ exports[`<Card /> can be presented as one of the allowed variants 4`] = `
               "border-radius: 4px;",
               [Function],
               [Function],
+              [Function],
             ],
           },
           "displayName": "Styled(Component)",
@@ -561,6 +581,7 @@ exports[`<Card /> can be presented as one of the allowed variants 4`] = `
       forwardedRef={null}
       fullHeight={false}
       horizontal={4}
+      shadow={true}
       variant="alternative"
       vertical={5}
     >
@@ -568,6 +589,7 @@ exports[`<Card /> can be presented as one of the allowed variants 4`] = `
         className="c0"
         fullHeight={false}
         horizontal={4}
+        shadow={true}
         variant="alternative"
         vertical={5}
       >
@@ -649,9 +671,9 @@ exports[`<Card /> can be presented as one of the allowed variants 5`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
   background-color: #fff;
   border: 1px solid #d8d8d8;
+  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
 }
 
 @media (max-width:767px) {
@@ -684,12 +706,14 @@ exports[`<Card /> can be presented as one of the allowed variants 5`] = `
 
 <Card
   fullHeight={false}
+  shadow={true}
   spacing="default"
   variant="defaultWithBorder"
 >
   <Styled(Component)
     fullHeight={false}
     horizontal={4}
+    shadow={true}
     variant="defaultWithBorder"
     vertical={5}
   >
@@ -707,6 +731,7 @@ exports[`<Card /> can be presented as one of the allowed variants 5`] = `
               "border-radius: 4px;",
               [Function],
               [Function],
+              [Function],
             ],
           },
           "displayName": "Styled(Component)",
@@ -722,6 +747,7 @@ exports[`<Card /> can be presented as one of the allowed variants 5`] = `
       forwardedRef={null}
       fullHeight={false}
       horizontal={4}
+      shadow={true}
       variant="defaultWithBorder"
       vertical={5}
     >
@@ -729,6 +755,7 @@ exports[`<Card /> can be presented as one of the allowed variants 5`] = `
         className="c0"
         fullHeight={false}
         horizontal={4}
+        shadow={true}
         variant="defaultWithBorder"
         vertical={5}
       >
@@ -822,8 +849,8 @@ exports[`<Card /> full bleed image renders with an image 1`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
   background-color: #fff;
+  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
 }
 
 .c2 {
@@ -884,11 +911,13 @@ exports[`<Card /> full bleed image renders with an image 1`] = `
     }
   }
   fullHeight={false}
+  shadow={true}
   spacing="default"
   variant="default"
 >
   <Styled(Component)
     fullHeight={false}
+    shadow={true}
     variant="default"
   >
     <StyledComponent
@@ -905,6 +934,7 @@ exports[`<Card /> full bleed image renders with an image 1`] = `
               "border-radius: 4px;",
               [Function],
               [Function],
+              [Function],
             ],
           },
           "displayName": "Styled(Component)",
@@ -919,11 +949,13 @@ exports[`<Card /> full bleed image renders with an image 1`] = `
       }
       forwardedRef={null}
       fullHeight={false}
+      shadow={true}
       variant="default"
     >
       <Component
         className="c0"
         fullHeight={false}
+        shadow={true}
         variant="default"
       >
         <Box
@@ -1180,8 +1212,8 @@ exports[`<Card /> full bleed image renders with responsive image props 1`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
   background-color: #fff;
+  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
 }
 
 @media (max-width:767px) {
@@ -1268,11 +1300,13 @@ exports[`<Card /> full bleed image renders with responsive image props 1`] = `
     }
   }
   fullHeight={false}
+  shadow={true}
   spacing="default"
   variant="default"
 >
   <Styled(Component)
     fullHeight={false}
+    shadow={true}
     variant="default"
   >
     <StyledComponent
@@ -1289,6 +1323,7 @@ exports[`<Card /> full bleed image renders with responsive image props 1`] = `
               "border-radius: 4px;",
               [Function],
               [Function],
+              [Function],
             ],
           },
           "displayName": "Styled(Component)",
@@ -1303,11 +1338,13 @@ exports[`<Card /> full bleed image renders with responsive image props 1`] = `
       }
       forwardedRef={null}
       fullHeight={false}
+      shadow={true}
       variant="default"
     >
       <Component
         className="c0"
         fullHeight={false}
+        shadow={true}
         variant="default"
       >
         <Box
@@ -1561,8 +1598,8 @@ exports[`<Card /> full bleed image renders without an image 1`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
   background-color: #fff;
+  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
 }
 
 @media (max-width:767px) {
@@ -1595,12 +1632,14 @@ exports[`<Card /> full bleed image renders without an image 1`] = `
 
 <Card
   fullHeight={false}
+  shadow={true}
   spacing="default"
   variant="default"
 >
   <Styled(Component)
     fullHeight={false}
     horizontal={4}
+    shadow={true}
     variant="default"
     vertical={5}
   >
@@ -1618,6 +1657,7 @@ exports[`<Card /> full bleed image renders without an image 1`] = `
               "border-radius: 4px;",
               [Function],
               [Function],
+              [Function],
             ],
           },
           "displayName": "Styled(Component)",
@@ -1633,6 +1673,7 @@ exports[`<Card /> full bleed image renders without an image 1`] = `
       forwardedRef={null}
       fullHeight={false}
       horizontal={4}
+      shadow={true}
       variant="default"
       vertical={5}
     >
@@ -1640,6 +1681,7 @@ exports[`<Card /> full bleed image renders without an image 1`] = `
         className="c0"
         fullHeight={false}
         horizontal={4}
+        shadow={true}
         variant="default"
         vertical={5}
       >
@@ -1721,8 +1763,8 @@ exports[`<Card /> renders 1`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
   background-color: #fff;
+  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
 }
 
 @media (max-width:767px) {
@@ -1775,18 +1817,20 @@ exports[`<Card /> spacing renders compact spacing 1`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
   background-color: #fff;
+  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
 }
 
 <Card
   fullHeight={false}
+  shadow={true}
   spacing="compact"
   variant="default"
 >
   <Styled(Component)
     fullHeight={false}
     inset={3}
+    shadow={true}
     variant="default"
   >
     <StyledComponent
@@ -1801,6 +1845,7 @@ exports[`<Card /> spacing renders compact spacing 1`] = `
             "rules": Array [
               "border-width: 0;",
               "border-radius: 4px;",
+              [Function],
               [Function],
               [Function],
             ],
@@ -1818,12 +1863,14 @@ exports[`<Card /> spacing renders compact spacing 1`] = `
       forwardedRef={null}
       fullHeight={false}
       inset={3}
+      shadow={true}
       variant="default"
     >
       <Component
         className="c0"
         fullHeight={false}
         inset={3}
+        shadow={true}
         variant="default"
       >
         <Box
@@ -1901,8 +1948,8 @@ exports[`<Card /> spacing renders default spacing 1`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
   background-color: #fff;
+  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
 }
 
 @media (max-width:767px) {
@@ -1935,12 +1982,14 @@ exports[`<Card /> spacing renders default spacing 1`] = `
 
 <Card
   fullHeight={false}
+  shadow={true}
   spacing="default"
   variant="default"
 >
   <Styled(Component)
     fullHeight={false}
     horizontal={4}
+    shadow={true}
     variant="default"
     vertical={5}
   >
@@ -1958,6 +2007,7 @@ exports[`<Card /> spacing renders default spacing 1`] = `
               "border-radius: 4px;",
               [Function],
               [Function],
+              [Function],
             ],
           },
           "displayName": "Styled(Component)",
@@ -1973,6 +2023,7 @@ exports[`<Card /> spacing renders default spacing 1`] = `
       forwardedRef={null}
       fullHeight={false}
       horizontal={4}
+      shadow={true}
       variant="default"
       vertical={5}
     >
@@ -1980,6 +2031,7 @@ exports[`<Card /> spacing renders default spacing 1`] = `
         className="c0"
         fullHeight={false}
         horizontal={4}
+        shadow={true}
         variant="default"
         vertical={5}
       >
@@ -2061,8 +2113,8 @@ exports[`<Card /> spacing renders intermediate spacing 1`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
   background-color: #fff;
+  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
 }
 
 @media (max-width:767px) {
@@ -2085,12 +2137,14 @@ exports[`<Card /> spacing renders intermediate spacing 1`] = `
 
 <Card
   fullHeight={false}
+  shadow={true}
   spacing="intermediate"
   variant="default"
 >
   <Styled(Component)
     fullHeight={false}
     inset={4}
+    shadow={true}
     variant="default"
   >
     <StyledComponent
@@ -2105,6 +2159,7 @@ exports[`<Card /> spacing renders intermediate spacing 1`] = `
             "rules": Array [
               "border-width: 0;",
               "border-radius: 4px;",
+              [Function],
               [Function],
               [Function],
             ],
@@ -2122,12 +2177,14 @@ exports[`<Card /> spacing renders intermediate spacing 1`] = `
       forwardedRef={null}
       fullHeight={false}
       inset={4}
+      shadow={true}
       variant="default"
     >
       <Component
         className="c0"
         fullHeight={false}
         inset={4}
+        shadow={true}
         variant="default"
       >
         <Box
@@ -2207,8 +2264,8 @@ exports[`<Card /> spacing renders narrow spacing 1`] = `
 .c0 {
   border-width: 0;
   border-radius: 4px;
-  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
   background-color: #fff;
+  box-shadow: 0 0 16px 0 rgba(0,0,0,0.1);
 }
 
 @media (max-width:767px) {
@@ -2227,12 +2284,14 @@ exports[`<Card /> spacing renders narrow spacing 1`] = `
 
 <Card
   fullHeight={false}
+  shadow={true}
   spacing="narrow"
   variant="default"
 >
   <Styled(Component)
     fullHeight={false}
     horizontal={3}
+    shadow={true}
     variant="default"
     vertical={4}
   >
@@ -2250,6 +2309,7 @@ exports[`<Card /> spacing renders narrow spacing 1`] = `
               "border-radius: 4px;",
               [Function],
               [Function],
+              [Function],
             ],
           },
           "displayName": "Styled(Component)",
@@ -2265,6 +2325,7 @@ exports[`<Card /> spacing renders narrow spacing 1`] = `
       forwardedRef={null}
       fullHeight={false}
       horizontal={3}
+      shadow={true}
       variant="default"
       vertical={4}
     >
@@ -2272,6 +2333,7 @@ exports[`<Card /> spacing renders narrow spacing 1`] = `
         className="c0"
         fullHeight={false}
         horizontal={3}
+        shadow={true}
         variant="default"
         vertical={4}
       >


### PR DESCRIPTION
https://telusdigital.atlassian.net/browse/DJR-3058

**enable shadow by default:**

<img width="977" alt="Screenshot 2020-11-24 at 12 28 03 PM" src="https://user-images.githubusercontent.com/66362909/100059599-59dfcd00-2e51-11eb-9f05-034f2dc44249.png">

 
**disable shadow:**

<img width="1033" alt="Screenshot 2020-12-02 at 4 31 28 PM" src="https://user-images.githubusercontent.com/47171926/100864316-d743b700-34bb-11eb-8e4e-b8aff82ed55c.png">
