### PR TITLE
Fix/web video show off centered in small resolutions

### DIFF
--- a/packages/WebVideo/WebVideo.jsx
+++ b/packages/WebVideo/WebVideo.jsx
@@ -10,7 +10,6 @@ import VideoSplash from '../../shared/components/VideoSplash/VideoSplash'
 
 const StyledPlayerContainer = styled.div({
   width: '100%',
-  minWidth: 288,
   outline: 'none',
 })
 

--- a/packages/WebVideo/__tests__/__snapshots__/WebVideo.spec.jsx.snap
+++ b/packages/WebVideo/__tests__/__snapshots__/WebVideo.spec.jsx.snap
@@ -213,7 +213,6 @@ exports[`WebVideo renders 1`] = `
 
 .c0 {
   width: 100%;
-  min-width: 288px;
   outline: none;
 }
 
@@ -266,7 +265,6 @@ exports[`WebVideo renders 1`] = `
             "lastClassName": "c0",
             "rules": Array [
               "width: 100%;",
-              "min-width: 288px;",
               "outline: none;",
             ],
           },


### PR DESCRIPTION
## Description

The webVideo component of tds-core show off centered in small resolutions.

##Before
<img width="602" alt="WebVideoImage" src="https://user-images.githubusercontent.com/91989904/156355920-59d1b2e4-429e-45cc-afa7-d78881bf60ec.png">

##After

https://user-images.githubusercontent.com/91989904/156356001-5ddf1f81-f945-4b3b-9cc2-e7328ff510ef.mov


