### PR TITLE
TDS sunset warning added for Core components and Gitbook pages

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,19 +4,20 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 **Describe the bug**
+
 > We're sunsetting the maintenance of TDS
-> Make sure to verify if your bug has [not been fixed](https://github.com/telus/universal-design-system) yet in [UDS / Allium](https://sites.google.com/telus.com/thinkcontentxdesign/about-us-our-products/allium)
-> We encourage everyone to switch to UDS / Allium
-Either way, feel free to fix the issue if you can't switch / pick the corresponding component from Allium.
+> Make sure to verify if your bug has [not been fixed](https://github.com/telus/universal-design-system/issues) yet in [UDS](https://github.com/telus/universal-design-system)
+> We encourage everyone to switch to UDS
+> Either way, feel free to fix the issue if you can't switch / pick the corresponding component from UDS.
 
 A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -29,15 +30,17 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_template.md
@@ -4,13 +4,12 @@ about: Suggest an idea for tds-core
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 > We're sunsetting the maintenance of TDS
-> Make sure to verify if your bug has [not been fixed](https://github.com/telus/universal-design-system) yet in [UDS / Allium](https://sites.google.com/telus.com/thinkcontentxdesign/about-us-our-products/allium)
-> We encourage everyone to switch to UDS / Allium
-Either way, feel free to fix the issue if you can't switch / pick the corresponding component from Allium.
+> Make sure to verify if your bug has [not been fixed](https://github.com/telus/universal-design-system/issues) yet in [UDS](https://github.com/telus/universal-design-system)
+> We encourage everyone to switch to UDS
+> Either way, feel free to fix the issue if you can't switch / pick the corresponding component from UDS.
 
 <!--
   ### IMPORTANT SECURITY NOTE ###

--- a/.github/ISSUE_TEMPLATE/icon_template.md
+++ b/.github/ISSUE_TEMPLATE/icon_template.md
@@ -4,13 +4,12 @@ about: Request a new icon
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 > We're sunsetting the maintenance of TDS
-> Make sure to verify if your bug has [not been fixed](https://github.com/telus/universal-design-system) yet in [UDS / Allium](https://sites.google.com/telus.com/thinkcontentxdesign/about-us-our-products/allium)
-> We encourage everyone to switch to UDS / Allium
-Either way, feel free to fix the issue if you can't switch / pick the corresponding component from Allium.
+> Make sure to verify if your bug has [not been fixed](https://github.com/telus/universal-design-system/issues) yet in [UDS](https://github.com/telus/universal-design-system/)
+> We encourage everyone to switch to UDS
+> Either way, feel free to fix the issue if you can't switch / pick the corresponding component from UDS.
 
 <!--
   ### IMPORTANT SECURITY NOTE ###
@@ -22,7 +21,7 @@ Either way, feel free to fix the issue if you can't switch / pick the correspond
   Also, do not include links to sites on staging.
 -->
 
-<!-- 
+<!--
   ### TDS Timeline for releasing icons ###
 
   New icon requests will be released midway in the next month.
@@ -37,7 +36,7 @@ Either way, feel free to fix the issue if you can't switch / pick the correspond
 ## Actions
 
 1. Did you check to see if there are icons available in TDS that can be used instead? Yes/No
-2. Is your proposed icon from the TELUS Brand-approved set from one of the appointed designers*? Yes/No
+2. Is your proposed icon from the TELUS Brand-approved set from one of the appointed designers\*? Yes/No
 3. If your design lead has approved this change, please note their name: [design lead name]
 4. If the art director has approved this change, please have them **comment on this issue**.
 

--- a/config/styleguide.config.js
+++ b/config/styleguide.config.js
@@ -516,6 +516,10 @@ module.exports = {
           test: /\.(png|jpg|svg)$/,
           use: 'url-loader',
         },
+        {
+          test: /\.html$/i,
+          loader: 'html-loader',
+        },
       ],
     },
   },

--- a/docs/Lists.md
+++ b/docs/Lists.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/list">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/list">
         List
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/docs/Typography.md
+++ b/docs/Typography.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/typography">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/typography">
         Typography
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/docs/components/overrides/StyleGuide/StyleGuideRenderer.js
+++ b/docs/components/overrides/StyleGuide/StyleGuideRenderer.js
@@ -8,6 +8,7 @@ import Markdown from 'rsg-components/Markdown'
 import FlexGrid from '../../../../packages/FlexGrid/FlexGrid'
 import CSSReset from '../../../../packages/css-reset'
 import GlobalStyleGuide from './GlobalStyleGuide'
+import tdsSunsetWarning from '../../../../guide/tds-sunset.html'
 
 const styles = ({ color, fontFamily, fontSize, sidebarWidth, mq, space, maxWidth }) => ({
   root: {
@@ -78,6 +79,7 @@ const TdsGrid = ({ children }) => (
 export function StyleGuideRenderer({ classes, title, homepageUrl, children, toc, hasSidebar }) {
   const main = (
     <main className={cx(hasSidebar && classes.content)}>
+      <div dangerouslySetInnerHTML={{ __html: tdsSunsetWarning }} />
       {children}
       <footer className={classes.footer}>
         <Markdown text={`Generated with [React Styleguidist](${homepageUrl})`} />

--- a/docs/icons.md
+++ b/docs/icons.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/icon">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/icon">
         Icons
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/guide/README.md
+++ b/guide/README.md
@@ -1,27 +1,31 @@
 # TELUS Design System
 
-<div style="display: flex; flex-direction: row; wrap: nowrap; padding: 1rem; background-color: rgb(255, 249, 238); margin-bottom: 1rem;">
+<div
+  style="display: flex; flex-direction: row; wrap: nowrap; padding: 1rem; background-color: rgb(255, 248, 230); margin-bottom: 1rem; border: 1px solid rgb(230, 167, 0); border-radius: 6px;">
   <div style="margin-right: 1rem; height: 100%;">
     <svg style="display: inline-block; vertical-align: middle;" width="20" height="20">
-      <path
-        fill="#8C5415"
-        fill-rule="evenodd"
-        d="M10.878 1.61l8.315 15.244a1 1 0 0 1-.878 1.48H1.685a1 1 0 0 1-.878-1.48L9.122 1.61a1 1 0 0 1 1.756 0zM10 16.794c.46 0 .833-.402.833-.898 0-.495-.373-.897-.833-.897-.46 0-.833.402-.833.897 0 .496.373.898.833.898zm-.022-2.885c.347 0 .63-.297.64-.67l.179-6.698c.01-.388-.28-.709-.64-.709h-.35c-.361 0-.65.32-.64.708l.171 6.699c.01.373.294.67.64.67z"
-      />
+      <path fill="#8C5415" fill-rule="evenodd"
+        d="M10.878 1.61l8.315 15.244a1 1 0 0 1-.878 1.48H1.685a1 1 0 0 1-.878-1.48L9.122 1.61a1 1 0 0 1 1.756 0zM10 16.794c.46 0 .833-.402.833-.898 0-.495-.373-.897-.833-.897-.46 0-.833.402-.833.897 0 .496.373.898.833.898zm-.022-2.885c.347 0 .63-.297.64-.67l.179-6.698c.01-.388-.28-.709-.64-.709h-.35c-.361 0-.65.32-.64.708l.171 6.699c.01.373.294.67.64.67z" />
     </svg>
   </div>
   <div>
     <p>
-      The evolution of the TELUS brand continues! The brand new <a href="https://telus.github.io/allium-design-system/">Allium Design System</a> is now available and all teams are encouraged to transition their applications to Allium components in order to better reflect the latest vision of the TELUS brand.
+      The evolution of the TELUS brand continues! The brand new <a
+        href="https://telus.github.io/universal-design-system/">Universal Design System</a> is now available and all
+      teams are
+      encouraged to transition their applications to UDS components in order to better reflect the latest vision of
+      the TELUS brand.
     </p>
     <p>TDS Core and TDS Community will continue with limited support and restrict new feature requests.</p>
     <p>While diving into this documentation, you’ll notice some new updates:</p>
     <ul>
-      <li>We’ll provide direct links to corresponding Allium component from either tds-core / tds-community</li>
-      <li>We’ll provide notice about deprecated components (that may not be implemented on Allium in the near future)</li>
+      <li>We’ll provide direct links to corresponding UDS components from either tds-core / tds-community</li>
+      <li>We’ll provide notice about deprecated components (that may not be implemented on UDS in the near future)
+      </li>
     </ul>
     <p style="margin-bottom: 0;">
-      <a href="/contact.html">Contact us</a> for more information on how to get support. And <a href="https://telusdigital.slack.com/archives/C2WK9TP5F">join our TELUS Slack channel</a> for updates.
+      <a href="/contact.html">Contact us</a> for more information on how to get support. And <a
+        href="https://telusdigital.slack.com/archives/C2WK9TP5F">join our TELUS Slack channel</a> for updates.
     </p>
   </div>
 </div>

--- a/guide/SUMMARY.md
+++ b/guide/SUMMARY.md
@@ -1,3 +1,5 @@
+!INCLUDE "tds-sunset.html"
+
 ## TELUS Design System
 
 - [Home](README.md)

--- a/guide/accessibility/accessibility.md
+++ b/guide/accessibility/accessibility.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Accessibility
 
 The TDS documentation is a starting point for accessibility information.

--- a/guide/accessibility/colour-contrast.md
+++ b/guide/accessibility/colour-contrast.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Colour and contrast
 
 ## Overview

--- a/guide/accessibility/content.md
+++ b/guide/accessibility/content.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Content
 
 ## Overview

--- a/guide/accessibility/keyboard-nav.md
+++ b/guide/accessibility/keyboard-nav.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Keyboard Navigation
 
 ## Overview

--- a/guide/accessibility/responsive-content.md
+++ b/guide/accessibility/responsive-content.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Responsive content
 
 When coding page content for all users, we consider the following:

--- a/guide/accessibility/screen-readers.md
+++ b/guide/accessibility/screen-readers.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Screen Readers
 
 ## Overview
@@ -12,5 +14,5 @@ See the [TELUS Standards site](https://digitalstandards.telus.com/accessibility)
 
 ## Governance
 
-The TELUS digital accessibility is managed by Operations: Security and Accessibility. If you have any questions or concerns 
+The TELUS digital accessibility is managed by Operations: Security and Accessibility. If you have any questions or concerns
 regarding designing or developing in an accessible manner please contact Oskar Westin.

--- a/guide/announcements.md
+++ b/guide/announcements.md
@@ -1,3 +1,5 @@
+!INCLUDE "tds-sunset.html"
+
 # TDS Announcement Board 📣
 
 Welcome to the TDS Announcement Board! Check back here regularly for the latest updates on TDS!

--- a/guide/book.json
+++ b/guide/book.json
@@ -1,7 +1,14 @@
 {
   "title": "TELUS Design System",
   "gitbook": "3.2.2",
-  "plugins": ["otherlink", "collapsible-menu", "insert-logo-link", "-sharing", "edit-link"],
+  "plugins": [
+    "otherlink",
+    "collapsible-menu",
+    "insert-logo-link",
+    "-sharing",
+    "edit-link",
+    "include-html"
+  ],
   "pluginsConfig": {
     "edit-link": {
       "base": "https://github.com/telus/tds-core/tree/master/guide",

--- a/guide/contact.md
+++ b/guide/contact.md
@@ -1,6 +1,8 @@
+!INCLUDE "tds-sunset.html"
+
 # Contact us
 
-<div style="display: flex; flex-direction: row; wrap: nowrap; padding: 1rem; background-color: rgb(255, 249, 238); margin-bottom: 1rem;">
+<div style="display: flex; flex-direction: row; wrap: nowrap; padding: 1rem; background-color: rgb(255, 248, 230); margin-bottom: 1rem; border: 1px solid rgb(230, 167, 0); border-radius: 6px;">
   <div style="margin-right: 1rem; height: 100%;">
     <svg style="display: inline-block; vertical-align: middle;" width="20" height="20">
       <path

--- a/guide/contributing/codebase-overview.md
+++ b/guide/contributing/codebase-overview.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Codebase overview
 
 A description of the structure of the codebase, conventions being followed, and patterns.

--- a/guide/contributing/contributing-standards.md
+++ b/guide/contributing/contributing-standards.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Contributing standards
 
 The TELUS Design System maintains a set of standards and practices for core components and community components.

--- a/guide/contributing/contributing.md
+++ b/guide/contributing/contributing.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Contributing to TDS
 
 Role-specific guides and resources:

--- a/guide/contributing/designer-guide.md
+++ b/guide/contributing/designer-guide.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Contributing to TDS - designer guide
 
 Guidelines & Standards

--- a/guide/contributing/developer-guide.md
+++ b/guide/contributing/developer-guide.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Contributing to TDS - developer guide
 
 ## Contents

--- a/guide/design/colour.md
+++ b/guide/design/colour.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Colour
 
 ## Overview

--- a/guide/design/depth.md
+++ b/guide/design/depth.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Depth
 
 Coming soon...

--- a/guide/design/dividers.md
+++ b/guide/design/dividers.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Dividers
 
 ## Overview

--- a/guide/design/heuristics.md
+++ b/guide/design/heuristics.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # TELUS Usability Heuristics
 
 Usability heuristics are a list of design principles against which the usability of an interface can be assessed.

--- a/guide/design/iconography.md
+++ b/guide/design/iconography.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Iconography
 
 ## Overview

--- a/guide/design/imagery.md
+++ b/guide/design/imagery.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Imagery
 
 ## Overview

--- a/guide/design/layout.md
+++ b/guide/design/layout.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Layout
 
 ## Overview

--- a/guide/design/motion.md
+++ b/guide/design/motion.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Motion Principles
 
 Check out the Motion principles on [The Brand Resource Centre (BRC)](https://www.telus.com/en/brand-resources/design/motion-principles)

--- a/guide/design/principles.md
+++ b/guide/design/principles.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Design Principles
 
 The TELUS design principles are a simple set of rules that enable teams to craft great digital experiences. All experiences

--- a/guide/design/typography.md
+++ b/guide/design/typography.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Typography
 
 ## Overview

--- a/guide/design/writing.md
+++ b/guide/design/writing.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Writing
 
 ## Overview

--- a/guide/faq.md
+++ b/guide/faq.md
@@ -1,3 +1,5 @@
+!INCLUDE "tds-sunset.html"
+
 # FAQs
 
 ## A TDS component does not do what I need. What do I do?

--- a/guide/getting-started/designers.md
+++ b/guide/getting-started/designers.md
@@ -1,6 +1,8 @@
+!INCLUDE "../tds-sunset.html"
+
 # Getting started - designer guide
 
-<div style="display: flex; flex-direction: row; wrap: nowrap; padding: 1rem; background-color: rgb(255, 249, 238); margin-bottom: 1rem;">
+<div style="display: flex; flex-direction: row; wrap: nowrap; padding: 1rem; background-color: rgb(255, 248, 230); margin-bottom: 1rem; border: 1px solid rgb(230, 167, 0); border-radius: 6px;">
   <div style="margin-right: 1rem; height: 100%;">
     <svg style="display: inline-block; vertical-align: middle;" width="20" height="20">
       <path

--- a/guide/getting-started/developers.md
+++ b/guide/getting-started/developers.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Getting started - developer guide
 
 As a developer, your primary interaction point with TDS is through React components. These components are independent, composable components distributed as individual packages.

--- a/guide/getting-started/getting-started.md
+++ b/guide/getting-started/getting-started.md
@@ -1,3 +1,5 @@
+!INCLUDE "../tds-sunset.html"
+
 # Getting started
 
 TDS includes resources for designers and developers that are needed to build consistent user interfaces on the TELUS Digital Platform. TDS enables designers and developers to focus on solving unique application challenges, rather than having to reinvent standard interface elements.

--- a/guide/roadmap.md
+++ b/guide/roadmap.md
@@ -1,3 +1,5 @@
+!INCLUDE "tds-sunset.html"
+
 # Roadmap
 
 We plan the TELUS Design System (TDS) roadmap based on the priorities of TELUS and partner teams. In addition, we coordinate with the other Digital Platform teams to provide a comprehensive system for building rich Web experiences in the TELUS ecosystem.

--- a/guide/tds-sunset.html
+++ b/guide/tds-sunset.html
@@ -1,0 +1,29 @@
+<div
+  style="display: flex; flex-direction: row; wrap: nowrap; padding: 1rem; background-color: rgb(255, 248, 230); margin-bottom: 1rem; border: 1px solid rgb(230, 167, 0); border-radius: 6px;">
+  <div style="margin-right: 1rem; height: 100%;">
+    <svg style="display: inline-block; vertical-align: middle;" width="20" height="20">
+      <path fill="#8C5415" fill-rule="evenodd"
+        d="M10.878 1.61l8.315 15.244a1 1 0 0 1-.878 1.48H1.685a1 1 0 0 1-.878-1.48L9.122 1.61a1 1 0 0 1 1.756 0zM10 16.794c.46 0 .833-.402.833-.898 0-.495-.373-.897-.833-.897-.46 0-.833.402-.833.897 0 .496.373.898.833.898zm-.022-2.885c.347 0 .63-.297.64-.67l.179-6.698c.01-.388-.28-.709-.64-.709h-.35c-.361 0-.65.32-.64.708l.171 6.699c.01.373.294.67.64.67z" />
+    </svg>
+  </div>
+  <div>
+    <p>
+      The evolution of the TELUS brand continues! The brand new <a
+        href="https://telus.github.io/universal-design-system/">Universal Design System</a> is now available and all
+      teams are
+      encouraged to transition their applications to UDS components in order to better reflect the latest vision of
+      the TELUS brand.
+    </p>
+    <p>TDS Core and TDS Community will continue with limited support and restrict new feature requests.</p>
+    <p>While diving into this documentation, you’ll notice some new updates:</p>
+    <ul>
+      <li>We’ll provide direct links to corresponding UDS components from either tds-core / tds-community</li>
+      <li>We’ll provide notice about deprecated components (that may not be implemented on UDS in the near future)
+      </li>
+    </ul>
+    <p style="margin-bottom: 0;">
+      <a href="/contact.html">Contact us</a> for more information on how to get support. And <a
+        href="https://telusdigital.slack.com/archives/C2WK9TP5F">join our TELUS Slack channel</a> for updates.
+    </p>
+  </div>
+</div>

--- a/guide/v3-upgrade.md
+++ b/guide/v3-upgrade.md
@@ -1,3 +1,5 @@
+!INCLUDE "tds-sunset.html"
+
 # Upgrading to TDS V3
 
 TDS has now moved feature support from V2: Split Components to V3: Styled Components of the design system. This was done primarily to facilitate the use of styled-components V4. For a detailed view of our sunsetting schedule, please read our [roadmap page](roadmap.md). Additionally, more information on this subject can be found on the [Reference Architecture CSS Document](https://github.com/telus/reference-architecture/blob/bb7059d135574c380d2865aa1bbdd633c2345461/development/css.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -3087,7 +3087,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
 			"integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
-			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.2"
 			}
@@ -8611,6 +8610,11 @@
 			"integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
 			"dev": true
 		},
+		"array-find-es6": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/array-find-es6/-/array-find-es6-2.0.3.tgz",
+			"integrity": "sha512-35QZe7bM24H1Q+tAhFRVp6mUsCD+M1zREs45fjeiVqF2OAgzly76tcCjBISvu4AlR6slKv1oDaYr4KlPmzBKZA=="
+		},
 		"array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -8924,6 +8928,25 @@
 				"url": "0.10.3",
 				"uuid": "3.3.2",
 				"xml2js": "0.4.19"
+			},
+			"dependencies": {
+				"buffer": {
+					"version": "4.9.2",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+					"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+					"dev": true,
+					"requires": {
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4",
+						"isarray": "^1.0.0"
+					}
+				},
+				"ieee754": {
+					"version": "1.1.13",
+					"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+					"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+					"dev": true
+				}
 			}
 		},
 		"aws-sign2": {
@@ -9698,7 +9721,7 @@
 		"bash-color": {
 			"version": "0.0.4",
 			"resolved": "https://registry.npmjs.org/bash-color/-/bash-color-0.0.4.tgz",
-			"integrity": "sha1-6b6M4zVAytpIgXaMWb1jhlc26RM=",
+			"integrity": "sha512-ZNB4525U7BxT6v9C8LEtywyCgB4Pjnm7/bh+ru/Z9Ecxvg3fDjaJ6z305z9a61orQdbB1zqYHh5JbUqx4s4K0g==",
 			"dev": true
 		},
 		"batch": {
@@ -10254,12 +10277,6 @@
 				}
 			}
 		},
-		"cachedir": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.1.0.tgz",
-			"integrity": "sha512-xGBpPqoBvn3unBW7oxgb8aJn42K0m9m1/wyjmazah10Fq7bROGG3kRAE6OIyr3U3PIJUqGuebhCEdMk9OKJG0A==",
-			"dev": true
-		},
 		"call-me-maybe": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
@@ -10297,6 +10314,24 @@
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"dev": true
+		},
+		"camel-case": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+			"integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+			"dev": true,
+			"requires": {
+				"pascal-case": "^3.1.2",
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+					"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+					"dev": true
+				}
+			}
 		},
 		"camelcase": {
 			"version": "4.1.0",
@@ -10570,6 +10605,23 @@
 			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
 			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
 			"dev": true
+		},
+		"clean-css": {
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
+			"integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
+			"dev": true,
+			"requires": {
+				"source-map": "~0.6.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
 		},
 		"clean-stack": {
 			"version": "2.1.0",
@@ -11057,39 +11109,88 @@
 					"dev": true
 				},
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+					"integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
 					"dev": true
+				},
+				"cachedir": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.2.0.tgz",
+					"integrity": "sha512-VvxA0xhNqIIfg0V9AmJkDg91DaJwryutH5rVEZAhcNi4iJFj9f+QxmAjgK1LT9I8OgToX27fypX6/MeCXVbBjQ==",
+					"dev": true
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
 				},
 				"cli-cursor": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+					"integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
 					"dev": true,
 					"requires": {
 						"restore-cursor": "^2.0.0"
 					}
 				},
 				"cli-width": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-					"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+					"integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+					"dev": true
+				},
+				"cz-conventional-changelog": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.0.1.tgz",
+					"integrity": "sha512-7KASIwB8/ClEyCRvQrCPbN7WkQnUSjSSVNyPM+gDJ0jskLi8h8N2hrdpyeCk7fIqKMRzziqVSOBTB8yyLTMHGQ==",
+					"dev": true,
+					"requires": {
+						"@commitlint/load": ">6.1.1",
+						"chalk": "^2.4.1",
+						"conventional-commit-types": "^2.0.0",
+						"lodash.map": "^4.5.1",
+						"longest": "^2.0.1",
+						"right-pad": "^1.0.1",
+						"word-wrap": "^1.0.3"
+					}
+				},
+				"detect-indent": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
+					"integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==",
 					"dev": true
 				},
 				"figures": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-					"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+					"integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
 					"dev": true,
 					"requires": {
 						"escape-string-regexp": "^1.0.5"
 					}
 				},
