### PR TITLE
fix(core-button): no hover on touch screens

### DIFF
--- a/packages/Button/Button.jsx
+++ b/packages/Button/Button.jsx
@@ -128,6 +128,13 @@ const getVariant = ({ variant, rank }) => {
     border,
     transition,
     '&:hover': hover,
+    '@media (hover: none)': {
+      '&:hover': {
+        boxShadow: 'none',
+        backgroundColor,
+        color,
+      },
+    },
     '&:active': active,
     '&:focus': focus,
     '@media (prefers-reduced-motion: reduce)': {

--- a/packages/Button/__tests__/__snapshots__/Button.spec.jsx.snap
+++ b/packages/Button/__tests__/__snapshots__/Button.spec.jsx.snap
@@ -66,6 +66,14 @@ exports[`Button can be presented as one of the allowed variants 1`] = `
   }
 }
 
+@media (hover:none) {
+  .c0:hover {
+    box-shadow: none;
+    background-color: #4b286d;
+    color: #fff;
+  }
+}
+
 @media (prefers-reduced-motion:reduce) {
   .c0 {
     -webkit-transition: none !important;
@@ -164,6 +172,14 @@ exports[`Button can be presented as one of the new allowed variants 1`] = `
   }
 }
 
+@media (hover:none) {
+  .c0:hover {
+    box-shadow: none;
+    background-color: #fff;
+    color: #2B8000;
+  }
+}
+
 @media (prefers-reduced-motion:reduce) {
   .c0 {
     -webkit-transition: none !important;
@@ -246,6 +262,14 @@ exports[`Button renders 1`] = `
     display: inline-flex;
     width: auto;
     min-width: 180px;
+  }
+}
+
+@media (hover:none) {
+  .c0:hover {
+    box-shadow: none;
+    background-color: #2B8000;
+    color: #fff;
   }
 }
 


### PR DESCRIPTION
## Related issues

Global issue

## Description

On touch displays, after a button is clicked it remains in the hover state.

We use hover media query here to remove hover styles on screens that don't handle hover well.

We cannot use `@media (hover: hover)` because ie11 would not render the hover style, so we enable by default and reset the style using `@media (hover: none)
