### PR TITLE
Fix/input label and hint are not vertically aligned

### DIFF
--- a/packages/Input/Input.jsx
+++ b/packages/Input/Input.jsx
@@ -118,7 +118,9 @@ const renderLabel = (id, label, hint, hintPosition, hintId, tooltip) => (
           <Text size="medium" bold>
             {label}
           </Text>
-          {hint && hintPosition === 'inline' && renderHint(hint, Text, hintId)}
+          {hint && hintPosition === 'inline' && (
+            <span style={{ alignSelf: 'baseline' }}>{renderHint(hint, Text, hintId)}</span>
+          )}
         </StyledLabelContainer>
       </label>
       {tooltip && React.cloneElement(tooltip, { connectedFieldLabel: label })}

--- a/packages/Input/__tests__/__snapshots__/Input.spec.jsx.snap
+++ b/packages/Input/__tests__/__snapshots__/Input.spec.jsx.snap
@@ -696,67 +696,75 @@ Object {
                                         </StyledComponent>
                                       </Text__StyledText>
                                     </Text>
-                                    <Text
-                                      block={false}
-                                      bold={false}
-                                      invert={false}
-                                      size="small"
+                                    <span
+                                      style={
+                                        Object {
+                                          "alignSelf": "baseline",
+                                        }
+                                      }
                                     >
-                                      <Text__StyledText
+                                      <Text
                                         block={false}
                                         bold={false}
                                         invert={false}
                                         size="small"
                                       >
-                                        <StyledComponent
+                                        <Text__StyledText
                                           block={false}
                                           bold={false}
-                                          forwardedComponent={
-                                            Object {
-                                              "$$typeof": Symbol(react.forward_ref),
-                                              "attrs": Array [],
-                                              "componentStyle": ComponentStyle {
-                                                "componentId": "Text__StyledText-sc-1m0rr67-0",
-                                                "isStatic": false,
-                                                "lastClassName": "c4",
-                                                "rules": Array [
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  [Function],
-                                                  "sup {",
-                                                  "top: -0.5em;",
-                                                  "font-size: 0.875rem;",
-                                                  "position: relative;",
-                                                  "vertical-align: baseline;",
-                                                  "padding-left: 0.1em;",
-                                                  "}",
-                                                ],
-                                              },
-                                              "displayName": "Text__StyledText",
-                                              "foldedComponentIds": Array [],
-                                              "render": [Function],
-                                              "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
-                                              "target": "span",
-                                              "toString": [Function],
-                                              "warnTooManyClasses": [Function],
-                                              "withComponent": [Function],
-                                            }
-                                          }
-                                          forwardedRef={null}
                                           invert={false}
                                           size="small"
                                         >
-                                          <span
-                                            className="c4"
+                                          <StyledComponent
+                                            block={false}
+                                            bold={false}
+                                            forwardedComponent={
+                                              Object {
+                                                "$$typeof": Symbol(react.forward_ref),
+                                                "attrs": Array [],
+                                                "componentStyle": ComponentStyle {
+                                                  "componentId": "Text__StyledText-sc-1m0rr67-0",
+                                                  "isStatic": false,
+                                                  "lastClassName": "c4",
+                                                  "rules": Array [
+                                                    [Function],
+                                                    [Function],
+                                                    [Function],
+                                                    [Function],
+                                                    [Function],
+                                                    "sup {",
+                                                    "top: -0.5em;",
+                                                    "font-size: 0.875rem;",
+                                                    "position: relative;",
+                                                    "vertical-align: baseline;",
+                                                    "padding-left: 0.1em;",
+                                                    "}",
+                                                  ],
+                                                },
+                                                "displayName": "Text__StyledText",
+                                                "foldedComponentIds": Array [],
+                                                "render": [Function],
+                                                "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
+                                                "target": "span",
+                                                "toString": [Function],
+                                                "warnTooManyClasses": [Function],
+                                                "withComponent": [Function],
+                                              }
+                                            }
+                                            forwardedRef={null}
+                                            invert={false}
                                             size="small"
                                           >
-                                            The short hint
-                                          </span>
-                                        </StyledComponent>
-                                      </Text__StyledText>
-                                    </Text>
+                                            <span
+                                              className="c4"
+                                              size="small"
+                                            >
+                                              The short hint
+                                            </span>
+                                          </StyledComponent>
+                                        </Text__StyledText>
+                                      </Text>
+                                    </span>
                                   </span>
                                 </StyledComponent>
                               </styled.div>
@@ -1211,67 +1219,75 @@ Object {
                     </StyledComponent>
                   </Text__StyledText>
                 </Text>
-                <Text
-                  block={false}
-                  bold={false}
-                  invert={false}
-                  size="small"
+                <span
+                  style={
+                    Object {
+                      "alignSelf": "baseline",
+                    }
+                  }
                 >
-                  <Text__StyledText
+                  <Text
                     block={false}
                     bold={false}
                     invert={false}
                     size="small"
                   >
-                    <StyledComponent
+                    <Text__StyledText
                       block={false}
                       bold={false}
-                      forwardedComponent={
-                        Object {
-                          "$$typeof": Symbol(react.forward_ref),
-                          "attrs": Array [],
-                          "componentStyle": ComponentStyle {
-                            "componentId": "Text__StyledText-sc-1m0rr67-0",
-                            "isStatic": false,
-                            "lastClassName": "c3",
-                            "rules": Array [
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              [Function],
-                              "sup {",
-                              "top: -0.5em;",
-                              "font-size: 0.875rem;",
-                              "position: relative;",
-                              "vertical-align: baseline;",
-                              "padding-left: 0.1em;",
-                              "}",
-                            ],
-                          },
-                          "displayName": "Text__StyledText",
-                          "foldedComponentIds": Array [],
-                          "render": [Function],
-                          "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
-                          "target": "span",
-                          "toString": [Function],
-                          "warnTooManyClasses": [Function],
-                          "withComponent": [Function],
-                        }
-                      }
-                      forwardedRef={null}
                       invert={false}
                       size="small"
                     >
-                      <span
-                        className="c3"
+                      <StyledComponent
+                        block={false}
+                        bold={false}
+                        forwardedComponent={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "attrs": Array [],
+                            "componentStyle": ComponentStyle {
+                              "componentId": "Text__StyledText-sc-1m0rr67-0",
+                              "isStatic": false,
+                              "lastClassName": "c3",
+                              "rules": Array [
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                [Function],
+                                "sup {",
+                                "top: -0.5em;",
+                                "font-size: 0.875rem;",
+                                "position: relative;",
+                                "vertical-align: baseline;",
+                                "padding-left: 0.1em;",
+                                "}",
+                              ],
+                            },
+                            "displayName": "Text__StyledText",
+                            "foldedComponentIds": Array [],
+                            "render": [Function],
+                            "styledComponentId": "Text__StyledText-sc-1m0rr67-0",
+                            "target": "span",
+                            "toString": [Function],
+                            "warnTooManyClasses": [Function],
+                            "withComponent": [Function],
+                          }
+                        }
+                        forwardedRef={null}
+                        invert={false}
                         size="small"
                       >
-                        The short hint
-                      </span>
-                    </StyledComponent>
-                  </Text__StyledText>
-                </Text>
+                        <span
+                          className="c3"
+                          size="small"
+                        >
+                          The short hint
+                        </span>
+                      </StyledComponent>
+                    </Text__StyledText>
+                  </Text>
+                </span>
               </span>
             </StyledComponent>
           </styled.div>


### PR DESCRIPTION

Before:
<img width="699" alt="Before" src="https://user-images.githubusercontent.com/91989904/155563090-f4d6a24e-f220-422a-96de-179ca4840f33.png">

After:
<img width="997" alt="After" src="https://user-images.githubusercontent.com/91989904/155563220-b2232092-1c17-487f-9480-0f04282d9d50.png">