+				"fs-extra": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
+					}
+				},
 				"glob": {
-					"version": "7.1.3",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
 					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -11100,68 +11201,67 @@
 						"path-is-absolute": "^1.0.0"
 					}
 				},
+				"graceful-fs": {
+					"version": "4.2.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+					"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+					"dev": true
+				},
 				"inquirer": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
-					"integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
+					"integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.0",
+						"ansi-escapes": "^3.2.0",
+						"chalk": "^2.4.2",
 						"cli-cursor": "^2.1.0",
 						"cli-width": "^2.0.0",
-						"external-editor": "^3.0.0",
+						"external-editor": "^3.0.3",
 						"figures": "^2.0.0",
-						"lodash": "^4.17.10",
+						"lodash": "^4.17.12",
 						"mute-stream": "0.0.7",
 						"run-async": "^2.2.0",
-						"rxjs": "^6.1.0",
+						"rxjs": "^6.4.0",
 						"string-width": "^2.1.0",
-						"strip-ansi": "^4.0.0",
+						"strip-ansi": "^5.1.0",
 						"through": "^2.3.6"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "2.4.2",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^3.2.1",
-								"escape-string-regexp": "^1.0.5",
-								"supports-color": "^5.3.0"
-							}
-						}
 					}
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
 					"dev": true
 				},
 				"lodash": {
-					"version": "4.17.11",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+					"dev": true
+				},
+				"longest": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/longest/-/longest-2.0.1.tgz",
+					"integrity": "sha512-Ajzxb8CM6WAnFjgiloPsI3bF+WCxcvhdIG3KNA2KN962+tdBsHcuQ4k4qX/EcS/2CRkcc0iAkR956Nib6aXU/Q==",
 					"dev": true
 				},
 				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 					"dev": true
 				},
 				"mute-stream": {
 					"version": "0.0.7",
 					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-					"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+					"integrity": "sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==",
 					"dev": true
 				},
 				"onetime": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+					"integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
 					"dev": true,
 					"requires": {
 						"mimic-fn": "^1.0.0"
@@ -11170,7 +11270,7 @@
 				"restore-cursor": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+					"integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
 					"dev": true,
 					"requires": {
 						"onetime": "^2.0.0",
@@ -11178,13 +11278,10 @@
 					}
 				},
 				"run-async": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-					"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-					"dev": true,
