### PR TITLE
fix(esm): require is not defined when creating esm modules.

### DIFF
--- a/packages/Spinner/SpinnerSvg/SpinnerSvg.jsx
+++ b/packages/Spinner/SpinnerSvg/SpinnerSvg.jsx
@@ -1,13 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
+import { keyframes } from 'styled-components'
 
 import { colorAccessibleGreen, colorSecondary } from '@tds/core-colours'
 import Text from '@tds/core-text'
 import { uniqueId, safeRest } from '@tds/util-helpers'
-
-// TODO: use ES6 module import after rollup fixes this issue: https://github.com/rollup/rollup/issues/3011
-const keyframes = require('styled-components').keyframes
 
 const zindexPopover = 1600
 


### PR DESCRIPTION
## Description
That piece of CJS was breaking vite(esbuild) production build. I tried fixing it the way as in this PR in the build file of your package and it worked. Only thing is left to check the build by rollup whether that works well.
And also to the commented TODO issue in rollup: last comment in that issue states that it's not an issue anymore. Anyone can run tests on this? I'm not part of this project, need active contributors' support here.

## Checklist before submitting pull request

- [ ] New code is unit tested
- [ ] Commits follow our [Developer Guide](https://tds.telus.com/contributing/developer-guide.html#make-a-commit)
- [ ] For code changes, run `npm run prepr` locally
- [ ] make sure visual and accessibility tests pass
