### PR TITLE
Feat/create a light font weight for h3 titles

### DIFF
--- a/docs/components/custom/MarkdownHeading/__tests__/__snapshots__/MarkdownHeading.spec.jsx.snap
+++ b/docs/components/custom/MarkdownHeading/__tests__/__snapshots__/MarkdownHeading.spec.jsx.snap
@@ -9,6 +9,7 @@ exports[`MarkdownHeading renders 1`] = `
   <Heading
     invert={false}
     level="h1"
+    light={false}
   >
     Some heading
   </Heading>

--- a/docs/components/custom/SectionHeading/__tests__/__snapshots__/SectionHeading.spec.jsx.snap
+++ b/docs/components/custom/SectionHeading/__tests__/__snapshots__/SectionHeading.spec.jsx.snap
@@ -16,6 +16,7 @@ exports[`SectionHeadingRenderer renders 1`] = `
     id="a-section"
     invert={false}
     level="h2"
+    light={false}
   >
     A Section
   </Heading>

--- a/packages/Heading/Heading.jsx
+++ b/packages/Heading/Heading.jsx
@@ -9,7 +9,7 @@ import {
   wordBreak,
   baseSupSubScripts,
 } from '@tds/shared-typography'
-import { colorWhite, colorText, colorSecondary } from '@tds/core-colours'
+import { colorWhite, colorText, colorSecondary, colorGreyRaven } from '@tds/core-colours'
 import { media } from '@tds/core-responsive'
 import { safeRest } from '@tds/util-helpers'
 
@@ -50,7 +50,6 @@ const HeadingLevels = {
     },
   },
   h3: {
-    ...helveticaNeueMedium65,
     fontSize: '1.25rem',
     lineHeight: '1.4', // 28px
     letterSpacing: '-0.6px',
@@ -72,11 +71,21 @@ const HeadingLevels = {
     },
   },
 }