-					"requires": {
-						"is-promise": "^2.1.0"
-					}
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+					"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
@@ -11194,16 +11291,47 @@
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
 						"strip-ansi": "^4.0.0"
+					},
+					"dependencies": {
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
 					}
 				},
 				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "^4.1.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "4.1.1",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+							"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+							"dev": true
+						}
 					}
+				},
+				"strip-bom": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+					"dev": true
+				},
+				"strip-json-comments": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+					"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+					"dev": true
 				}
 			}
 		},
@@ -12655,19 +12783,6 @@
 			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
 			"dev": true
 		},
-		"cz-conventional-changelog": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-2.1.0.tgz",
-			"integrity": "sha1-L0vHOQ4yROTfKT5ro1Hkx0Cnx2Q=",
-			"dev": true,
-			"requires": {
-				"conventional-commit-types": "^2.0.0",
-				"lodash.map": "^4.5.1",
-				"longest": "^1.0.1",
-				"right-pad": "^1.0.1",
-				"word-wrap": "^1.0.3"
-			}
-		},
 		"damerau-levenshtein": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
@@ -12691,12 +12806,6 @@
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
-		},
-		"data-uri-to-buffer": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
-			"integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ==",
-			"dev": true
 		},
 		"data-urls": {
 			"version": "1.1.0",
@@ -12922,25 +13031,6 @@
 				}
 			}
 		},
