### PR TITLE
Fix/chevron link deprecated icon

### DIFF
--- a/packages/ChevronLink/ChevronLink.jsx
+++ b/packages/ChevronLink/ChevronLink.jsx
@@ -3,9 +3,8 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 import { componentWithName, or, htmlElement } from '@tds/util-prop-types'
-
+import { ChevronRight, ChevronLeft } from '@tds/core-interactive-icon'
 import Box from '@tds/core-box'
-import DecorativeIcon from '@tds/core-decorative-icon'
 import { medium, helveticaNeueRoman55 } from '@tds/shared-typography'
 import { colorPrimary, colorSecondary, colorWhite } from '@tds/core-colours'
 import { safeRest } from '@tds/util-helpers'
@@ -17,6 +16,12 @@ const base = {
   textDecoration: 'none',
   maxWidth: '100%',
   verticalAlign: 'top',
+}
+
+const variantDict = {
+  primary: 'default',
+  secondary: 'alternative',
+  inverted: 'inverted',
 }
 
 const StyledChevronLink = styled.a(medium, helveticaNeueRoman55, base, ({ variant }) => {
@@ -44,9 +49,10 @@ const StyledChevron = styled.span(({ direction }) => ({
   },
 }))
 
-const getIcon = (symbol, direction) => (
+const getIcon = (direction, variant) => (
   <StyledChevron direction={direction}>
-    <DecorativeIcon symbol={symbol} size={16} />
+    {direction === 'left' && <ChevronLeft size={16} variant={variant} />}
+    {direction === 'right' && <ChevronRight size={16} variant={variant} />}
   </StyledChevron>
 )
 
@@ -61,11 +67,13 @@ const ChevronLink = forwardRef(
       warn('Chevron Link', 'The props `reactRouterLinkComponent` and `to` must be used together.')
     }
 
+    const iconVariant = variantDict[variant]
+
     const innerLink = (
       <Box tag="span" inline between={2}>
-        {direction === 'left' ? getIcon('leftChevron', direction) : undefined}
+        {direction === 'left' ? getIcon(direction, iconVariant) : undefined}
         <span>{children}</span>
-        {direction === 'right' ? getIcon('chevron', direction) : undefined}
+        {direction === 'right' ? getIcon(direction, iconVariant) : undefined}
       </Box>
     )
 

--- a/packages/ChevronLink/__tests__/ChevronLink.spec.jsx
+++ b/packages/ChevronLink/__tests__/ChevronLink.spec.jsx
@@ -54,10 +54,10 @@ describe('ChevronLink', () => {
 
   it('has a chevron icon', () => {
     let link = doShallow({ href: 'https://telus.com' })
-    expect(link).toContainReact(<ChevronRight size={16} />)
+    expect(link).toContainReact(<ChevronRight size={16} variant="default" />)
 
     link = doShallow({ href: 'https://telus.com', direction: 'left' })
-    expect(link).toContainReact(<ChevronLeft size={16} />)
+    expect(link).toContainReact(<ChevronLeft size={16} variant="default" />)
   })
 
   it('can have specific variants', () => {

--- a/packages/ChevronLink/__tests__/ChevronLink.spec.jsx
+++ b/packages/ChevronLink/__tests__/ChevronLink.spec.jsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import { shallow, render, mount } from 'enzyme'
 
-import DecorativeIcon from '@tds/core-decorative-icon'
 import A11yContent from '../../A11yContent'
 
 import { warn } from '../../../shared/utils/warn'
 
 import ChevronLink from '../ChevronLink'
+import { ChevronLeft, ChevronRight } from '../../InteractiveIcon/index.cjs'
 
 jest.mock('../../../shared/utils/warn')
 
@@ -54,10 +54,10 @@ describe('ChevronLink', () => {
 
   it('has a chevron icon', () => {
     let link = doShallow({ href: 'https://telus.com' })
-    expect(link).toContainReact(<DecorativeIcon symbol="chevron" size={16} />)
+    expect(link).toContainReact(<ChevronRight size={16} />)
 
     link = doShallow({ href: 'https://telus.com', direction: 'left' })
-    expect(link).toContainReact(<DecorativeIcon symbol="leftChevron" size={16} />)
+    expect(link).toContainReact(<ChevronLeft size={16} />)
   })
 
   it('can have specific variants', () => {

--- a/packages/ChevronLink/__tests__/__snapshots__/ChevronLink.spec.jsx.snap
+++ b/packages/ChevronLink/__tests__/__snapshots__/ChevronLink.spec.jsx.snap
@@ -2,24 +2,21 @@
 
 exports[`ChevronLink can have specific variants 1`] = `
 .c4 {
-  font-family: 'TELUS Core Icons';
-  display: inline-block;
-  font-weight: normal;
-  font-style: normal;
-  speak: none;
-  -webkit-text-decoration: inherit;
-  text-decoration: inherit;
-  text-transform: none;
-  text-rendering: auto;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  line-height: 1;
-  vertical-align: middle;
-  font-size: 1rem;
+  fill: #2B8000;
+  width: 1.5rem;
+  height: 1.5rem;
+  z-index: 2;
+  -webkit-transition: -webkit-transform 150ms ease-in-out;
+  -webkit-transition: transform 150ms ease-in-out;
+  transition: transform 150ms ease-in-out;
 }
 
-.c4::before {
-  content: '\\f107';
+.c4:hover,
+.c4:focus,
+.c4:active {
+  -webkit-transform: translateX(4px);
+  -ms-transform: translateX(4px);
+  transform: translateX(4px);
 }
 
 .c2 {
@@ -70,6 +67,34 @@ exports[`ChevronLink can have specific variants 1`] = `
   transform: translateX(0.25rem);
 }
 
+@media (prefers-reduced-motion:reduce) {
+  .c4 {
+    -webkit-transition: none;
+    transition: none;
+  }
+}
+
+@media (prefers-reduced-motion:reduce) {
+  .c4 {
+    -webkit-transition: none;
+    transition: none;
+  }
+}
+
+@media (max-width:767px) {
+  .c4 {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+}
+
 <a
   class="c0 c1"
   direction="right"
@@ -85,10 +110,15 @@ exports[`ChevronLink can have specific variants 1`] = `
       class="c3"
       direction="right"
     >
-      <i
-        aria-hidden="true"
+      <svg
         class="c4"
-      />
+        size="16"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M9.18323023,17.7940812 C8.8825106,17.4424627 9.04504427,17.0896181 9.24527574,16.8868854 L13.740553,11.9968161 L9.24527573,7.11722187 C9.08145209,6.93839231 8.81996721,6.49053328 9.18323023,6.16524043 C9.54649326,5.83994757 9.91610528,6.06520964 10.0799289,6.24327169 L15.8766027,11.6348225 C16.0411324,11.8136521 16.0411324,12.1060729 15.8766027,12.2849025 C15.8758965,12.2849025 10.079929,17.7940809 10.079929,17.7940809 C9.93504267,17.9792355 9.48394985,18.1456996 9.18323023,17.7940812 Z"
+        />
+      </svg>
     </span>
   </span>
 </a>
@@ -96,24 +126,21 @@ exports[`ChevronLink can have specific variants 1`] = `
 
 exports[`ChevronLink can have specific variants 2`] = `
 .c4 {
-  font-family: 'TELUS Core Icons';
-  display: inline-block;
-  font-weight: normal;
-  font-style: normal;
-  speak: none;
-  -webkit-text-decoration: inherit;
-  text-decoration: inherit;
-  text-transform: none;
-  text-rendering: auto;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  line-height: 1;
-  vertical-align: middle;
-  font-size: 1rem;
+  fill: #4b286d;
+  width: 1.5rem;
+  height: 1.5rem;
+  z-index: 2;
+  -webkit-transition: -webkit-transform 150ms ease-in-out;
+  -webkit-transition: transform 150ms ease-in-out;
+  transition: transform 150ms ease-in-out;
 }
 
-.c4::before {
-  content: '\\f107';
+.c4:hover,
+.c4:focus,
+.c4:active {
+  -webkit-transform: translateX(4px);
+  -ms-transform: translateX(4px);
+  transform: translateX(4px);
 }
 
 .c2 {
@@ -164,6 +191,34 @@ exports[`ChevronLink can have specific variants 2`] = `
   transform: translateX(0.25rem);
 }
 
+@media (prefers-reduced-motion:reduce) {
+  .c4 {
+    -webkit-transition: none;
+    transition: none;
+  }
+}
+
+@media (prefers-reduced-motion:reduce) {
+  .c4 {
+    -webkit-transition: none;
+    transition: none;
+  }
+}
+
+@media (max-width:767px) {
+  .c4 {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+}
+
 <a
   class="c0 c1"
   direction="right"
@@ -179,10 +234,15 @@ exports[`ChevronLink can have specific variants 2`] = `
       class="c3"
       direction="right"
     >
-      <i
-        aria-hidden="true"
+      <svg
         class="c4"
-      />
+        size="16"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M9.18323023,17.7940812 C8.8825106,17.4424627 9.04504427,17.0896181 9.24527574,16.8868854 L13.740553,11.9968161 L9.24527573,7.11722187 C9.08145209,6.93839231 8.81996721,6.49053328 9.18323023,6.16524043 C9.54649326,5.83994757 9.91610528,6.06520964 10.0799289,6.24327169 L15.8766027,11.6348225 C16.0411324,11.8136521 16.0411324,12.1060729 15.8766027,12.2849025 C15.8758965,12.2849025 10.079929,17.7940809 10.079929,17.7940809 C9.93504267,17.9792355 9.48394985,18.1456996 9.18323023,17.7940812 Z"
+        />
+      </svg>
     </span>
   </span>
 </a>
@@ -190,24 +250,21 @@ exports[`ChevronLink can have specific variants 2`] = `
 
 exports[`ChevronLink can have specific variants 3`] = `
 .c4 {
-  font-family: 'TELUS Core Icons';
-  display: inline-block;
-  font-weight: normal;
-  font-style: normal;
-  speak: none;
-  -webkit-text-decoration: inherit;
-  text-decoration: inherit;
-  text-transform: none;
-  text-rendering: auto;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  line-height: 1;
-  vertical-align: middle;
-  font-size: 1rem;
+  fill: #2B8000;
+  width: 1.5rem;
+  height: 1.5rem;
+  z-index: 2;
+  -webkit-transition: -webkit-transform 150ms ease-in-out;
+  -webkit-transition: transform 150ms ease-in-out;
+  transition: transform 150ms ease-in-out;
 }
 
-.c4::before {
-  content: '\\f107';
+.c4:hover,
+.c4:focus,
+.c4:active {
+  -webkit-transform: translateX(4px);
+  -ms-transform: translateX(4px);
+  transform: translateX(4px);
 }
 
 .c2 {
@@ -258,6 +315,34 @@ exports[`ChevronLink can have specific variants 3`] = `
   transform: translateX(0.25rem);
 }
 
+@media (prefers-reduced-motion:reduce) {
+  .c4 {
+    -webkit-transition: none;
+    transition: none;
+  }
+}
+
+@media (prefers-reduced-motion:reduce) {
+  .c4 {
+    -webkit-transition: none;
+    transition: none;
+  }
+}
+
+@media (max-width:767px) {
+  .c4 {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+}
+
 <a
   class="c0 c1"
   direction="right"
@@ -273,10 +358,15 @@ exports[`ChevronLink can have specific variants 3`] = `
       class="c3"
       direction="right"
     >
-      <i
-        aria-hidden="true"
+      <svg
         class="c4"
-      />
+        size="16"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M9.18323023,17.7940812 C8.8825106,17.4424627 9.04504427,17.0896181 9.24527574,16.8868854 L13.740553,11.9968161 L9.24527573,7.11722187 C9.08145209,6.93839231 8.81996721,6.49053328 9.18323023,6.16524043 C9.54649326,5.83994757 9.91610528,6.06520964 10.0799289,6.24327169 L15.8766027,11.6348225 C16.0411324,11.8136521 16.0411324,12.1060729 15.8766027,12.2849025 C15.8758965,12.2849025 10.079929,17.7940809 10.079929,17.7940809 C9.93504267,17.9792355 9.48394985,18.1456996 9.18323023,17.7940812 Z"
+        />
+      </svg>
     </span>
   </span>
 </a>
@@ -284,24 +374,21 @@ exports[`ChevronLink can have specific variants 3`] = `
 
 exports[`ChevronLink can have specific variants 4`] = `
 .c4 {
-  font-family: 'TELUS Core Icons';
-  display: inline-block;
-  font-weight: normal;
-  font-style: normal;
-  speak: none;
-  -webkit-text-decoration: inherit;
-  text-decoration: inherit;
-  text-transform: none;
-  text-rendering: auto;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  line-height: 1;
-  vertical-align: middle;
-  font-size: 1rem;
+  fill: #fff;
+  width: 1.5rem;
+  height: 1.5rem;
+  z-index: 2;
+  -webkit-transition: -webkit-transform 150ms ease-in-out;
+  -webkit-transition: transform 150ms ease-in-out;
+  transition: transform 150ms ease-in-out;
 }
 
-.c4::before {
-  content: '\\f107';
+.c4:hover,
+.c4:focus,
+.c4:active {
+  -webkit-transform: translateX(4px);
+  -ms-transform: translateX(4px);
+  transform: translateX(4px);
 }
 
 .c2 {
@@ -352,6 +439,34 @@ exports[`ChevronLink can have specific variants 4`] = `
   transform: translateX(0.25rem);
 }
 
+@media (prefers-reduced-motion:reduce) {
+  .c4 {
+    -webkit-transition: none;
+    transition: none;
+  }
+}
+
+@media (prefers-reduced-motion:reduce) {
+  .c4 {
+    -webkit-transition: none;
+    transition: none;
+  }
+}
+
+@media (max-width:767px) {
+  .c4 {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+}
+
 <a
   class="c0 c1"
   direction="right"
@@ -367,10 +482,15 @@ exports[`ChevronLink can have specific variants 4`] = `
       class="c3"
       direction="right"
     >
-      <i
-        aria-hidden="true"
+      <svg
         class="c4"
-      />
+        size="16"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M9.18323023,17.7940812 C8.8825106,17.4424627 9.04504427,17.0896181 9.24527574,16.8868854 L13.740553,11.9968161 L9.24527573,7.11722187 C9.08145209,6.93839231 8.81996721,6.49053328 9.18323023,6.16524043 C9.54649326,5.83994757 9.91610528,6.06520964 10.0799289,6.24327169 L15.8766027,11.6348225 C16.0411324,11.8136521 16.0411324,12.1060729 15.8766027,12.2849025 C15.8758965,12.2849025 10.079929,17.7940809 10.079929,17.7940809 C9.93504267,17.9792355 9.48394985,18.1456996 9.18323023,17.7940812 Z"
+        />
+      </svg>
     </span>
   </span>
 </a>
@@ -378,24 +498,21 @@ exports[`ChevronLink can have specific variants 4`] = `
 
 exports[`ChevronLink renders 1`] = `
 .c4 {
-  font-family: 'TELUS Core Icons';
-  display: inline-block;
-  font-weight: normal;
-  font-style: normal;
-  speak: none;
-  -webkit-text-decoration: inherit;
-  text-decoration: inherit;
-  text-transform: none;
-  text-rendering: auto;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  line-height: 1;
-  vertical-align: middle;
-  font-size: 1rem;
+  fill: #2B8000;
+  width: 1.5rem;
+  height: 1.5rem;
+  z-index: 2;
+  -webkit-transition: -webkit-transform 150ms ease-in-out;
+  -webkit-transition: transform 150ms ease-in-out;
+  transition: transform 150ms ease-in-out;
 }
 
-.c4::before {
-  content: '\\f107';
+.c4:hover,
+.c4:focus,
+.c4:active {
+  -webkit-transform: translateX(4px);
+  -ms-transform: translateX(4px);
+  transform: translateX(4px);
 }
 
 .c2 {
@@ -446,6 +563,34 @@ exports[`ChevronLink renders 1`] = `
   transform: translateX(0.25rem);
 }
 
+@media (prefers-reduced-motion:reduce) {
+  .c4 {
+    -webkit-transition: none;
+    transition: none;
+  }
+}
+
+@media (prefers-reduced-motion:reduce) {
+  .c4 {
+    -webkit-transition: none;
+    transition: none;
+  }
+}
+
+@media (max-width:767px) {
+  .c4 {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+}
+
+@media (min-width:768px) {
+  .c4 {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+}
+
 <a
   class="c0 c1"
   direction="right"
@@ -461,10 +606,15 @@ exports[`ChevronLink renders 1`] = `
       class="c3"
       direction="right"
     >
-      <i
-        aria-hidden="true"
+      <svg
         class="c4"
-      />
+        size="16"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M9.18323023,17.7940812 C8.8825106,17.4424627 9.04504427,17.0896181 9.24527574,16.8868854 L13.740553,11.9968161 L9.24527573,7.11722187 C9.08145209,6.93839231 8.81996721,6.49053328 9.18323023,6.16524043 C9.54649326,5.83994757 9.91610528,6.06520964 10.0799289,6.24327169 L15.8766027,11.6348225 C16.0411324,11.8136521 16.0411324,12.1060729 15.8766027,12.2849025 C15.8758965,12.2849025 10.079929,17.7940809 10.079929,17.7940809 C9.93504267,17.9792355 9.48394985,18.1456996 9.18323023,17.7940812 Z"
+        />
+      </svg>
     </span>
   </span>
 </a>

--- a/packages/ChevronLink/package.json
+++ b/packages/ChevronLink/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@tds/core-box": "^2.4.0",
     "@tds/core-colours": "^2.2.1",
-    "@tds/core-decorative-icon": "^2.18.0",
+    "@tds/core-interactive-icon": "^2.4.0",
     "@tds/shared-typography": "^1.3.5",
     "@tds/util-helpers": "^1.6.0",
     "@tds/util-prop-types": "^1.4.0",


### PR DESCRIPTION
<!--
  ### IMPORTANT SECURITY NOTE ###

  When opening pull requests, be sure NOT to include any private or personal
  information such as secrets, passwords, or any source code that involves
  data retrieval.

  Also, do not include links to sites on staging.
-->

## Related issues

See [#https://github.com/telus/tds-core/issues/1598](https://github.com/telus/tds-core/issues/1598)

## Description
- remove deprecated dependency
- use ChevronRight and ChevronLeft from `code-interactive-icon`

## Checklist before submitting pull request

- [ ] New code is unit tested
- [X] New UI/UX is validated by `design team`
- Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [ ] For code changes, run `npm run prepr` locally
  - make sure visual and accessibility tests pass
