### PR TITLE
fix(core-price-lockup): update proptypes

### DIFF
--- a/packages/PriceLockup/PriceLockup.jsx
+++ b/packages/PriceLockup/PriceLockup.jsx
@@ -343,11 +343,11 @@ PriceLockup.propTypes = {
   /**
    * Statement above Price Value.
    */
-  topText: PropTypes.string,
+  topText: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   /**
    * Statement below Price Value.
    */
-  bottomText: PropTypes.string,
+  bottomText: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   /**
    * Statement right of Price Value.
    */
@@ -355,7 +355,7 @@ PriceLockup.propTypes = {
   /**
    * Price value of component.
    */
-  price: PropTypes.string.isRequired,
+  price: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
   /**
    * A [FootnoteLink](/#/Terms%20and%20Conditions?id=footnotelink) component, which may include multiple footnotes.
    *


### PR DESCRIPTION
## Description

<!-- 'Description' section is optional -->
In SiteBuilder, we noticed console errors invalid prop types of `object` were being passed as props to `price`, `bottomText` and `topText` in the PriceLockup component. This is caused because the content passed is being wrapped in `WithLegal`

Example:
`topText={<WithLegal content={topText} />}`

To fix this, I'd like to add the option of adding `object` as an acceptable prop type in addition to `string` for these fields.

## Checklist before submitting pull request

- [x] New code is unit tested
- Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [x] For code changes, run `npm run prepr` locally
  - make sure visual and accessibility tests pass