-		"degenerator": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
-			"integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
-			"dev": true,
-			"requires": {
-				"ast-types": "0.x.x",
-				"escodegen": "1.x.x",
-				"esprima": "3.x.x"
-			},
-			"dependencies": {
-				"esprima": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-					"dev": true
-				}
-			}
-		},
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -12950,8 +13040,7 @@
 		"delegate": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-			"optional": true
+			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
 		},
 		"delegates": {
 			"version": "1.0.0",
@@ -13142,6 +13231,14 @@
 				"esutils": "^2.0.2"
 			}
 		},
+		"dom-helpers": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+			"integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+			"requires": {
+				"@babel/runtime": "^7.1.2"
+			}
+		},
 		"dom-iterator": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/dom-iterator/-/dom-iterator-1.0.0.tgz",
@@ -13200,6 +13297,24 @@
 			"requires": {
 				"dom-serializer": "0",
 				"domelementtype": "1"
+			}
+		},
+		"dot-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+			"integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+			"dev": true,
+			"requires": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+					"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+					"dev": true
+				}
 			}
 		},
 		"dot-prop": {
@@ -15460,12 +15575,6 @@
 				"flat-cache": "^2.0.1"
 			}
 		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-			"dev": true
-		},
 		"filelist": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
@@ -15869,6 +15978,11 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
+		},
+		"fscreen": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fscreen/-/fscreen-1.2.0.tgz",
+			"integrity": "sha512-hlq4+BU0hlPmwsFjwGGzZ+OZ9N/wq9Ljg/sq3pX+2CD7hrJsX9tJgWWK/wiNTFM212CLHWhicOoqwXyZGGetJg=="
 		},
 		"fsevents": {
 			"version": "1.2.9",
@@ -16931,37 +17045,6 @@
 				"pump": "^3.0.0"
 			}
 		},
-		"get-uri": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.4.tgz",
-			"integrity": "sha512-v7LT/s8kVjs+Tx0ykk1I+H/rbpzkHvuIq87LmeXptcf5sNWm9uQiwjNAt94SJPA1zOlCntmnOlJvVWKmzsxG8Q==",
-			"dev": true,
-			"requires": {
-				"data-uri-to-buffer": "1",
-				"debug": "2",
-				"extend": "~3.0.2",
-				"file-uri-to-path": "1",
-				"ftp": "~0.3.10",
-				"readable-stream": "2"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
-			}
-		},
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -17180,7 +17263,7 @@
 				"fs-extra": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
-					"integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+					"integrity": "sha512-V3Z3WZWVUYd8hoCL5xfXJCaHWYzmtwW5XWYSlLgERi8PWd8bx1kUHUk8L1BT57e49oKnDDD180mjfrHc1yA9rg==",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
@@ -17241,7 +17324,7 @@
 				"jsonfile": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-					"integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+					"integrity": "sha512-oBko6ZHlubVB5mRFkur5vgYR1UyqX+S6Y/oCfLhqNdcc2fYFlDpIoNc7AfKS1KOGcnNAkvsr0grLck9ANM815w==",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.6"
