### PR TITLE
fix(core-terms-and-conditions): use index as key when mapping

### DIFF
--- a/packages/TermsAndConditions/TermsAndConditions.jsx
+++ b/packages/TermsAndConditions/TermsAndConditions.jsx
@@ -121,8 +121,9 @@ const TermsAndConditions = forwardRef(
                         <FlexGrid.Row>
                           <FlexGrid.Col xs={12} mdOffset={1} md={10}>
                             <List size="small" below={4} type="indexed">
-                              {indexedContent.map(c => (
-                                <List.Item key={c}>{renderContent(c)}</List.Item>
+                              {indexedContent.map((c, idx) => (
+                                // eslint-disable-next-line react/no-array-index-key
+                                <List.Item key={idx}>{renderContent(c)}</List.Item>
                               ))}
                             </List>
                           </FlexGrid.Col>
@@ -142,8 +143,9 @@ const TermsAndConditions = forwardRef(
                                 </div>
                               )}
                               <List size="small" below={4} type="nonIndexed">
-                                {nonIndexedContent.map(c => (
-                                  <List.Item key={c}>{renderContent(c)}</List.Item>
+                                {nonIndexedContent.map((c, idx) => (
+                                  // eslint-disable-next-line react/no-array-index-key
+                                  <List.Item key={idx}>{renderContent(c)}</List.Item>
                                 ))}
                               </List>
                             </Box>

--- a/packages/TermsAndConditions/__tests__/__snapshots__/TermsAndConditions.spec.jsx.snap
+++ b/packages/TermsAndConditions/__tests__/__snapshots__/TermsAndConditions.spec.jsx.snap
@@ -2520,7 +2520,7 @@ exports[`TermsAndConditions renders expanded 1`] = `
                                                                   type="indexed"
                                                                 >
                                                                   <Item
-                                                                    key=".$One"
+                                                                    key=".$0"
                                                                     styledComponent={
                                                                       Object {
                                                                         "$$typeof": Symbol(react.forward_ref),
@@ -2585,7 +2585,7 @@ exports[`TermsAndConditions renders expanded 1`] = `
                                                                     </List__StyledListItem>
                                                                   </Item>
                                                                   <Item
-                                                                    key=".$Two"
+                                                                    key=".$1"
                                                                     styledComponent={
                                                                       Object {
                                                                         "$$typeof": Symbol(react.forward_ref),
@@ -2650,7 +2650,7 @@ exports[`TermsAndConditions renders expanded 1`] = `
                                                                     </List__StyledListItem>
                                                                   </Item>
                                                                   <Item
-                                                                    key=".$Three"
+                                                                    key=".$2"
                                                                     styledComponent={
                                                                       Object {
                                                                         "$$typeof": Symbol(react.forward_ref),
@@ -4747,7 +4747,7 @@ exports[`TermsAndConditions renders expanded with indexedContent and nonIndexedC
                                                                   type="indexed"
                                                                 >
                                                                   <Item
-                                                                    key=".$One"
+                                                                    key=".$0"
                                                                     styledComponent={
                                                                       Object {
                                                                         "$$typeof": Symbol(react.forward_ref),
@@ -4812,7 +4812,7 @@ exports[`TermsAndConditions renders expanded with indexedContent and nonIndexedC
                                                                     </List__StyledListItem>
                                                                   </Item>
                                                                   <Item
-                                                                    key=".$Two"
+                                                                    key=".$1"
                                                                     styledComponent={
                                                                       Object {
                                                                         "$$typeof": Symbol(react.forward_ref),
@@ -4877,7 +4877,7 @@ exports[`TermsAndConditions renders expanded with indexedContent and nonIndexedC
                                                                     </List__StyledListItem>
                                                                   </Item>
                                                                   <Item
-                                                                    key=".$Three"
+                                                                    key=".$2"
                                                                     styledComponent={
                                                                       Object {
                                                                         "$$typeof": Symbol(react.forward_ref),
@@ -5528,7 +5528,7 @@ exports[`TermsAndConditions renders expanded with indexedContent and nonIndexedC
                                                                           type="nonIndexed"
                                                                         >
                                                                           <Item
-                                                                            key=".$Four"
+                                                                            key=".$0"
                                                                             styledComponent={
                                                                               Object {
                                                                                 "$$typeof": Symbol(react.forward_ref),
@@ -5593,7 +5593,7 @@ exports[`TermsAndConditions renders expanded with indexedContent and nonIndexedC
                                                                             </List__StyledListItem>
                                                                           </Item>
                                                                           <Item
-                                                                            key=".$Five"
+                                                                            key=".$1"
                                                                             styledComponent={
                                                                               Object {
                                                                                 "$$typeof": Symbol(react.forward_ref),
@@ -7712,7 +7712,7 @@ exports[`TermsAndConditions renders expanded with just nonIndexedContent 1`] = `
                                                                           type="nonIndexed"
                                                                         >
                                                                           <Item
-                                                                            key=".$Four"
+                                                                            key=".$0"
                                                                             styledComponent={
                                                                               Object {
                                                                                 "$$typeof": Symbol(react.forward_ref),
@@ -7777,7 +7777,7 @@ exports[`TermsAndConditions renders expanded with just nonIndexedContent 1`] = `
                                                                             </List__StyledListItem>
                                                                           </Item>
                                                                           <Item
-                                                                            key=".$Five"
+                                                                            key=".$1"
                                                                             styledComponent={
                                                                               Object {
                                                                                 "$$typeof": Symbol(react.forward_ref),


### PR DESCRIPTION
<!--
  ### IMPORTANT SECURITY NOTE ###

  When opening pull requests, be sure NOT to include any private or personal
  information such as secrets, passwords, or any source code that involves
  data retrieval.

  Also, do not include links to sites on staging.
-->

## Related issues

See #1485

## Description

<!-- 'Description' section is optional -->

Fixes key warning by using an index since `indexedContent` and `nonIndexContent` allows components

## Checklist before submitting pull request

Unfortunately having a number of issues running the environment - gitbook doesn't install.  Hoping this change is minor enough to submit?
