### PR TITLE
fix(core-button-link): use media hover to apply hover color

### DIFF
--- a/packages/ButtonLink/ButtonLink.jsx
+++ b/packages/ButtonLink/ButtonLink.jsx
@@ -59,8 +59,10 @@ const getHoverColor = (variant, rank) => {
 const hoverStyles = ({ variant, rank }) => {
   const hoverColor = getHoverColor(variant, rank)
   return {
-    '&:hover': {
-      color: hoverColor,
+    '@media(hover: hover)': {
+      '&:hover': {
+        color: hoverColor,
+      },
     },
   }
 }

--- a/packages/ButtonLink/__tests__/__snapshots__/ButtonLink.spec.jsx.snap
+++ b/packages/ButtonLink/__tests__/__snapshots__/ButtonLink.spec.jsx.snap
@@ -62,10 +62,6 @@ exports[`ButtonLink can be presented as one of the allowed fullwidth 1`] = `
   color: #fff;
 }
 
-.c0:hover {
-  color: #2B8000;
-}
-
 .c0:link,
 .c0:visited {
   width: 100%;
@@ -94,6 +90,12 @@ exports[`ButtonLink can be presented as one of the allowed fullwidth 1`] = `
   .c0 {
     -webkit-transition: none !important;
     transition: none !important;
+  }
+}
+
+@media (hover:hover) {
+  .c0:hover {
+    color: #2B8000;
   }
 }
 
@@ -166,10 +168,6 @@ exports[`ButtonLink can be presented as one of the allowed variants 1`] = `
   color: #fff;
 }
 
-.c0:hover {
-  color: #4b286d;
-}
-
 .c0:link,
 .c0:visited {
   width: auto;
@@ -198,6 +196,12 @@ exports[`ButtonLink can be presented as one of the allowed variants 1`] = `
   .c0 {
     -webkit-transition: none !important;
     transition: none !important;
+  }
+}
+
+@media (hover:hover) {
+  .c0:hover {
+    color: #4b286d;
   }
 }
 
@@ -281,10 +285,6 @@ exports[`ButtonLink can be presented as one of the allowed variants 2`] = `
   color: #fff;
 }
 
-.c0:hover {
-  color: #fff;
-}
-
 .c0:link,
 .c0:visited {
   width: auto;
@@ -313,6 +313,12 @@ exports[`ButtonLink can be presented as one of the allowed variants 2`] = `
   .c0 {
     -webkit-transition: none !important;
     transition: none !important;
+  }
+}
+
+@media (hover:hover) {
+  .c0:hover {
+    color: #fff;
   }
 }
 
@@ -385,10 +391,6 @@ exports[`ButtonLink renders 1`] = `
   color: #fff;
 }
 
-.c0:hover {
-  color: #2B8000;
-}
-
 .c0:link,
 .c0:visited {
   width: auto;
@@ -417,6 +419,12 @@ exports[`ButtonLink renders 1`] = `
   .c0 {
     -webkit-transition: none !important;
     transition: none !important;
+  }
+}
+
+@media (hover:hover) {
+  .c0:hover {
+    color: #2B8000;
   }
 }
 


### PR DESCRIPTION
## Description

This is a fix for applying hover effect for only devices that support it.

## Checklist before submitting pull request

- [x] New code is unit tested
- Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [ ] For code changes, run `npm run prepr` locally
  - make sure visual and accessibility tests pass