@@ -17250,7 +17333,7 @@
 				"lodash": {
 					"version": "4.17.4",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-					"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+					"integrity": "sha512-6X37Sq9KCpLSXEh8uM12AKYlviHPNNk4RxiGBn4cmKGJinbXBneWIV7iE/nXkM928O7ytHcHb6+X6Svl0f4hXg==",
 					"dev": true
 				},
 				"make-fetch-happen": {
@@ -19638,7 +19721,7 @@
 				"q": {
 					"version": "1.5.0",
 					"resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-					"integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
+					"integrity": "sha512-VVMcd+HnuWZalHPycK7CsbVJ+sSrrrnCvHcW38YJVK9Tywnb5DUWJjONi81bLUj7aqDjIXnePxBl5t1r/F/ncg==",
 					"dev": true
 				},
 				"qs": {
@@ -19692,7 +19775,7 @@
 				"semver": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+					"integrity": "sha512-mfmm3/H9+67MCVix1h+IXTpDwL6710LyHuk7+cWC9T1mE0qz4iHhh6r4hU2wrIT9iTsAAC2XQRvfblL028cpLw==",
 					"dev": true
 				},
 				"smart-buffer": {
@@ -19744,7 +19827,7 @@
 				"tmp": {
 					"version": "0.0.31",
 					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
-					"integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+					"integrity": "sha512-lfyEfOppKvWNeId5CArFLwgwef+iCnbEIy0JWYf1httIEXnx4ndL4Dr1adw7hPgeQfSlTbc/gqn6iaKcROpw5Q==",
 					"dev": true,
 					"requires": {
 						"os-tmpdir": "~1.0.1"
@@ -19913,7 +19996,6 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
 			"integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-			"optional": true,
 			"requires": {
 				"delegate": "^3.1.2"
 			}
@@ -20234,6 +20316,12 @@
 				"sntp": "1.x.x"
 			}
 		},
+		"he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"dev": true
+		},
 		"hex-color-regex": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
@@ -20351,6 +20439,185 @@
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
 			"integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
 			"dev": true
+		},
+		"html-loader": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/html-loader/-/html-loader-1.1.0.tgz",
+			"integrity": "sha512-zwLbEgy+i7sgIYTlxI9M7jwkn29IvdsV6f1y7a2aLv/w8l1RigVk0PFijBZLLFsdi2gvL8sf2VJhTjLlfnK8sA==",
+			"dev": true,
+			"requires": {
+				"html-minifier-terser": "^5.0.5",
+				"htmlparser2": "^4.1.0",
+				"loader-utils": "^2.0.0",
+				"parse-srcset": "^1.0.2",
+				"schema-utils": "^2.6.5"
+			},
+			"dependencies": {
+				"@types/json-schema": {
+					"version": "7.0.11",
+					"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+					"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+					"dev": true
+				},
+				"ajv": {
+					"version": "6.12.6",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"ajv-keywords": {
+					"version": "3.5.2",
+					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+					"dev": true
+				},
+				"dom-serializer": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+					"integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+					"dev": true,
+					"requires": {
+						"domelementtype": "^2.0.1",
+						"domhandler": "^4.2.0",
+						"entities": "^2.0.0"
+					},
+					"dependencies": {
+						"domhandler": {
+							"version": "4.3.1",
+							"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+							"integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+							"dev": true,
+							"requires": {
+								"domelementtype": "^2.2.0"
+							}
+						}
+					}
+				},
+				"domelementtype": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+					"dev": true
+				},
+				"domhandler": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+					"integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+					"dev": true,
+					"requires": {
+						"domelementtype": "^2.0.1"
+					}
+				},
+				"domutils": {
+					"version": "2.8.0",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+					"integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+					"dev": true,
+					"requires": {
+						"dom-serializer": "^1.0.1",
+						"domelementtype": "^2.2.0",
+						"domhandler": "^4.2.0"
+					},
+					"dependencies": {
+						"domhandler": {
+							"version": "4.3.1",
+							"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+							"integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+							"dev": true,
+							"requires": {
+								"domelementtype": "^2.2.0"
+							}
+						}
+					}
+				},
+				"emojis-list": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+					"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+					"dev": true
+				},
+				"entities": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+					"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+					"dev": true
+				},
+				"fast-deep-equal": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+					"dev": true
+				},
+				"htmlparser2": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
+					"integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+					"dev": true,
+					"requires": {
+						"domelementtype": "^2.0.1",
+						"domhandler": "^3.0.0",
+						"domutils": "^2.0.0",
+						"entities": "^2.0.0"
+					}
+				},
+				"json5": {
+					"version": "2.2.3",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+					"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+					"dev": true
+				},
+				"loader-utils": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+					"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+					"dev": true,
+					"requires": {
+						"big.js": "^5.2.2",
+						"emojis-list": "^3.0.0",
+						"json5": "^2.1.2"
+					}
+				},
+				"schema-utils": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+					"integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+					"dev": true,
+					"requires": {
+						"@types/json-schema": "^7.0.5",
+						"ajv": "^6.12.4",
+						"ajv-keywords": "^3.5.2"
+					}
+				}
+			}
+		},
+		"html-minifier-terser": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
+			"integrity": "sha512-ZPr5MNObqnV/T9akshPKbVgyOqLmy+Bxo7juKCfTfnjNniTAMdy4hz21YQqoofMBJD2kdREaqPPdThoR78Tgxg==",
+			"dev": true,
+			"requires": {
+				"camel-case": "^4.1.1",
+				"clean-css": "^4.2.3",
+				"commander": "^4.1.1",
+				"he": "^1.2.0",
+				"param-case": "^3.0.3",
+				"relateurl": "^0.2.7",
+				"terser": "^4.6.3"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+					"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+					"dev": true
+				}
+			}
 		},
 		"html-tags": {
 			"version": "3.1.0",
@@ -20601,25 +20868,33 @@
 					"dev": true
 				},
 				"cosmiconfig": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-					"integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+					"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
 					"dev": true,
 					"requires": {
 						"@types/parse-json": "^4.0.0",
-						"import-fresh": "^3.1.0",
+						"import-fresh": "^3.2.1",
 						"parse-json": "^5.0.0",
 						"path-type": "^4.0.0",
-						"yaml": "^1.7.2"
+						"yaml": "^1.10.0"
+					},
+					"dependencies": {
+						"yaml": {
+							"version": "1.10.2",
+							"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+							"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+							"dev": true
+						}
 					}
 				},
 				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 					"dev": true,
 					"requires": {
-						"locate-path": "^5.0.0",
+						"locate-path": "^6.0.0",
 						"path-exists": "^4.0.0"
 					}
 				},
@@ -20630,9 +20905,9 @@
 					"dev": true
 				},
 				"import-fresh": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-					"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+					"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
 					"dev": true,
 					"requires": {
 						"parent-module": "^1.0.0",
@@ -20640,47 +20915,41 @@
 					}
 				},
 				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 					"dev": true,
 					"requires": {
-						"p-locate": "^4.1.0"
+						"p-locate": "^5.0.0"
 					}
 				},
 				"p-limit": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 					"dev": true,
 					"requires": {
-						"p-try": "^2.0.0"
+						"yocto-queue": "^0.1.0"
 					}
 				},
 				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 					"dev": true,
 					"requires": {
-						"p-limit": "^2.2.0"
+						"p-limit": "^3.0.2"
 					}
 				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				},
 				"parse-json": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
-					"integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+					"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
 						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1",
+						"json-parse-even-better-errors": "^2.3.0",
 						"lines-and-columns": "^1.1.6"
 					}
 				},
@@ -20697,12 +20966,12 @@
 					"dev": true
 				},
 				"pkg-dir": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+					"integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
 					"dev": true,
 					"requires": {
-						"find-up": "^4.0.0"
+						"find-up": "^5.0.0"
 					}
 				},
 				"resolve-from": {
@@ -21196,7 +21465,6 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
@@ -27423,6 +27691,12 @@
 			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
 			"dev": true
 		},
+		"json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+			"dev": true
+		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -27455,6 +27729,14 @@
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 			"dev": true
+		},
+		"json2mq": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+			"integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+			"requires": {
+				"string-convert": "^0.2.0"
+			}
 		},
 		"json3": {
 			"version": "3.3.3",
@@ -28445,6 +28727,11 @@
 				"resolve-from": "^5.0.0"
 			}
 		},
+		"load-script": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+			"integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="
+		},
 		"loader-runner": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
@@ -28833,12 +29120,6 @@
 				"@sinonjs/commons": "^1.7.0"
 			}
 		},
-		"longest": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-			"dev": true
-		},
 		"longest-streak": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.3.tgz",
