### PR TITLE
fix(core-tooltip): add button type

### DIFF
--- a/packages/Tooltip/TooltipButton.jsx
+++ b/packages/Tooltip/TooltipButton.jsx
@@ -10,7 +10,7 @@ export const StyledIconButton = styled.button(buttons.noStyle)
 
 const TooltipButton = forwardRef(({ a11yText, inverted, onClick, icon: Icon }, ref) => {
   return (
-    <StyledIconButton onClick={onClick} ref={ref}>
+    <StyledIconButton onClick={onClick} ref={ref} type="button">
       <A11yContent>{a11yText}</A11yContent>
       <Icon color={inverted ? 'white' : 'greyShark'} />
     </StyledIconButton>

--- a/packages/Tooltip/__tests__/__snapshots__/Tooltip.spec.jsx.snap
+++ b/packages/Tooltip/__tests__/__snapshots__/Tooltip.spec.jsx.snap
@@ -511,6 +511,7 @@ exports[`Tooltip accessibility accepts custom copy 1`] = `
                   >
                     <TooltipButton__StyledIconButton
                       onClick={[Function]}
+                      type="button"
                     >
                       <StyledComponent
                         forwardedComponent={
@@ -545,10 +546,12 @@ exports[`Tooltip accessibility accepts custom copy 1`] = `
                         }
                         forwardedRef={null}
                         onClick={[Function]}
+                        type="button"
                       >
                         <button
                           className="c6"
                           onClick={[Function]}
+                          type="button"
                         >
                           <A11yContent>
                             <A11yContent__StyledA11yContent>
@@ -1172,6 +1175,7 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 1`] 
                   >
                     <TooltipButton__StyledIconButton
                       onClick={[Function]}
+                      type="button"
                     >
                       <StyledComponent
                         forwardedComponent={
@@ -1206,10 +1210,12 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 1`] 
                         }
                         forwardedRef={null}
                         onClick={[Function]}
+                        type="button"
                       >
                         <button
                           className="c6"
                           onClick={[Function]}
+                          type="button"
                         >
                           <A11yContent>
                             <A11yContent__StyledA11yContent>
@@ -1833,6 +1839,7 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 2`] 
                   >
                     <TooltipButton__StyledIconButton
                       onClick={[Function]}
+                      type="button"
                     >
                       <StyledComponent
                         forwardedComponent={
@@ -1867,10 +1874,12 @@ exports[`Tooltip interactivity hides the bubble when clicking outside of it 2`] 
                         }
                         forwardedRef={null}
                         onClick={[Function]}
+                        type="button"
                       >
                         <button
                           className="c6"
                           onClick={[Function]}
+                          type="button"
                         >
                           <A11yContent>
                             <A11yContent__StyledA11yContent>
@@ -3082,6 +3091,7 @@ exports[`Tooltip renders 1`] = `
                   >
                     <TooltipButton__StyledIconButton
                       onClick={[Function]}
+                      type="button"
                     >
                       <StyledComponent
                         forwardedComponent={
@@ -3116,10 +3126,12 @@ exports[`Tooltip renders 1`] = `
                         }
                         forwardedRef={null}
                         onClick={[Function]}
+                        type="button"
                       >
                         <button
                           className="c6"
                           onClick={[Function]}
+                          type="button"
                         >
                           <A11yContent>
                             <A11yContent__StyledA11yContent>


### PR DESCRIPTION
Relates to issue #1627 
prevents tooltip from submitting forms

<!--
  ### IMPORTANT SECURITY NOTE ###

  When opening pull requests, be sure NOT to include any private or personal
  information such as secrets, passwords, or any source code that involves
  data retrieval.

  Also, do not include links to sites on staging.
-->

## Description

Add `type=button` to Tooltip button to prevent it from submitting forms.

## Checklist before submitting pull request

- [x] New code is unit tested
- Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [x] For code changes, run `npm run prepr` locally
  - make sure visual and accessibility tests pass
