### PR TITLE
feat(core-step-tracker): remove background colour prop

### DIFF
--- a/packages/StepTracker/StepTracker.jsx
+++ b/packages/StepTracker/StepTracker.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-import { colorGreyAthens, colorWhite } from '@tds/core-colours'
+import { colorWhite } from '@tds/core-colours'
 import Text from '@tds/core-text'
 import FlexGrid from '@tds/core-flex-grid'
 import { getCopy, safeRest } from '@tds/util-helpers'
@@ -13,10 +13,10 @@ import copyDictionary from './stepTrackerText'
 
 import Step from './Step/Step'
 
-const StyledStepBg = styled.div(({ backgroundColour }) => ({
+const StyledStepBg = styled.div({
   padding: '1rem 0',
-  backgroundColor: backgroundColour === 'grey' ? colorGreyAthens : colorWhite,
-}))
+  backgroundColor: colorWhite,
+})
 
 const StyledStepContainer = styled.div({
   display: 'flex',
@@ -48,14 +48,7 @@ const getStepLabel = (current, steps) => {
  * @version ./package.json
  */
 
-const StepTracker = ({
-  current,
-  steps,
-  copy,
-  mobileStepLabelTemplate,
-  backgroundColour,
-  ...rest
-}) => {
+const StepTracker = ({ current, steps, copy, mobileStepLabelTemplate, ...rest }) => {
   if (mobileStepLabelTemplate && copy === undefined) {
     deprecate(
       'core-step-tracker',
@@ -70,11 +63,7 @@ const StepTracker = ({
   )
   const stepLabel = getStepLabel(current, steps)
   return (
-    <StyledStepBg
-      {...safeRest(rest)}
-      data-testid="stepTrackerContainer"
-      backgroundColour={backgroundColour}
-    >
+    <StyledStepBg {...safeRest(rest)} data-testid="stepTrackerContainer">
       <FlexGrid>
         <FlexGrid.Row>
           <FlexGrid.Col xs={12}>
@@ -141,16 +130,11 @@ StepTracker.propTypes = {
    * Use %current to place the current step and use %total to place the total amount of steps.
    */
   mobileStepLabelTemplate: PropTypes.string,
-  /**
-   * The background colour of the StepTracker.
-   */
-  backgroundColour: PropTypes.oneOf(['grey', 'white']),
 }
 
 StepTracker.defaultProps = {
   copy: undefined,
   mobileStepLabelTemplate: 'Step %{current} of %{total}:',
-  backgroundColour: 'grey',
 }
 
 export default StepTracker

--- a/packages/StepTracker/StepTracker.md
+++ b/packages/StepTracker/StepTracker.md
@@ -4,8 +4,6 @@ will indicate both the active step and the completed steps.
 `StepTracker` adjusts to accommodate smaller screens by hiding the labels, displaying only a summary. Resize your browser
 window to see this behavior.
 
-While a grey background is preferred, a white background is available through the use of the `backgroundColour` prop.
-
 **Note** this component is not interactive, so the user cannot use it to navigate through the steps. The application will
 need to provide its own navigation mechanism and state control. `StepTracker` also does not prevent the current step
 from reaching integers beyond the number of steps provided; the application must prevent negative or exceeding

--- a/packages/StepTracker/__tests__/__snapshots__/StepTracker.spec.jsx.snap
+++ b/packages/StepTracker/__tests__/__snapshots__/StepTracker.spec.jsx.snap
@@ -171,7 +171,7 @@ exports[`<StepTracker /> renders 1`] = `
 
 .c0 {
   padding: 1rem 0;
-  background-color: #f7f7f8;
+  background-color: #fff;
 }
 
 .c4 {


### PR DESCRIPTION
Sets background colour of StepTracker to white, removes grey option and prop.
<img width="927" alt="Screen Shot 2021-04-29 at 10 55 39 AM" src="https://user-images.githubusercontent.com/55095713/116581564-742b4480-a8e2-11eb-9524-0df055acc7ef.png">