@@ -28861,6 +29142,23 @@
 			"requires": {
 				"currently-unhandled": "^0.4.1",
 				"signal-exit": "^3.0.0"
+			}
+		},
+		"lower-case": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+			"dev": true,
+			"requires": {
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+					"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+					"dev": true
+				}
 			}
 		},
 		"lowercase-keys": {
@@ -29691,12 +29989,6 @@
 			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
 			"dev": true
 		},
-		"netmask": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
-			"integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
-			"dev": true
-		},
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -30009,6 +30301,24 @@
 			"dev": true,
 			"requires": {
 				"axe-core": "^3.1.2"
+			}
+		},
+		"no-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+			"dev": true,
+			"requires": {
+				"lower-case": "^2.0.2",
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+					"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+					"dev": true
+				}
 			}
 		},
 		"node-dir": {
@@ -30485,7 +30795,7 @@
 		"npmi": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/npmi/-/npmi-1.0.1.tgz",
-			"integrity": "sha1-FddpJzVHVF5oCdzwzhiu1IsCkOI=",
+			"integrity": "sha512-KGSWKUKllQFwd5L2t3+rA9sJhlbXynQEiUOcW9Ii9c2j6l0ETspJnsj5RaOeVl16K23S9uL8m3McFazul3jZeA==",
 			"dev": true,
 			"requires": {
 				"npm": "^2.1.12",
@@ -30749,7 +31059,7 @@
 				"npm": {
 					"version": "2.15.12",
 					"resolved": "https://registry.npmjs.org/npm/-/npm-2.15.12.tgz",
-					"integrity": "sha1-33w+1aJ3w/nUtdgZsFMR0QogCuY=",
+					"integrity": "sha512-WMoAJ518W0vHjWy1abYnTeyG9YQpSoYGPxAx7d0C0L7U7Jo44bZsrvTjccmDohCJGxpasdKfqsKsl6o/RUPx6A==",
 					"dev": true,
 					"requires": {
 						"abbrev": "~1.0.9",
@@ -31837,7 +32147,7 @@
 				"semver": {
 					"version": "4.3.6",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-					"integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+					"integrity": "sha512-IrpJ+yoG4EOH8DFWuVg+8H1kW1Oaof0Wxe7cPcXW3x9BjkN/eVo54F15LyqemnDIUYskQWr9qvl/RihmSy6+xQ==",
 					"dev": true
 				},
 				"supports-color": {
@@ -32124,7 +32434,7 @@
 		"optimist": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
 			"dev": true,
 			"requires": {
 				"minimist": "~0.0.1",
@@ -32134,7 +32444,7 @@
 				"minimist": {
 					"version": "0.0.10",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+					"integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
 					"dev": true
 				}
 			}
@@ -32545,34 +32855,110 @@
 				"socks-proxy-agent": "5"
 			},
 			"dependencies": {
-				"https-proxy-agent": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-					"integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+				"agent-base": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+					"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
 					"dev": true,
 					"requires": {
-						"agent-base": "^4.3.0",
-						"debug": "^3.1.0"
-					},
-					"dependencies": {
-						"agent-base": {
-							"version": "4.3.0",
-							"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-							"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-							"dev": true,
-							"requires": {
-								"es6-promisify": "^5.0.0"
-							}
-						},
-						"debug": {
-							"version": "3.2.6",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-							"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-							"dev": true,
-							"requires": {
-								"ms": "^2.1.1"
-							}
-						}
+						"debug": "4"
+					}
+				},
+				"data-uri-to-buffer": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+					"integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
+					"dev": true
+				},
+				"file-uri-to-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz",
+					"integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==",
+					"dev": true
+				},
+				"fs-extra": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
+					}
+				},
+				"get-uri": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-3.0.2.tgz",
+					"integrity": "sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==",
+					"dev": true,
+					"requires": {
+						"@tootallnate/once": "1",
+						"data-uri-to-buffer": "3",
+						"debug": "4",
+						"file-uri-to-path": "2",
+						"fs-extra": "^8.1.0",
+						"ftp": "^0.3.10"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.2.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+					"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+					"dev": true
+				},
+				"http-proxy-agent": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+					"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+					"dev": true,
+					"requires": {
+						"@tootallnate/once": "1",
+						"agent-base": "6",
+						"debug": "4"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+					"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+					"dev": true,
+					"requires": {
+						"agent-base": "6",
+						"debug": "4"
+					}
+				},
+				"ip": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+					"integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+					"dev": true
+				},
+				"smart-buffer": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+					"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+					"dev": true
+				},
+				"socks": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+					"integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+					"dev": true,
+					"requires": {
+						"ip": "^2.0.0",
+						"smart-buffer": "^4.2.0"
+					}
+				},
+				"socks-proxy-agent": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz",
+					"integrity": "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==",
+					"dev": true,
+					"requires": {
+						"agent-base": "^6.0.2",
+						"debug": "4",
+						"socks": "^2.3.3"
 					}
 				}
 			}
@@ -32592,6 +32978,24 @@
 					"version": "4.6.0",
 					"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
 					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+				},
+				"degenerator": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-3.0.2.tgz",
+					"integrity": "sha512-c0mef3SNQo56t6urUU6tdQAs+ThoD0o9B9MJ8HEt7NQcGEILCRFqQb7ZbP9JAv+QF1Ky5plydhMR/IrqWDm+TQ==",
+					"dev": true,
+					"requires": {
+						"ast-types": "^0.13.2",
+						"escodegen": "^1.8.1",
+						"esprima": "^4.0.0",
+						"vm2": "^3.9.8"
+					}
+				},
+				"netmask": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+					"integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+					"dev": true
 				}
 			}
 		},
@@ -32610,6 +33014,24 @@
 				"cyclist": "~0.2.2",
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.1.5"
+			}
+		},
+		"param-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+			"integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+			"dev": true,
+			"requires": {
+				"dot-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+					"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+					"dev": true
+				}
 			}
 		},
 		"parent-module": {
@@ -32678,7 +33100,21 @@
 			"dev": true,
 			"requires": {
 				"protocols": "^2.0.0"
+			},
+			"dependencies": {
+				"protocols": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
+					"integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
+					"dev": true
+				}
 			}
+		},
+		"parse-srcset": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+			"integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+			"dev": true
 		},
 		"parse-url": {
 			"version": "6.0.1",
@@ -32690,6 +33126,29 @@
 				"normalize-url": "^6.1.0",
 				"parse-path": "^5.0.0",
 				"protocols": "^2.0.1"
+			},
+			"dependencies": {
+				"is-ssh": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.0.tgz",
+					"integrity": "sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==",
+					"dev": true,
+					"requires": {
+						"protocols": "^2.0.1"
+					}
+				},
+				"normalize-url": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+					"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+					"dev": true
+				},
+				"protocols": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
+					"integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
+					"dev": true
+				}
 			}
 		},
 		"parse5": {
@@ -32706,6 +33165,24 @@
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
 			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
 			"dev": true
+		},
+		"pascal-case": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+			"dev": true,
+			"requires": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+					"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+					"dev": true
+				}
+			}
 		},
 		"pascalcase": {
 			"version": "0.1.1",
@@ -34256,35 +34733,41 @@
 				"socks-proxy-agent": "^5.0.0"
 			},
 			"dependencies": {
-				"https-proxy-agent": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-					"integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+				"agent-base": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+					"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
 					"dev": true,
 					"requires": {
-						"agent-base": "^4.3.0",
-						"debug": "^3.1.0"
-					},
-					"dependencies": {
-						"agent-base": {
-							"version": "4.3.0",
-							"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-							"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-							"dev": true,
-							"requires": {
-								"es6-promisify": "^5.0.0"
-							}
-						},
-						"debug": {
-							"version": "3.2.6",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-							"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-							"dev": true,
-							"requires": {
-								"ms": "^2.1.1"
-							}
-						}
+						"debug": "4"
 					}
+				},
+				"http-proxy-agent": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+					"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+					"dev": true,
+					"requires": {
+						"@tootallnate/once": "1",
+						"agent-base": "6",
+						"debug": "4"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+					"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+					"dev": true,
+					"requires": {
+						"agent-base": "6",
+						"debug": "4"
+					}
+				},
+				"ip": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+					"integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+					"dev": true
 				},
 				"lru-cache": {
 					"version": "5.1.1",
@@ -34293,6 +34776,33 @@
 					"dev": true,
 					"requires": {
 						"yallist": "^3.0.2"
+					}
+				},
+				"smart-buffer": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+					"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+					"dev": true
+				},
+				"socks": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+					"integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+					"dev": true,
+					"requires": {
+						"ip": "^2.0.0",
+						"smart-buffer": "^4.2.0"
+					}
+				},
+				"socks-proxy-agent": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz",
+					"integrity": "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==",
+					"dev": true,
+					"requires": {
+						"agent-base": "^6.0.2",
+						"debug": "4",
+						"socks": "^2.3.3"
 					}
 				},
 				"yallist": {
@@ -34981,6 +35491,11 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
 			"integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
 		},