-export const StyledHeading = styled.h1(wordBreak, ({ level, invert }) => {
+export const StyledHeading = styled.h1(wordBreak, ({ level, tag, invert, light }) => {
   const baseColor = level === 'h1' || level === 'h2' ? colorSecondary : colorText
-  const color = invert ? colorWhite : baseColor
+  // eslint-disable-next-line no-nested-ternary
+  const color = invert
+    ? colorWhite
+    : level === 'h3' && light && tag === 'h3'
+    ? colorGreyRaven
+    : baseColor
+  const fontWeight =
+    level === 'h3' && light && tag === 'h3'
+      ? helveticaNeueLight45.fontWeight
+      : helveticaNeueMedium65.fontWeight
   return {
     color,
+    fontWeight,
     ...HeadingLevels[`${level}`],
     '& > span': {
       letterSpacing: 'inherit',
@@ -89,7 +98,7 @@ export const StyledHeading = styled.h1(wordBreak, ({ level, invert }) => {
  *
  * @version ./package.json
  */
-const Heading = forwardRef(({ level, tag = level, invert, children, ...rest }, ref) => {
+const Heading = forwardRef(({ level, tag = level, invert, light, children, ...rest }, ref) => {
   return (
     <StyledHeading
       {...safeRest(rest)}
@@ -97,6 +106,8 @@ const Heading = forwardRef(({ level, tag = level, invert, children, ...rest }, r
       as={tag}
       level={level}
       invert={invert}
+      light={light}
+      tag={tag}
       data-testid="heading"
     >
       {children}
@@ -120,6 +131,10 @@ Heading.propTypes = {
    */
   invert: PropTypes.bool,
   /**
+   * Apply a light text color on the h3 tags.
+   */
+  light: PropTypes.bool,
+  /**
    * The content. Can be text, other components, or HTML elements.
    */
   children: PropTypes.node.isRequired,
@@ -127,6 +142,7 @@ Heading.propTypes = {
 Heading.defaultProps = {
   invert: false,
   tag: undefined,
+  light: false,
 }
 
 export default Heading

--- a/packages/TermsAndConditions/__tests__/__snapshots__/TermsAndConditions.spec.jsx.snap
+++ b/packages/TermsAndConditions/__tests__/__snapshots__/TermsAndConditions.spec.jsx.snap
@@ -1620,6 +1620,7 @@ exports[`TermsAndConditions renders expanded 1`] = `
                                               <Heading
                                                 invert={false}
                                                 level="h4"
+                                                light={false}
                                                 tag="h2"
                                               >
                                                 <Heading__StyledHeading
@@ -1627,6 +1628,8 @@ exports[`TermsAndConditions renders expanded 1`] = `
                                                   data-testid="heading"
                                                   invert={false}
                                                   level="h4"
+                                                  light={false}
+                                                  tag="h2"
                                                 >
                                                   <StyledComponent
                                                     as="h2"
@@ -1657,6 +1660,8 @@ exports[`TermsAndConditions renders expanded 1`] = `
                                                     forwardedRef={null}
                                                     invert={false}
                                                     level="h4"
+                                                    light={false}
+                                                    tag="h2"
                                                   >
                                                     <h2
                                                       className="c10"
@@ -3847,6 +3852,7 @@ exports[`TermsAndConditions renders expanded with indexedContent and nonIndexedC
                                               <Heading
                                                 invert={false}
                                                 level="h4"
+                                                light={false}
                                                 tag="h2"
                                               >
                                                 <Heading__StyledHeading
@@ -3854,6 +3860,8 @@ exports[`TermsAndConditions renders expanded with indexedContent and nonIndexedC
                                                   data-testid="heading"
                                                   invert={false}
                                                   level="h4"
+                                                  light={false}
+                                                  tag="h2"
                                                 >
                                                   <StyledComponent
                                                     as="h2"
@@ -3884,6 +3892,8 @@ exports[`TermsAndConditions renders expanded with indexedContent and nonIndexedC
                                                     forwardedRef={null}
                                                     invert={false}
                                                     level="h4"
+                                                    light={false}
+                                                    tag="h2"
                                                   >
                                                     <h2
                                                       className="c10"
@@ -5240,6 +5250,7 @@ exports[`TermsAndConditions renders expanded with indexedContent and nonIndexedC
                                                                   <Heading
                                                                     invert={false}
                                                                     level="h4"
+                                                                    light={false}
                                                                     tag="span"
                                                                   >
                                                                     <Heading__StyledHeading
@@ -5247,6 +5258,8 @@ exports[`TermsAndConditions renders expanded with indexedContent and nonIndexedC
                                                                       data-testid="heading"
                                                                       invert={false}
                                                                       level="h4"
+                                                                      light={false}
+                                                                      tag="span"
                                                                     >
                                                                       <StyledComponent
                                                                         as="span"
@@ -5277,6 +5290,8 @@ exports[`TermsAndConditions renders expanded with indexedContent and nonIndexedC
                                                                         forwardedRef={null}
                                                                         invert={false}
                                                                         level="h4"
+                                                                        light={false}
+                                                                        tag="span"
                                                                       >
                                                                         <span
                                                                           className="c10"
@@ -6765,6 +6780,7 @@ exports[`TermsAndConditions renders expanded with just nonIndexedContent 1`] = `
                                               <Heading
                                                 invert={false}
                                                 level="h4"
+                                                light={false}
                                                 tag="h2"
                                               >
                                                 <Heading__StyledHeading
@@ -6772,6 +6788,8 @@ exports[`TermsAndConditions renders expanded with just nonIndexedContent 1`] = `
                                                   data-testid="heading"
                                                   invert={false}
                                                   level="h4"
+                                                  light={false}
+                                                  tag="h2"
                                                 >
                                                   <StyledComponent
                                                     as="h2"
@@ -6802,6 +6820,8 @@ exports[`TermsAndConditions renders expanded with just nonIndexedContent 1`] = `
                                                     forwardedRef={null}
                                                     invert={false}
                                                     level="h4"
+                                                    light={false}
+                                                    tag="h2"
                                                   >
                                                     <h2
                                                       className="c10"


### PR DESCRIPTION
## Description
See [#1600](https://github.com/telus/tds-core/issues/1600)
Create a light font weight for H3 Heading titles tds-core component.


https://user-images.githubusercontent.com/91989904/156361323-4182eb0e-34b4-418c-a0f1-1919028acb00.mov

