### PR TITLE
fix(core-web-video): remove broken css background declaration

### DIFF
--- a/packages/WebVideo/WebVideo.jsx
+++ b/packages/WebVideo/WebVideo.jsx
@@ -31,7 +31,6 @@ const aspectRatios = {
 const AspectLimiter = styled.div(props => ({
   ...aspectRatios[props.aspectRatio],
   position: 'relative',
-  backgroundImage: `url(${props.aspectRatio})`,
 }))
 
 /**

--- a/packages/WebVideo/__tests__/__snapshots__/WebVideo.spec.jsx.snap
+++ b/packages/WebVideo/__tests__/__snapshots__/WebVideo.spec.jsx.snap
@@ -220,7 +220,6 @@ exports[`WebVideo renders 1`] = `
 .c1 {
   padding-top: 56.25%;
   position: relative;
-  background-image: url(16:9);
 }
 
 @media (min-width:768px) {


### PR DESCRIPTION
## Related issues
See #1529

## Description
Removes a background declaration that was not specifying a URL, and resulted in an incorrect network request using the aspect ratio. More detail in issue above.

## PR Checklist
- [x] New code is unit tested
- [x] Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [x] For code changes, run `npm run prepr` locally
- [x] Make sure visual and accessibility tests pass