+		"react-lifecycles-compat": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+		},
 		"react-live": {
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/react-live/-/react-live-1.12.0.tgz",
@@ -34994,6 +35509,17 @@
 				"prismjs": "1.6",
 				"prop-types": "^15.5.8",
 				"unescape": "^0.2.0"
+			}
+		},
+		"react-media": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/react-media/-/react-media-1.10.0.tgz",
+			"integrity": "sha512-FjgYmFoaPTImST06jqotuu0Mk8LOXiGYS/fIyiXuLnf20l3DPniBwtrxi604/HxxjqvmHS3oz5rAwnqdvosV4A==",
+			"requires": {
+				"@babel/runtime": "^7.2.0",
+				"invariant": "^2.2.2",
+				"json2mq": "^0.2.0",
+				"prop-types": "^15.5.10"
 			}
 		},
 		"react-router": {
@@ -35330,6 +35856,34 @@
 				"scheduler": "^0.13.6"
 			}
 		},
+		"react-transition-group": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+			"integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+			"requires": {
+				"dom-helpers": "^3.4.0",
+				"loose-envify": "^1.4.0",
+				"prop-types": "^15.6.2",
+				"react-lifecycles-compat": "^3.0.4"
+			}
+		},
+		"react-youtube": {
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/react-youtube/-/react-youtube-7.14.0.tgz",
+			"integrity": "sha512-SUHZ4F4pd1EHmQu0CV0KSQvAs5KHOT5cfYaq4WLCcDbU8fBo1ouTXaAOIASWbrz8fHwg+G1evfoSIYpV2AwSAg==",
+			"requires": {
+				"fast-deep-equal": "3.1.3",
+				"prop-types": "15.7.2",
+				"youtube-player": "5.5.2"
+			},
+			"dependencies": {
+				"fast-deep-equal": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+				}
+			}
+		},
 		"read": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -35531,8 +36085,7 @@
 		"regenerator-runtime": {
 			"version": "0.13.2",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-			"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
-			"dev": true
+			"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
 		},
 		"regenerator-transform": {
 			"version": "0.14.1",
@@ -35604,6 +36157,12 @@
 					"dev": true
 				}
 			}
+		},
+		"relateurl": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+			"integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
+			"dev": true
 		},
 		"relative-luminance": {
 			"version": "0.0.0",
@@ -37079,6 +37638,11 @@
 				"walker": "~1.0.5"
 			}
 		},
+		"sass-mq": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/sass-mq/-/sass-mq-5.0.1.tgz",
+			"integrity": "sha512-ugSVZO5fzasSFrGfKCtY02spnkOOfo9U9sXuzCuSXoCl1CgcoqdJRdNmigZkhvRVph1GKM6o0pgI00Jjc445CA=="
+		},
 		"sax": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
@@ -37139,8 +37703,7 @@
 		"select": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-			"integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-			"optional": true
+			"integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
 		},
 		"select-hose": {
 			"version": "2.0.0",
@@ -37409,6 +37972,11 @@
 					"dev": true
 				}
 			}
+		},
+		"sister": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/sister/-/sister-3.0.2.tgz",
+			"integrity": "sha512-p19rtTs+NksBRKW9qn0UhZ8/TUI9BPw9lmtHny+Y3TinWlOa9jWh9xB0AtPSdmOy49NJJJSSe0Ey4C7h0TrcYA=="
 		},
 		"sisteransi": {
 			"version": "1.0.4",
@@ -37937,6 +38505,11 @@
 			"integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
 			"dev": true
 		},
+		"string-convert": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+			"integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A=="
+		},
 		"string-hash": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
@@ -38376,6 +38949,26 @@
 						"electron-to-chromium": "^1.3.719",
 						"escalade": "^3.1.1",
 						"node-releases": "^1.1.71"
+					},
+					"dependencies": {
+						"caniuse-lite": {
+							"version": "1.0.30001469",
+							"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001469.tgz",
+							"integrity": "sha512-Rcp7221ScNqQPP3W+lVOYDyjdR6dC+neEQCttoNr5bAyz54AboB4iwpnWgyi8P4YUsPybVzT4LgWiBbI3drL4g==",
+							"dev": true
+						},
+						"electron-to-chromium": {
+							"version": "1.4.335",
+							"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.335.tgz",
+							"integrity": "sha512-l/eowQqTnrq3gu+WSrdfkhfNHnPgYqlKAwxz7MTOj6mom19vpEDHNXl6dxDxyTiYuhemydprKr/HCrHfgk+OfQ==",
+							"dev": true
+						},
+						"node-releases": {
+							"version": "1.1.77",
+							"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz",
+							"integrity": "sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==",
+							"dev": true
+						}
 					}
 				},
 				"camelcase": {
@@ -38435,8 +39028,7 @@
 				"electron-to-chromium": {
 					"version": "1.3.349",
 					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.349.tgz",
-					"integrity": "sha512-uEb2zs6EJ6OZIqaMsCSliYVgzE/f7/s1fLWqtvRtHg/v5KBF2xds974fUnyatfxIDgkqzQVwFtam5KExqywx0Q==",
-					"dev": true
+					"integrity": "sha512-uEb2zs6EJ6OZIqaMsCSliYVgzE/f7/s1fLWqtvRtHg/v5KBF2xds974fUnyatfxIDgkqzQVwFtam5KExqywx0Q=="
 				},
 				"emoji-regex": {
 					"version": "8.0.0",
@@ -38662,7 +39254,6 @@
 					"version": "1.1.49",
 					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.49.tgz",
 					"integrity": "sha512-xH8t0LS0disN0mtRCh+eByxFPie+msJUBL/lJDBuap53QGiYPa9joh83K4pCZgWJ+2L4b9h88vCVdXQ60NO2bg==",
-					"dev": true,
 					"requires": {
 						"semver": "^6.3.0"
 					}
@@ -38826,8 +39417,7 @@
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				},
 				"slash": {
 					"version": "3.0.0",
@@ -39220,10 +39810,59 @@
 				"yallist": "^3.1.1"
 			},
 			"dependencies": {
+				"chownr": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+					"dev": true
+				},
+				"fs-minipass": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+					"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+					"dev": true,
+					"requires": {
+						"minipass": "^2.6.0"
+					}
+				},
+				"minipass": {
+					"version": "2.9.0",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+					"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "^5.1.2",
+						"yallist": "^3.0.0"
+					}
+				},
+				"minizlib": {
+					"version": "1.3.3",
+					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+					"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+					"dev": true,
+					"requires": {
+						"minipass": "^2.9.0"
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.6",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+					"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.6"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+					"dev": true
+				},
 				"yallist": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 					"dev": true
 				}
 			}
@@ -39765,8 +40404,7 @@
 		"tiny-emitter": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-			"optional": true
+			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
 		},
 		"tiny-invariant": {
 			"version": "1.0.6",
@@ -40745,7 +41383,7 @@
 		"user-home": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-			"integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+			"integrity": "sha512-KMWqdlOcjCYdtIJpicDSFBQ8nFwS2i9sslAd6f4+CBGcU4gist2REnr2fxj2YocvJFxSF3ZOHLYLVZnUxv4BZQ==",
 			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.0"
@@ -40992,6 +41630,30 @@
 			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
 			"integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
 			"dev": true
+		},
+		"vm2": {
+			"version": "3.9.14",
+			"resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.14.tgz",
+			"integrity": "sha512-HgvPHYHeQy8+QhzlFryvSteA4uQLBCOub02mgqdR+0bN/akRZ48TGB1v0aCv7ksyc0HXx16AZtMHKS38alc6TA==",
+			"dev": true,
+			"requires": {
+				"acorn": "^8.7.0",
+				"acorn-walk": "^8.2.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "8.8.2",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+					"integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+					"dev": true
+				},
+				"acorn-walk": {
+					"version": "8.2.0",
+					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+					"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+					"dev": true
+				}
+			}
 		},
 		"vorpal": {
 			"version": "1.12.0",
@@ -42036,7 +42698,7 @@
 		"wordwrap": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+			"integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
 			"dev": true
 		},
 		"worker-farm": {
@@ -42477,6 +43139,37 @@
 						"camelcase": "^5.0.0",
 						"decamelize": "^1.2.0"
 					}
+				}
+			}
+		},
+		"yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true
+		},
+		"youtube-player": {
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/youtube-player/-/youtube-player-5.5.2.tgz",
+			"integrity": "sha512-ZGtsemSpXnDky2AUYWgxjaopgB+shFHgXVpiJFeNB5nWEugpW1KWYDaHKuLqh2b67r24GtP6HoSW5swvf0fFIQ==",
+			"requires": {
+				"debug": "^2.6.6",
+				"load-script": "^1.0.0",
+				"sister": "^3.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "eslint-plugin-react": "^7.18.0",
     "eslint-plugin-react-hooks": "^2.3.0",
     "gitbook-cli": "^2.3.2",
+    "html-loader": "^1.1.0",
     "husky": "^4.0.0",
     "identity-obj-proxy": "^3.0.0",
     "install-group": "^3.0.0",

--- a/packages/Box/Box.md
+++ b/packages/Box/Box.md
@@ -6,8 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/box">Box</Link>{' '}
-      from Allium
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/box">
+        Box
+      </Link>{' '}
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/Breadcrumbs/Breadcrumbs.md
+++ b/packages/Breadcrumbs/Breadcrumbs.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/breadcrumbs">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/breadcrumbs">
         Breadcrumbs
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/Button/Button.md
+++ b/packages/Button/Button.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/button">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/button">
         Button
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/ButtonGroup/ButtonGroup.md
+++ b/packages/ButtonGroup/ButtonGroup.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/button-group">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/button-group">
         ButtonGroup
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/ButtonLink/ButtonLink.md
+++ b/packages/ButtonLink/ButtonLink.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/button-link">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/button-link">
         ButtonLink
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/Card/Card.md
+++ b/packages/Card/Card.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/card">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/card">
         Card
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/Checkbox/Checkbox.md
+++ b/packages/Checkbox/Checkbox.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/checkbox">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/checkbox">
         Checkbox
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/ChevronLink/ChevronLink.md
+++ b/packages/ChevronLink/ChevronLink.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/chevron-link">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/chevron-link">
         ChevronLink
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/ExpandCollapse/ExpandCollapse.md
+++ b/packages/ExpandCollapse/ExpandCollapse.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/expand-collapse">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/expand-collapse">
         ExpandCollpase
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/FlexGrid/FlexGrid.md
+++ b/packages/FlexGrid/FlexGrid.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/flex-grid">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/flex-grid">
         FlexGrid
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/Image/Image.md
+++ b/packages/Image/Image.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/image">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/image">
         Image
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/InteractiveIcon/IconButton.md
+++ b/packages/InteractiveIcon/IconButton.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/icon-button">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/icon-button">
         IconButton
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/Link/Link.md
+++ b/packages/Link/Link.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/link">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/link">
         Link
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/Notification/Notification.md
+++ b/packages/Notification/Notification.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/notification">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/notification">
         Notification
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/OrderedList/OrderedList.md
+++ b/packages/OrderedList/OrderedList.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/ordered-list">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/ordered-list">
         OrderedList
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/PriceLockup/PriceLockup.md
+++ b/packages/PriceLockup/PriceLockup.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/price-lockup">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/price-lockup">
         PriceLockup
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/Radio/Radio.md
+++ b/packages/Radio/Radio.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/radio">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/radio">
         Radio
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/ResponsiveImage/ResponsiveImage.md
+++ b/packages/ResponsiveImage/ResponsiveImage.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/responsive-image">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/responsive-image">
         ResponsiveImage
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/Select/Select.md
+++ b/packages/Select/Select.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/select">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/select">
         Select
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/StepTracker/StepTracker.md
+++ b/packages/StepTracker/StepTracker.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/step-tracker">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/step-tracker">
         StepTracker
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/TermsAndConditions/Disclaimer/Disclaimer.md
+++ b/packages/TermsAndConditions/Disclaimer/Disclaimer.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/disclaimer">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/disclaimer">
         Disclaimer
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/TermsAndConditions/Footnote/Footnote.md
+++ b/packages/TermsAndConditions/Footnote/Footnote.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/footnote">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/footnote">
         Footnote
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/TermsAndConditions/TermsAndConditions.md
+++ b/packages/TermsAndConditions/TermsAndConditions.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/termsandconditions">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/termsandconditions">
         TermsAndConditions
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/TextArea/TextArea.md
+++ b/packages/TextArea/TextArea.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/text-area">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/text-area">
         TextArea
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/TextButton/TextButton.md
+++ b/packages/TextButton/TextButton.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/text-button">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/text-button">
         TextButton
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/Tooltip/Tooltip.md
+++ b/packages/Tooltip/Tooltip.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/tooltip">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/tooltip">
         Tooltip
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/Video/Video.md
+++ b/packages/Video/Video.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/components/video">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/video">
         Video
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/WebVideo/WebVideo.md
+++ b/packages/WebVideo/WebVideo.md
@@ -5,11 +5,11 @@
       New! The TDS documentation experience has been updated to be more performant!
     </Paragraph>
     <Paragraph>
-      We encourage you tu use our new component{' '}
-      <Link href="https://telus.github.io/universal-design-system/@telus-uds/ds-allium/components/components/web-video">
+      We encourage you to use our new component{' '}
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/web-video">
         WebVideo
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>

--- a/packages/colours/Colours.md
+++ b/packages/colours/Colours.md
@@ -6,10 +6,10 @@
     </Paragraph>
     <Paragraph>
       We encourage you to use our new component{' '}
-      <Link href="https://telus.github.io/allium-design-system/components/palette/colour">
+      <Link href="https://telus.github.io/universal-design-system/components/allium/web/colour">
         Colour
       </Link>{' '}
-      from Allium
+      from UDS
     </Paragraph>
   </Box>
 </Notification>


### PR DESCRIPTION
This PR adds TDS sunset warning for Core components and Gitbook pages. It's straightforward to do that for core components pages as those are based on StyleGuidist but the rest of the site is based on GitBooks which doesn't have any firest-class way of doing it. So I had to add a gitbook plugin to inject HTML dynamically.

![SCR-20230322-jmqf](https://user-images.githubusercontent.com/18225515/226948227-10eb3ca6-209b-408a-a1cc-848df4653a04.jpeg)
